### PR TITLE
Add launch lifecycle API and UI

### DIFF
--- a/apps/frontend/src/App.css
+++ b/apps/frontend/src/App.css
@@ -94,6 +94,112 @@ main {
   box-shadow: 0 12px 35px -20px rgba(59, 130, 246, 0.85);
 }
 
+.search-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
+.sort-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.controls-label {
+  font-weight: 600;
+  color: #1d4ed8;
+  font-size: 0.9rem;
+}
+
+.sort-options {
+  display: inline-flex;
+  background: rgba(148, 163, 184, 0.18);
+  border-radius: 999px;
+  padding: 0.2rem;
+  gap: 0.2rem;
+}
+
+.sort-option {
+  border: none;
+  background: transparent;
+  padding: 0.3rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: #475569;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.sort-option.active {
+  background: #2563eb;
+  color: #ffffff;
+  font-weight: 600;
+}
+
+.sort-option:not(.active):hover {
+  background: rgba(148, 163, 184, 0.3);
+}
+
+.highlight-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.9rem;
+  color: #1e293b;
+  cursor: pointer;
+}
+
+.highlight-toggle input {
+  width: 1rem;
+  height: 1rem;
+}
+
+.highlight-toggle.disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.search-meta-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-top: 0.6rem;
+}
+
+.token-chip-row,
+.weight-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.token-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.16);
+  color: #1d4ed8;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: lowercase;
+}
+
+.weight-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.6rem;
+  border-radius: 8px;
+  background: rgba(14, 165, 233, 0.16);
+  color: #0369a1;
+  font-size: 0.8rem;
+  font-weight: 500;
+}
+
 .suggestion-list {
   position: absolute;
   inset: auto 0 0 0;
@@ -287,6 +393,13 @@ main {
   box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
 }
 
+mark {
+  background: #fef08a;
+  color: #111827;
+  border-radius: 4px;
+  padding: 0 0.2em;
+}
+
 .tag-facet {
   display: inline-flex;
   align-items: center;
@@ -371,6 +484,44 @@ main {
   display: flex;
   align-items: center;
   gap: 0.6rem;
+}
+
+.relevance-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-top: 0.5rem;
+}
+
+.relevance-score-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.6rem;
+}
+
+.relevance-score {
+  font-weight: 600;
+  color: #1d4ed8;
+}
+
+.relevance-score.secondary {
+  color: #64748b;
+  font-size: 0.85rem;
+}
+
+.relevance-breakdown {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  color: #334155;
+}
+
+.relevance-breakdown span {
+  background: rgba(59, 130, 246, 0.12);
+  border-radius: 999px;
+  padding: 0.2rem 0.55rem;
 }
 
 .status-badge {

--- a/apps/frontend/src/App.css
+++ b/apps/frontend/src/App.css
@@ -536,6 +536,184 @@ main {
   font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
 }
 
+.launch-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  background: rgba(209, 250, 229, 0.35);
+  border: 1px solid rgba(16, 185, 129, 0.2);
+  border-radius: 12px;
+  padding: 0.6rem 0.8rem;
+  font-size: 0.84rem;
+  margin-top: 0.75rem;
+}
+
+.launch-section-empty {
+  background: rgba(236, 253, 245, 0.6);
+}
+
+.launch-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.launch-head time {
+  font-size: 0.76rem;
+  color: #0f766e;
+}
+
+.launch-preview-link {
+  font-size: 0.75rem;
+  color: #0d9488;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.launch-preview-link:hover {
+  text-decoration: underline;
+}
+
+.launch-error {
+  margin: 0;
+  color: #b91c1c;
+  font-size: 0.82rem;
+}
+
+.launch-note {
+  margin: 0;
+  color: #0f766e;
+  font-size: 0.8rem;
+}
+
+.launch-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.launch-button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.35rem 0.9rem;
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: rgba(16, 185, 129, 0.18);
+  color: #047857;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.launch-button.secondary {
+  background: rgba(14, 116, 144, 0.14);
+  color: #0f172a;
+}
+
+.launch-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.launch-preview-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  font-size: 0.78rem;
+  align-items: center;
+}
+
+.launch-preview-row a {
+  color: #0f766e;
+  word-break: break-all;
+}
+
+.launch-history {
+  margin-top: 0.6rem;
+  border: 1px solid rgba(15, 118, 110, 0.2);
+  border-radius: 10px;
+  padding: 0.6rem 0.7rem;
+  background: rgba(236, 253, 245, 0.7);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.launch-status {
+  font-size: 0.78rem;
+  color: #0f766e;
+}
+
+.launch-status.error {
+  color: #b91c1c;
+}
+
+.launch-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.launch-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.launch-status-pill {
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  background: rgba(15, 118, 110, 0.2);
+  color: #0f766e;
+}
+
+.launch-status-pill.status-failed {
+  background: rgba(220, 38, 38, 0.18);
+  color: #b91c1c;
+}
+
+.launch-status-pill.status-running {
+  background: rgba(34, 197, 94, 0.2);
+  color: #047857;
+}
+
+.launch-status-pill.status-starting,
+.launch-status-pill.status-stopping {
+  background: rgba(59, 130, 246, 0.15);
+  color: #1d4ed8;
+}
+
+.launch-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.78rem;
+}
+
+.launch-error-text {
+  color: #b91c1c;
+}
+
+.launch-profile {
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.launch-build {
+  font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  background: rgba(15, 23, 42, 0.05);
+  padding: 0.15rem 0.4rem;
+  border-radius: 6px;
+  font-size: 0.72rem;
+}
+
 .app-links {
   display: flex;
   flex-wrap: wrap;

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -22,6 +22,21 @@ type BuildSummary = {
   logsTruncated: boolean;
 };
 
+type LaunchSummary = {
+  id: string;
+  status: 'pending' | 'starting' | 'running' | 'stopping' | 'stopped' | 'failed';
+  buildId: string;
+  instanceUrl: string | null;
+  resourceProfile: string | null;
+  errorMessage: string | null;
+  createdAt: string;
+  updatedAt: string;
+  startedAt: string | null;
+  stoppedAt: string | null;
+  expiresAt: string | null;
+  port: number | null;
+};
+
 type AppRecord = {
   id: string;
   name: string;
@@ -34,6 +49,7 @@ type AppRecord = {
   ingestError: string | null;
   ingestAttempts: number;
   latestBuild: BuildSummary | null;
+  latestLaunch: LaunchSummary | null;
 };
 
 type TagSuggestion = {
@@ -72,6 +88,16 @@ type HistoryState = Record<
     loading: boolean;
     error: string | null;
     events: IngestionEvent[] | null;
+  }
+>;
+
+type LaunchListState = Record<
+  string,
+  {
+    open: boolean;
+    loading: boolean;
+    error: string | null;
+    launches: LaunchSummary[] | null;
   }
 >;
 
@@ -123,6 +149,10 @@ function App() {
   const [highlightIndex, setHighlightIndex] = useState(0);
   const [retryingId, setRetryingId] = useState<string | null>(null);
   const [historyState, setHistoryState] = useState<HistoryState>({});
+  const [launchLists, setLaunchLists] = useState<LaunchListState>({});
+  const [launchingId, setLaunchingId] = useState<string | null>(null);
+  const [stoppingLaunchId, setStoppingLaunchId] = useState<string | null>(null);
+  const [launchErrors, setLaunchErrors] = useState<Record<string, string | null>>({});
   const [statusFilters, setStatusFilters] = useState<AppRecord['ingestStatus'][]>([]);
   const [ingestedAfter, setIngestedAfter] = useState('');
   const [ingestedBefore, setIngestedBefore] = useState('');
@@ -378,6 +408,46 @@ function App() {
     }
   };
 
+  const fetchLaunches = async (id: string, force = false) => {
+    setLaunchLists((prev) => ({
+      ...prev,
+      [id]: {
+        open: true,
+        loading: true,
+        error: null,
+        launches: force ? null : prev[id]?.launches ?? null
+      }
+    }));
+
+    try {
+      const response = await fetch(`${API_BASE_URL}/apps/${id}/launches`);
+      if (!response.ok) {
+        const payload = await response.json().catch(() => ({}));
+        throw new Error(payload?.error ?? `Failed to load launches (${response.status})`);
+      }
+      const payload = await response.json();
+      setLaunchLists((prev) => ({
+        ...prev,
+        [id]: {
+          open: true,
+          loading: false,
+          error: null,
+          launches: payload?.data ?? []
+        }
+      }));
+    } catch (err) {
+      setLaunchLists((prev) => ({
+        ...prev,
+        [id]: {
+          open: true,
+          loading: false,
+          error: (err as Error).message,
+          launches: null
+        }
+      }));
+    }
+  };
+
   const handleToggleHistory = async (id: string) => {
     const existing = historyState[id];
     const nextOpen = !(existing?.open ?? false);
@@ -409,6 +479,93 @@ function App() {
     }
 
     await fetchHistory(id);
+  };
+
+  const handleToggleLaunches = async (id: string) => {
+    const existing = launchLists[id];
+    const nextOpen = !(existing?.open ?? false);
+
+    if (!nextOpen) {
+      setLaunchLists((prev) => ({
+        ...prev,
+        [id]: {
+          open: false,
+          loading: false,
+          error: existing?.error ?? null,
+          launches: existing?.launches ?? null
+        }
+      }));
+      return;
+    }
+
+    if (existing?.launches) {
+      setLaunchLists((prev) => ({
+        ...prev,
+        [id]: {
+          ...existing,
+          open: true,
+          loading: false,
+          error: null
+        }
+      }));
+      return;
+    }
+
+    await fetchLaunches(id);
+  };
+
+  const handleLaunch = async (id: string) => {
+    setLaunchingId(id);
+    setLaunchErrors((prev) => ({ ...prev, [id]: null }));
+    try {
+      const response = await fetch(`${API_BASE_URL}/apps/${id}/launch`, {
+        method: 'POST'
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(payload?.error ?? `Launch failed with status ${response.status}`);
+      }
+      if (payload?.data?.repository) {
+        setApps((prev) =>
+          prev.map((app) => (app.id === id ? (payload.data.repository as AppRecord) : app))
+        );
+      }
+      if (launchLists[id]?.open) {
+        await fetchLaunches(id, true);
+      }
+      setLaunchErrors((prev) => ({ ...prev, [id]: null }));
+    } catch (err) {
+      setLaunchErrors((prev) => ({ ...prev, [id]: (err as Error).message }));
+    } finally {
+      setLaunchingId(null);
+    }
+  };
+
+  const handleStopLaunch = async (appId: string, launchId: string) => {
+    setStoppingLaunchId(launchId);
+    setLaunchErrors((prev) => ({ ...prev, [appId]: null }));
+    try {
+      const response = await fetch(`${API_BASE_URL}/apps/${appId}/launches/${launchId}/stop`, {
+        method: 'POST'
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(payload?.error ?? `Stop failed with status ${response.status}`);
+      }
+      if (payload?.data?.repository) {
+        setApps((prev) =>
+          prev.map((app) => (app.id === appId ? (payload.data.repository as AppRecord) : app))
+        );
+      }
+      if (launchLists[appId]?.open) {
+        await fetchLaunches(appId, true);
+      }
+      setLaunchErrors((prev) => ({ ...prev, [appId]: null }));
+    } catch (err) {
+      setLaunchErrors((prev) => ({ ...prev, [appId]: (err as Error).message }));
+    } finally {
+      setStoppingLaunchId(null);
+    }
   };
 
   const renderTags = (tags: TagKV[]) => (
@@ -462,6 +619,87 @@ function App() {
             {build.logsPreview}
             {build.logsTruncated ? '\n…' : ''}
           </pre>
+        )}
+      </div>
+    );
+  };
+
+  const renderLaunchSection = (app: AppRecord) => {
+    const launch = app.latestLaunch;
+    const statusClass = launch
+      ? launch.status === 'running'
+        ? 'status-succeeded'
+        : launch.status === 'failed'
+        ? 'status-failed'
+        : launch.status === 'starting' || launch.status === 'stopping'
+        ? 'status-processing'
+        : 'status-pending'
+      : 'status-pending';
+    const updatedAt = launch?.updatedAt ?? null;
+    const isLaunching = launchingId === app.id;
+    const isStopping = launch ? stoppingLaunchId === launch.id : false;
+    const canLaunch = app.latestBuild?.status === 'succeeded';
+    const canStop = launch ? ['running', 'starting', 'stopping'].includes(launch.status) : false;
+    const launchError = launchErrors[app.id] ?? null;
+
+    return (
+      <div className={`launch-section${launch ? '' : ' launch-section-empty'}`}>
+        <div className="launch-head">
+          <span className={`status-badge ${statusClass}`}>
+            {launch ? `launch ${launch.status}` : 'launch pending'}
+          </span>
+          {updatedAt && (
+            <time dateTime={updatedAt}>Updated {new Date(updatedAt).toLocaleString()}</time>
+          )}
+          {launch?.instanceUrl && (
+            <a className="launch-preview-link" href={launch.instanceUrl} target="_blank" rel="noreferrer">
+              Preview
+            </a>
+          )}
+        </div>
+        {(launchError || launch?.errorMessage) && (
+          <p className="launch-error">{launchError ?? launch?.errorMessage}</p>
+        )}
+        {!canLaunch && (
+          <p className="launch-note">Launch requires a successful build.</p>
+        )}
+        {launch?.status === 'starting' && <p className="launch-note">Container starting…</p>}
+        {launch?.status === 'stopping' && <p className="launch-note">Stopping container…</p>}
+        {launch?.status === 'stopped' && <p className="launch-note">Last launch has ended.</p>}
+        <div className="launch-actions">
+          <button
+            type="button"
+            className="launch-button"
+            onClick={() => {
+              void handleLaunch(app.id);
+            }}
+            disabled={isLaunching || !canLaunch || canStop}
+          >
+            {isLaunching ? 'Launching…' : 'Launch app'}
+          </button>
+          <button
+            type="button"
+            className="launch-button secondary"
+            onClick={() => {
+              if (launch) {
+                void handleStopLaunch(app.id, launch.id);
+              }
+            }}
+            disabled={!launch || !canStop || isStopping}
+          >
+            {isStopping ? 'Stopping…' : 'Stop launch'}
+          </button>
+        </div>
+        {launch?.instanceUrl && (
+          <div className="launch-preview-row">
+            <span>Preview URL:</span>
+            <a href={launch.instanceUrl} target="_blank" rel="noreferrer">
+              {launch.instanceUrl}
+            </a>
+          </div>
+        )}
+        {launch?.resourceProfile && (
+          <div className="launch-note">Profile: {launch.resourceProfile}</div>
         )}
       </div>
     );
@@ -633,6 +871,9 @@ function App() {
                   const historyEntry = historyState[app.id];
                   const events = historyEntry?.events ?? [];
                   const showHistory = historyEntry?.open ?? false;
+                  const launchEntry = launchLists[app.id];
+                  const launches = launchEntry?.launches ?? [];
+                  const showLaunches = launchEntry?.open ?? false;
 
                   return (
                     <article key={app.id} className="app-card">
@@ -650,6 +891,7 @@ function App() {
                       )}
                       {renderTags(app.tags)}
                       {renderBuildSection(app.latestBuild)}
+                      {renderLaunchSection(app)}
                       <div className="app-links">
                         <a href={app.repoUrl} target="_blank" rel="noreferrer">
                           View repository
@@ -668,11 +910,69 @@ function App() {
                         <button
                           type="button"
                           className="history-button"
+                          onClick={() => handleToggleLaunches(app.id)}
+                        >
+                          {showLaunches ? 'Hide launches' : 'View launches'}
+                        </button>
+                        <button
+                          type="button"
+                          className="history-button"
                           onClick={() => handleToggleHistory(app.id)}
                         >
                           {showHistory ? 'Hide history' : 'View history'}
                         </button>
                       </div>
+                      {showLaunches && (
+                        <div className="launch-history">
+                          {launchEntry?.loading && (
+                            <div className="launch-status">Loading launches…</div>
+                          )}
+                          {launchEntry?.error && (
+                            <div className="launch-status error">{launchEntry.error}</div>
+                          )}
+                          {launchEntry && !launchEntry.loading && !launchEntry.error && launches.length === 0 && (
+                            <div className="launch-status">No launches recorded yet.</div>
+                          )}
+                          {launches.length > 0 && (
+                            <ul className="launch-list">
+                              {launches.map((launchItem) => {
+                                const timestamp = launchItem.updatedAt ?? launchItem.createdAt;
+                                return (
+                                  <li key={launchItem.id}>
+                                    <div className="launch-row">
+                                      <span className={`launch-status-pill status-${launchItem.status}`}>
+                                        {launchItem.status}
+                                      </span>
+                                      <time dateTime={timestamp}>
+                                        {new Date(timestamp).toLocaleString()}
+                                      </time>
+                                      <code className="launch-build">{launchItem.buildId.slice(0, 8)}</code>
+                                    </div>
+                                    <div className="launch-detail">
+                                      {launchItem.instanceUrl && (
+                                        <a
+                                          href={launchItem.instanceUrl}
+                                          target="_blank"
+                                          rel="noreferrer"
+                                          className="launch-preview-link"
+                                        >
+                                          Open preview
+                                        </a>
+                                      )}
+                                      {launchItem.errorMessage && (
+                                        <div className="launch-error-text">{launchItem.errorMessage}</div>
+                                      )}
+                                      {launchItem.resourceProfile && (
+                                        <span className="launch-profile">{launchItem.resourceProfile}</span>
+                                      )}
+                                    </div>
+                                  </li>
+                                );
+                              })}
+                            </ul>
+                          )}
+                        </div>
+                      )}
                       {showHistory && (
                         <div className="history-section">
                           {historyEntry?.loading && <div className="history-status">Loading history…</div>}

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type KeyboardEventHandler } from 'react';
+import { Fragment, useEffect, useMemo, useState, type KeyboardEventHandler } from 'react';
 import './App.css';
 import SubmitApp from './SubmitApp';
 
@@ -37,6 +37,22 @@ type LaunchSummary = {
   port: number | null;
 };
 
+type RelevanceComponent = {
+  hits: number;
+  weight: number;
+  score: number;
+};
+
+type RelevanceSummary = {
+  score: number;
+  normalizedScore: number;
+  components: {
+    name: RelevanceComponent;
+    description: RelevanceComponent;
+    tags: RelevanceComponent;
+  };
+};
+
 type AppRecord = {
   id: string;
   name: string;
@@ -50,6 +66,7 @@ type AppRecord = {
   ingestAttempts: number;
   latestBuild: BuildSummary | null;
   latestLaunch: LaunchSummary | null;
+  relevance: RelevanceSummary | null;
 };
 
 type TagSuggestion = {
@@ -70,6 +87,16 @@ type StatusFacet = {
 };
 
 const INGEST_STATUSES: AppRecord['ingestStatus'][] = ['seed', 'pending', 'processing', 'ready', 'failed'];
+
+type SearchMeta = {
+  tokens: string[];
+  sort: 'relevance' | 'updated' | 'name';
+  weights: {
+    name: number;
+    description: number;
+    tags: number;
+  };
+};
 
 type IngestionEvent = {
   id: number;
@@ -139,6 +166,37 @@ function computeAutocompleteContext(input: string) {
   return { base: basePart, activeToken: token };
 }
 
+function escapeRegexToken(token: string) {
+  return token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function highlightSegments(text: string, tokens: string[], enabled: boolean) {
+  if (!enabled || tokens.length === 0) {
+    return text;
+  }
+  const escaped = tokens.map(escapeRegexToken).filter(Boolean);
+  if (escaped.length === 0) {
+    return text;
+  }
+  const regex = new RegExp(`(${escaped.join('|')})`, 'gi');
+  const segments = text.split(regex);
+  const tokenSet = new Set(tokens.map((token) => token.toLowerCase()));
+  return segments.map((segment, index) => {
+    if (!segment) {
+      return null;
+    }
+    const lower = segment.toLowerCase();
+    if (tokenSet.has(lower)) {
+      return (
+        <mark key={`match-${index}`}>{segment}</mark>
+      );
+    }
+    return (
+      <Fragment key={`text-${index}`}>{segment}</Fragment>
+    );
+  });
+}
+
 function App() {
   const [activeTab, setActiveTab] = useState<'catalog' | 'submit'>('catalog');
   const [inputValue, setInputValue] = useState('');
@@ -160,6 +218,12 @@ function App() {
   const [statusFacets, setStatusFacets] = useState<StatusFacet[]>(() =>
     INGEST_STATUSES.map((status) => ({ status, count: 0 }))
   );
+  const [ownerFacets, setOwnerFacets] = useState<TagFacet[]>([]);
+  const [frameworkFacets, setFrameworkFacets] = useState<TagFacet[]>([]);
+  const [searchMeta, setSearchMeta] = useState<SearchMeta | null>(null);
+  const [sortMode, setSortMode] = useState<SearchMeta['sort']>('relevance');
+  const [sortManuallySet, setSortManuallySet] = useState(false);
+  const [showHighlights, setShowHighlights] = useState(false);
 
   const autocompleteContext = useMemo(() => computeAutocompleteContext(inputValue), [inputValue]);
   const parsedQuery = useMemo(() => parseSearchInput(inputValue), [inputValue]);
@@ -169,9 +233,28 @@ function App() {
   );
   const searchSignature = useMemo(
     () =>
-      [parsedQuery.text, parsedQuery.tags.join(','), statusSignature, ingestedAfter, ingestedBefore].join('|'),
-    [parsedQuery.text, parsedQuery.tags, statusSignature, ingestedAfter, ingestedBefore]
+      [
+        parsedQuery.text,
+        parsedQuery.tags.join(','),
+        statusSignature,
+        ingestedAfter,
+        ingestedBefore,
+        sortMode
+      ].join('|'),
+    [parsedQuery.text, parsedQuery.tags, statusSignature, ingestedAfter, ingestedBefore, sortMode]
   );
+
+  useEffect(() => {
+    if (!parsedQuery.text) {
+      setSortManuallySet(false);
+    }
+    if (parsedQuery.text && !sortManuallySet && sortMode !== 'relevance') {
+      setSortMode('relevance');
+    }
+    if (!parsedQuery.text && !sortManuallySet && sortMode !== 'updated') {
+      setSortMode('updated');
+    }
+  }, [parsedQuery.text, sortMode, sortManuallySet]);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -195,6 +278,7 @@ function App() {
         if (ingestedBefore) {
           params.set('ingestedBefore', ingestedBefore);
         }
+        params.set('sort', sortMode);
         const response = await fetch(`${API_BASE_URL}/apps?${params.toString()}`, {
           signal: controller.signal
         });
@@ -212,6 +296,13 @@ function App() {
             count: counts.get(status) ?? 0
           }));
         });
+        setOwnerFacets(payload.facets?.owners ?? []);
+        setFrameworkFacets(payload.facets?.frameworks ?? []);
+        setSearchMeta(payload.meta ?? null);
+        if (payload.meta?.sort && payload.meta.sort !== sortMode) {
+          setSortMode(payload.meta.sort);
+          setSortManuallySet(false);
+        }
       } catch (err) {
         if ((err as Error).name === 'AbortError') {
           return;
@@ -226,7 +317,7 @@ function App() {
       controller.abort();
       clearTimeout(timeoutId);
     };
-  }, [searchSignature, parsedQuery, statusFilters, ingestedAfter, ingestedBefore]);
+  }, [searchSignature, parsedQuery, statusFilters, ingestedAfter, ingestedBefore, sortMode]);
 
   useEffect(() => {
     const { activeToken } = autocompleteContext;
@@ -270,6 +361,12 @@ function App() {
       setHighlightIndex((current) => Math.min(current, suggestions.length - 1));
     }
   }, [suggestions]);
+
+  const activeTokens = useMemo(() => searchMeta?.tokens ?? [], [searchMeta]);
+  const highlightEnabled = showHighlights && activeTokens.length > 0;
+  const formatScore = (value: number) => value.toFixed(2);
+  const formatNormalizedScore = (value: number) => value.toFixed(3);
+  const formatWeight = (value: number) => value.toFixed(1);
 
   const applySuggestion = (suggestion: TagSuggestion) => {
     setInputValue((prev) => {
@@ -341,6 +438,11 @@ function App() {
 
   const handleClearStatusFilters = () => {
     setStatusFilters([]);
+  };
+
+  const handleSortChange = (next: SearchMeta['sort']) => {
+    setSortMode(next);
+    setSortManuallySet(true);
   };
 
   const handleRetry = async (id: string) => {
@@ -527,7 +629,9 @@ function App() {
       }
       if (payload?.data?.repository) {
         setApps((prev) =>
-          prev.map((app) => (app.id === id ? (payload.data.repository as AppRecord) : app))
+          prev.map((app) =>
+            app.id === id ? (payload.data.repository as AppRecord) : app
+          )
         );
       }
       if (launchLists[id]?.open) {
@@ -554,7 +658,9 @@ function App() {
       }
       if (payload?.data?.repository) {
         setApps((prev) =>
-          prev.map((app) => (app.id === appId ? (payload.data.repository as AppRecord) : app))
+          prev.map((app) =>
+            app.id === appId ? (payload.data.repository as AppRecord) : app
+          )
         );
       }
       if (launchLists[appId]?.open) {
@@ -572,9 +678,9 @@ function App() {
     <div className="tag-row">
       {tags.map((tag) => (
         <span key={`${tag.key}:${tag.value}`} className="tag-chip">
-          <span className="tag-key">{tag.key}</span>
+          <span className="tag-key">{highlightSegments(tag.key, activeTokens, highlightEnabled)}</span>
           <span className="tag-separator">:</span>
-          <span>{tag.value}</span>
+          <span>{highlightSegments(tag.value, activeTokens, highlightEnabled)}</span>
         </span>
       ))}
     </div>
@@ -658,7 +764,9 @@ function App() {
           )}
         </div>
         {(launchError || launch?.errorMessage) && (
-          <p className="launch-error">{launchError ?? launch?.errorMessage}</p>
+          <p className="launch-error">
+            {highlightSegments(launchError ?? launch?.errorMessage ?? '', activeTokens, highlightEnabled)}
+          </p>
         )}
         {!canLaunch && (
           <p className="launch-note">Launch requires a successful build.</p>
@@ -763,6 +871,56 @@ function App() {
                   </ul>
                 )}
               </div>
+              <div className="search-controls">
+                <div className="sort-controls">
+                  <span className="controls-label">Sort by</span>
+                  <div className="sort-options">
+                    {(
+                      [
+                        { key: 'relevance', label: 'Relevance' },
+                        { key: 'updated', label: 'Recently updated' },
+                        { key: 'name', label: 'Name A→Z' }
+                      ] as { key: SearchMeta['sort']; label: string }[]
+                    ).map((option) => (
+                      <button
+                        key={option.key}
+                        type="button"
+                        className={`sort-option${sortMode === option.key ? ' active' : ''}`}
+                        onClick={() => handleSortChange(option.key)}
+                      >
+                        {option.label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+                <label className={`highlight-toggle${activeTokens.length === 0 ? ' disabled' : ''}`}>
+                  <input
+                    type="checkbox"
+                    checked={showHighlights}
+                    onChange={(event) => setShowHighlights(event.target.checked)}
+                    disabled={activeTokens.length === 0}
+                  />
+                  Highlight matches
+                </label>
+              </div>
+              {activeTokens.length > 0 && (
+                <div className="search-meta-row">
+                  <div className="token-chip-row">
+                    {activeTokens.map((token) => (
+                      <span key={token} className="token-chip">
+                        {token}
+                      </span>
+                    ))}
+                  </div>
+                  {searchMeta && (
+                    <div className="weight-chip-row">
+                      <span className="weight-chip">name × {formatWeight(searchMeta.weights.name)}</span>
+                      <span className="weight-chip">description × {formatWeight(searchMeta.weights.description)}</span>
+                      <span className="weight-chip">tags × {formatWeight(searchMeta.weights.tags)}</span>
+                    </div>
+                  )}
+                </div>
+              )}
               <div className="search-hints">
                 <span>Tab</span> accepts highlighted suggestion · <span>Esc</span> clears suggestions
               </div>
@@ -864,6 +1022,56 @@ function App() {
                       </div>
                     </div>
                   )}
+                  {ownerFacets.length > 0 && (
+                    <div className="filter-group">
+                      <div className="filter-group-header">
+                        <span>Top Owners</span>
+                      </div>
+                      <div className="facet-tag-row">
+                        {ownerFacets.slice(0, 10).map((facet) => {
+                          const token = `${facet.key}:${facet.value}`;
+                          const isActive = parsedQuery.tags.includes(token);
+                          return (
+                            <button
+                              key={token}
+                              type="button"
+                              className={`tag-facet${isActive ? ' active' : ''}`}
+                              onClick={() => handleApplyTagFacet(facet)}
+                              disabled={isActive}
+                            >
+                              <span className="tag-facet-label">{token}</span>
+                              <span className="tag-facet-count">{facet.count}</span>
+                            </button>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  )}
+                  {frameworkFacets.length > 0 && (
+                    <div className="filter-group">
+                      <div className="filter-group-header">
+                        <span>Top Frameworks</span>
+                      </div>
+                      <div className="facet-tag-row">
+                        {frameworkFacets.slice(0, 10).map((facet) => {
+                          const token = `${facet.key}:${facet.value}`;
+                          const isActive = parsedQuery.tags.includes(token);
+                          return (
+                            <button
+                              key={token}
+                              type="button"
+                              className={`tag-facet${isActive ? ' active' : ''}`}
+                              onClick={() => handleApplyTagFacet(facet)}
+                              disabled={isActive}
+                            >
+                              <span className="tag-facet-label">{token}</span>
+                              <span className="tag-facet-count">{facet.count}</span>
+                            </button>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  )}
                 </aside>
               )}
               <div className="grid">
@@ -878,16 +1086,49 @@ function App() {
                   return (
                     <article key={app.id} className="app-card">
                       <div className="app-card-header">
-                        <h2>{app.name}</h2>
+                        <h2>{highlightSegments(app.name, activeTokens, highlightEnabled)}</h2>
                         <div className="app-card-meta">
                           <span className={`status-badge status-${app.ingestStatus}`}>{app.ingestStatus}</span>
                           <time dateTime={app.updatedAt}>Updated {new Date(app.updatedAt).toLocaleDateString()}</time>
                           <span className="attempts-pill">Attempts {app.ingestAttempts}</span>
                         </div>
+                        {app.relevance && (
+                          <div className="relevance-panel">
+                            <div className="relevance-score-row">
+                              <span className="relevance-score">
+                                Score {formatScore(app.relevance.score)}
+                              </span>
+                              <span className="relevance-score secondary">
+                                Normalized {formatNormalizedScore(app.relevance.normalizedScore)}
+                              </span>
+                            </div>
+                            <div className="relevance-breakdown">
+                              <span
+                                title={`${app.relevance.components.name.hits} name hits × ${app.relevance.components.name.weight}`}
+                              >
+                                Name {formatScore(app.relevance.components.name.score)}
+                              </span>
+                              <span
+                                title={`${app.relevance.components.description.hits} description hits × ${app.relevance.components.description.weight}`}
+                              >
+                                Description {formatScore(app.relevance.components.description.score)}
+                              </span>
+                              <span
+                                title={`${app.relevance.components.tags.hits} tag hits × ${app.relevance.components.tags.weight}`}
+                              >
+                                Tags {formatScore(app.relevance.components.tags.score)}
+                              </span>
+                            </div>
+                          </div>
+                        )}
                       </div>
-                      <p className="app-description">{app.description}</p>
+                      <p className="app-description">
+                        {highlightSegments(app.description, activeTokens, highlightEnabled)}
+                      </p>
                       {app.ingestError && (
-                        <p className="ingest-error">{app.ingestError}</p>
+                        <p className="ingest-error">
+                          {highlightSegments(app.ingestError, activeTokens, highlightEnabled)}
+                        </p>
                       )}
                       {renderTags(app.tags)}
                       {renderBuildSection(app.latestBuild)}
@@ -896,7 +1137,7 @@ function App() {
                         <a href={app.repoUrl} target="_blank" rel="noreferrer">
                           View repository
                         </a>
-                        <code>{app.dockerfilePath}</code>
+                        <code>{highlightSegments(app.dockerfilePath, activeTokens, highlightEnabled)}</code>
                         {app.ingestStatus === 'failed' && (
                           <button
                             type="button"
@@ -960,7 +1201,9 @@ function App() {
                                         </a>
                                       )}
                                       {launchItem.errorMessage && (
-                                        <div className="launch-error-text">{launchItem.errorMessage}</div>
+                                        <div className="launch-error-text">
+                                          {highlightSegments(launchItem.errorMessage, activeTokens, highlightEnabled)}
+                                        </div>
                                       )}
                                       {launchItem.resourceProfile && (
                                         <span className="launch-profile">{launchItem.resourceProfile}</span>

--- a/package.json
+++ b/package.json
@@ -2,12 +2,13 @@
   "name": "apphub",
   "private": true,
   "scripts": {
-    "dev": "concurrently \"npm run dev:redis\" \"npm run dev:api\" \"npm run dev:worker\" \"npm run dev:builds\" \"npm run dev:frontend\"",
+    "dev": "concurrently \"npm run dev:redis\" \"npm run dev:api\" \"npm run dev:worker\" \"npm run dev:builds\" \"npm run dev:launches\" \"npm run dev:frontend\"",
     "dev:redis": "redis-server --save \"\" --appendonly no",
     "dev:api": "cd services/catalog && PORT=4000 HOST=127.0.0.1 npm run dev",
     "dev:worker": "cd services/catalog && npm run ingest",
     "dev:builds": "cd services/catalog && npm run builds",
-    "dev:frontend": "cd apps/frontend && npm run dev"
+    "dev:frontend": "cd apps/frontend && npm run dev",
+    "dev:launches": "cd services/catalog && npm run launches"
   },
   "devDependencies": {
     "concurrently": "^9.0.1"

--- a/services/catalog/package.json
+++ b/services/catalog/package.json
@@ -9,6 +9,7 @@
     "start": "node dist/server.js",
     "ingest": "tsx src/ingestionWorker.ts",
     "builds": "tsx src/buildWorker.ts",
+    "launches": "tsx src/launchWorker.ts",
     "test:e2e": "tsx tests/ingestion.e2e.ts"
   },
   "keywords": [

--- a/services/catalog/src/db.ts
+++ b/services/catalog/src/db.ts
@@ -84,12 +84,22 @@ export type RepositoryInsert = {
   tags?: (TagKV & { source?: string })[];
 };
 
+export type RepositorySort = 'updated' | 'name' | 'relevance';
+
+export type RelevanceWeights = {
+  name: number;
+  description: number;
+  tags: number;
+};
+
 export type RepositorySearchParams = {
   text?: string;
   tags?: TagKV[];
   statuses?: IngestStatus[];
   ingestedAfter?: string | null;
   ingestedBefore?: string | null;
+  sort?: RepositorySort;
+  relevanceWeights?: Partial<RelevanceWeights>;
 };
 
 export type TagFacet = {
@@ -103,13 +113,42 @@ export type StatusFacet = {
   count: number;
 };
 
+export type RepositoryRelevanceComponent = {
+  hits: number;
+  score: number;
+  weight: number;
+};
+
+export type RepositoryRelevance = {
+  score: number;
+  normalizedScore: number;
+  components: {
+    name: RepositoryRelevanceComponent;
+    description: RepositoryRelevanceComponent;
+    tags: RepositoryRelevanceComponent;
+  };
+};
+
+export type RepositoryRecordWithRelevance = RepositoryRecord & {
+  relevance?: RepositoryRelevance;
+};
+
+export type RepositorySearchMeta = {
+  tokens: string[];
+  sort: RepositorySort;
+  weights: RelevanceWeights;
+};
+
 export type RepositorySearchResult = {
-  records: RepositoryRecord[];
+  records: RepositoryRecordWithRelevance[];
   total: number;
   facets: {
     tags: TagFacet[];
     statuses: StatusFacet[];
+    owners: TagFacet[];
+    frameworks: TagFacet[];
   };
+  meta: RepositorySearchMeta;
 };
 
 export type IngestionEvent = {
@@ -204,7 +243,7 @@ db.exec(`
   CREATE INDEX IF NOT EXISTS idx_builds_repo_created
     ON builds(repository_id, datetime(created_at) DESC);
 
-  CREATE INDEX IF NOT EXISTS idx_builds_status
+CREATE INDEX IF NOT EXISTS idx_builds_status
     ON builds(status);
 
   CREATE TABLE IF NOT EXISTS launches (
@@ -231,6 +270,17 @@ db.exec(`
 
   CREATE INDEX IF NOT EXISTS idx_launches_status
     ON launches(status);
+`);
+
+db.exec(`
+  CREATE VIRTUAL TABLE IF NOT EXISTS repository_search USING fts5(
+    repository_id UNINDEXED,
+    name,
+    description,
+    repo_url,
+    tag_text,
+    tokenize = 'porter'
+  );
 `);
 
 function ensureColumn(table: string, column: string, ddl: string) {
@@ -356,6 +406,61 @@ const selectRepositoryTagsStatement = db.prepare(
 const selectRepositoriesStatement = db.prepare('SELECT * FROM repositories ORDER BY datetime(updated_at) DESC');
 
 const selectRepositoryByIdStatement = db.prepare('SELECT * FROM repositories WHERE id = ?');
+
+const insertRepositorySearchStatement = db.prepare(
+  `INSERT INTO repository_search (repository_id, name, description, repo_url, tag_text)
+   VALUES (@repositoryId, @name, @description, @repoUrl, @tagText)`
+);
+
+const deleteRepositorySearchStatement = db.prepare('DELETE FROM repository_search WHERE repository_id = ?');
+
+const countRepositorySearchStatement = db.prepare('SELECT COUNT(*) AS count FROM repository_search');
+
+function buildTagSearchText(tagRows: TagRow[]): string {
+  return tagRows
+    .map((tag) => `${tag.key}:${tag.value}`)
+    .join(' ');
+}
+
+function refreshRepositorySearchIndex(repositoryId: string) {
+  const repository = selectRepositoryByIdStatement.get(repositoryId) as RepositoryRow | undefined;
+  if (!repository) {
+    return;
+  }
+  const tagRows = selectRepositoryTagsStatement.all(repositoryId) as TagRow[];
+  const tagText = buildTagSearchText(tagRows);
+  deleteRepositorySearchStatement.run(repositoryId);
+  insertRepositorySearchStatement.run({
+    repositoryId: repository.id,
+    name: repository.name,
+    description: repository.description,
+    repoUrl: repository.repo_url,
+    tagText
+  });
+}
+
+function rebuildRepositorySearchIndex() {
+  const transaction = db.transaction(() => {
+    db.prepare('DELETE FROM repository_search').run();
+    const rows = db.prepare('SELECT * FROM repositories').all() as RepositoryRow[];
+    for (const row of rows) {
+      const tagRows = selectRepositoryTagsStatement.all(row.id) as TagRow[];
+      insertRepositorySearchStatement.run({
+        repositoryId: row.id,
+        name: row.name,
+        description: row.description,
+        repoUrl: row.repo_url,
+        tagText: buildTagSearchText(tagRows)
+      });
+    }
+  });
+  transaction();
+}
+
+const searchIndexCountRow = countRepositorySearchStatement.get() as { count: number };
+if (Number(searchIndexCountRow.count) === 0) {
+  rebuildRepositorySearchIndex();
+}
 
 const insertIngestionEventStatement = db.prepare(
   `INSERT INTO ingestion_events (repository_id, status, message, attempt, commit_sha, duration_ms, created_at)
@@ -606,6 +711,8 @@ export const ALL_INGEST_STATUSES: IngestStatus[] = ['seed', 'pending', 'processi
 type WhereClauseOptions = {
   includeTags?: boolean;
   includeStatuses?: boolean;
+  includeText?: boolean;
+  tableAlias?: string;
 };
 
 function buildRepositoryWhereClause(
@@ -614,12 +721,20 @@ function buildRepositoryWhereClause(
 ) {
   const includeTags = options.includeTags ?? true;
   const includeStatuses = options.includeStatuses ?? true;
+  const includeText = options.includeText ?? true;
+  const tableAlias = options.tableAlias ?? 'repositories';
   const conditions: string[] = [];
   const substitutions: unknown[] = [];
 
-  if (params.text) {
+  if (params.text && includeText) {
     const pattern = `%${params.text.toLowerCase()}%`;
-    conditions.push('(lower(name) LIKE ? OR lower(description) LIKE ? OR lower(repo_url) LIKE ? )');
+    conditions.push(
+      `(
+        lower(${tableAlias}.name) LIKE ?
+        OR lower(${tableAlias}.description) LIKE ?
+        OR lower(${tableAlias}.repo_url) LIKE ?
+      )`
+    );
     substitutions.push(pattern, pattern, pattern);
   }
 
@@ -631,7 +746,7 @@ function buildRepositoryWhereClause(
         SELECT 1
         FROM repository_tags rt
         JOIN tags t ON t.id = rt.tag_id
-        WHERE rt.repository_id = repositories.id
+        WHERE rt.repository_id = ${tableAlias}.id
           AND lower(t.key) = ?
           AND lower(t.value) = ?
       )`);
@@ -641,22 +756,49 @@ function buildRepositoryWhereClause(
 
   if (includeStatuses && params.statuses && params.statuses.length > 0) {
     const placeholders = params.statuses.map(() => '?').join(',');
-    conditions.push(`ingest_status IN (${placeholders})`);
+    conditions.push(`${tableAlias}.ingest_status IN (${placeholders})`);
     substitutions.push(...params.statuses);
   }
 
   if (params.ingestedAfter) {
-    conditions.push('last_ingested_at IS NOT NULL AND datetime(last_ingested_at) >= datetime(?)');
+    conditions.push(
+      `${tableAlias}.last_ingested_at IS NOT NULL AND datetime(${tableAlias}.last_ingested_at) >= datetime(?)`
+    );
     substitutions.push(params.ingestedAfter);
   }
 
   if (params.ingestedBefore) {
-    conditions.push('last_ingested_at IS NOT NULL AND datetime(last_ingested_at) <= datetime(?)');
+    conditions.push(
+      `${tableAlias}.last_ingested_at IS NOT NULL AND datetime(${tableAlias}.last_ingested_at) <= datetime(?)`
+    );
     substitutions.push(params.ingestedBefore);
   }
 
   const clause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
   return { clause, substitutions };
+}
+
+function tokenizeSearchText(text?: string): string[] {
+  if (!text) {
+    return [];
+  }
+  const matches = text.toLowerCase().match(/[a-z0-9]+/g);
+  if (!matches) {
+    return [];
+  }
+  const seen = new Set<string>();
+  const tokens: string[] = [];
+  for (const token of matches.slice(0, 12)) {
+    if (!seen.has(token)) {
+      seen.add(token);
+      tokens.push(token);
+    }
+  }
+  return tokens;
+}
+
+function buildFtsQuery(tokens: string[]): string {
+  return tokens.map((token) => `${token}*`).join(' AND ');
 }
 
 function rowToRepository(row: RepositoryRow): RepositoryRecord {
@@ -681,55 +823,180 @@ function rowToRepository(row: RepositoryRow): RepositoryRecord {
   };
 }
 
-export function listRepositories(params: RepositorySearchParams): RepositorySearchResult {
-  const baseClause = buildRepositoryWhereClause(params);
-  const sql = `SELECT * FROM repositories ${baseClause.clause} ORDER BY datetime(updated_at) DESC`;
-  const rows = db.prepare(sql).all(...baseClause.substitutions) as RepositoryRow[];
-  const records = rows.map(rowToRepository);
+function computeComponent(
+  hits: number,
+  weight: number
+): RepositoryRelevanceComponent {
+  return {
+    hits,
+    weight,
+    score: hits * weight
+  };
+}
 
-  const statusClause = buildRepositoryWhereClause(params, { includeStatuses: false });
-  const statusRows = db
-    .prepare(
-      `SELECT ingest_status AS status, COUNT(*) AS count
-       FROM repositories ${statusClause.clause}
-       GROUP BY ingest_status`
-    )
-    .all(...statusClause.substitutions) as { status: IngestStatus; count: number }[];
-  const statusCountMap = new Map<IngestStatus, number>();
-  for (const row of statusRows) {
-    statusCountMap.set(row.status, Number(row.count));
+export function listRepositories(params: RepositorySearchParams): RepositorySearchResult {
+  const DEFAULT_WEIGHTS: RelevanceWeights = {
+    name: 4,
+    description: 1.5,
+    tags: 2
+  };
+
+  const tokens = tokenizeSearchText(params.text);
+  const requestedSort: RepositorySort = params.sort ?? (tokens.length > 0 ? 'relevance' : 'updated');
+  const effectiveSort: RepositorySort =
+    tokens.length === 0 && requestedSort === 'relevance' ? 'updated' : requestedSort;
+
+  const weights: RelevanceWeights = {
+    name: params.relevanceWeights?.name ?? DEFAULT_WEIGHTS.name,
+    description: params.relevanceWeights?.description ?? DEFAULT_WEIGHTS.description,
+    tags: params.relevanceWeights?.tags ?? DEFAULT_WEIGHTS.tags
+  };
+
+  const relevanceScores = new Map<string, number>();
+  let rows: RepositoryRow[];
+
+  if (tokens.length > 0) {
+    const ftsQuery = buildFtsQuery(tokens);
+    const filterClause = buildRepositoryWhereClause(params, { includeText: false, tableAlias: 'r' });
+    const filterSql = filterClause.clause ? `AND ${filterClause.clause.replace(/^WHERE\s+/i, '')}` : '';
+    const orderByClause =
+      effectiveSort === 'name'
+        ? 'ORDER BY lower(r.name) ASC'
+        : effectiveSort === 'updated'
+        ? 'ORDER BY datetime(r.updated_at) DESC'
+        : 'ORDER BY relevance_score DESC, datetime(r.updated_at) DESC';
+    const bm25Weights = [0, weights.name, weights.description, 0.2, weights.tags].join(', ');
+    const query = `
+      SELECT r.*, 1.0 / (bm25(repository_search, ${bm25Weights}) + 1.0) AS relevance_score
+      FROM repositories r
+      JOIN repository_search ON repository_search.repository_id = r.id
+      WHERE repository_search MATCH ?
+      ${filterSql}
+      ${orderByClause}
+    `;
+    const searchRows = db
+      .prepare(query)
+      .all(ftsQuery, ...filterClause.substitutions) as (RepositoryRow & { relevance_score: number })[];
+    for (const row of searchRows) {
+      relevanceScores.set(row.id, Number(row.relevance_score ?? 0));
+    }
+    rows = searchRows;
+  } else {
+    const baseClause = buildRepositoryWhereClause(params, { tableAlias: 'repositories' });
+    const orderByClause =
+      effectiveSort === 'name' ? 'ORDER BY lower(name) ASC' : 'ORDER BY datetime(updated_at) DESC';
+    const sql = `SELECT * FROM repositories ${baseClause.clause} ${orderByClause}`;
+    rows = db.prepare(sql).all(...baseClause.substitutions) as RepositoryRow[];
   }
+
+  const records = rows.map((row) => rowToRepository(row) as RepositoryRecordWithRelevance);
+
+  if (tokens.length > 0) {
+    for (const record of records) {
+      const lowerName = record.name.toLowerCase();
+      const lowerDescription = record.description.toLowerCase();
+      const lowerTags = record.tags.map((tag) => `${tag.key}:${tag.value}`).join(' ').toLowerCase();
+
+      let nameHits = 0;
+      let descriptionHits = 0;
+      let tagHits = 0;
+
+      for (const token of tokens) {
+        if (lowerName.includes(token)) {
+          nameHits += 1;
+        }
+        if (lowerDescription.includes(token)) {
+          descriptionHits += 1;
+        }
+        if (lowerTags.includes(token)) {
+          tagHits += 1;
+        }
+      }
+
+      const components = {
+        name: computeComponent(nameHits, weights.name),
+        description: computeComponent(descriptionHits, weights.description),
+        tags: computeComponent(tagHits, weights.tags)
+      } satisfies RepositoryRelevance['components'];
+
+      record.relevance = {
+        score: components.name.score + components.description.score + components.tags.score,
+        normalizedScore: relevanceScores.get(record.id) ?? 0,
+        components
+      } satisfies RepositoryRelevance;
+    }
+  }
+
+  const statusCountMap = new Map<IngestStatus, number>();
+  for (const status of ALL_INGEST_STATUSES) {
+    statusCountMap.set(status, 0);
+  }
+  const tagCountMap = new Map<string, { key: string; value: string; count: number }>();
+  const ownerCountMap = new Map<string, number>();
+  const frameworkCountMap = new Map<string, number>();
+
+  for (const record of records) {
+    statusCountMap.set(record.ingestStatus, (statusCountMap.get(record.ingestStatus) ?? 0) + 1);
+    for (const tag of record.tags) {
+      const tagKey = `${tag.key}:${tag.value}`;
+      const current = tagCountMap.get(tagKey);
+      if (current) {
+        current.count += 1;
+      } else {
+        tagCountMap.set(tagKey, { key: tag.key, value: tag.value, count: 1 });
+      }
+
+      if (tag.key.toLowerCase() === 'owner') {
+        ownerCountMap.set(tag.value, (ownerCountMap.get(tag.value) ?? 0) + 1);
+      }
+      if (tag.key.toLowerCase() === 'framework') {
+        frameworkCountMap.set(tag.value, (frameworkCountMap.get(tag.value) ?? 0) + 1);
+      }
+    }
+  }
+
   const statusFacets = ALL_INGEST_STATUSES.map((status) => ({
     status,
     count: statusCountMap.get(status) ?? 0
   }));
 
-  const tagClause = buildRepositoryWhereClause(params);
-  const tagRows = db
-    .prepare(
-      `SELECT t.key AS key, t.value AS value, COUNT(*) AS count
-       FROM repositories
-       JOIN repository_tags rt ON rt.repository_id = repositories.id
-       JOIN tags t ON t.id = rt.tag_id
-       ${tagClause.clause}
-       GROUP BY t.key, t.value
-       ORDER BY count DESC, t.key ASC, t.value ASC
-       LIMIT 50`
-    )
-    .all(...tagClause.substitutions) as { key: string; value: string; count: number }[];
+  const tagFacets = Array.from(tagCountMap.values())
+    .sort((a, b) => {
+      if (b.count !== a.count) {
+        return b.count - a.count;
+      }
+      const keyCompare = a.key.localeCompare(b.key);
+      if (keyCompare !== 0) {
+        return keyCompare;
+      }
+      return a.value.localeCompare(b.value);
+    })
+    .slice(0, 50)
+    .map((row) => ({ key: row.key, value: row.value, count: row.count }));
 
-  const tagFacets = tagRows.map((row) => ({
-    key: row.key,
-    value: row.value,
-    count: Number(row.count)
-  }));
+  const owners = Array.from(ownerCountMap.entries())
+    .map(([value, count]) => ({ key: 'owner', value, count }))
+    .sort((a, b) => (b.count !== a.count ? b.count - a.count : a.value.localeCompare(b.value)))
+    .slice(0, 10);
+
+  const frameworks = Array.from(frameworkCountMap.entries())
+    .map(([value, count]) => ({ key: 'framework', value, count }))
+    .sort((a, b) => (b.count !== a.count ? b.count - a.count : a.value.localeCompare(b.value)))
+    .slice(0, 10);
 
   return {
     records,
     total: records.length,
     facets: {
       tags: tagFacets,
-      statuses: statusFacets
+      statuses: statusFacets,
+      owners,
+      frameworks
+    },
+    meta: {
+      tokens,
+      sort: effectiveSort,
+      weights
     }
   };
 }
@@ -1152,6 +1419,7 @@ export function upsertRepository(repository: RepositoryInsert): RepositoryRecord
       deleteRepositoryTagsStatement.run(repository.id);
       attachTags(repository.id, repository.tags);
     }
+    refreshRepositorySearchIndex(repository.id);
     return rowToRepository(selectRepositoryByIdStatement.get(repository.id) as RepositoryRow);
   });
 
@@ -1173,6 +1441,7 @@ export function addRepository(repository: RepositoryInsert): RepositoryRecord {
     if (repository.tags && repository.tags.length > 0) {
       attachTags(repository.id, repository.tags.map((tag) => ({ ...tag, source: tag.source ?? 'author' })));
     }
+    refreshRepositorySearchIndex(repository.id);
     return rowToRepository(selectRepositoryByIdStatement.get(repository.id) as RepositoryRow);
   });
 
@@ -1201,6 +1470,7 @@ export function replaceRepositoryTags(
     );
   });
   transaction();
+  refreshRepositorySearchIndex(repositoryId);
 }
 
 export function listTagSuggestions(prefix: string, limit: number): TagSuggestion[] {

--- a/services/catalog/src/db.ts
+++ b/services/catalog/src/db.ts
@@ -283,6 +283,17 @@ db.exec(`
   );
 `);
 
+db.exec(`
+  CREATE VIRTUAL TABLE IF NOT EXISTS repository_search USING fts5(
+    repository_id UNINDEXED,
+    name,
+    description,
+    repo_url,
+    tag_text,
+    tokenize = 'porter'
+  );
+`);
+
 function ensureColumn(table: string, column: string, ddl: string) {
   const rows = db.prepare(`PRAGMA table_info(${table})`).all() as { name: string }[];
   if (!rows.some((row) => row.name === column)) {

--- a/services/catalog/src/launchRunner.ts
+++ b/services/catalog/src/launchRunner.ts
@@ -1,0 +1,161 @@
+import { spawn } from 'node:child_process';
+import { failLaunch, getBuildById, getLaunchById, markLaunchRunning, markLaunchStopped, requestLaunchStop, startLaunch } from './db';
+
+function log(message: string, meta?: Record<string, unknown>) {
+  const payload = meta ? ` ${JSON.stringify(meta)}` : '';
+  console.log(`[launch] ${message}${payload}`);
+}
+
+function sanitizeName(value: string) {
+  return value.toLowerCase().replace(/[^a-z0-9_.-]+/g, '-').replace(/^-+|-+$/g, '') || 'app';
+}
+
+function runDocker(args: string[]): Promise<{ exitCode: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve) => {
+    const child = spawn('docker', args, { env: process.env });
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    child.on('close', (code) => {
+      resolve({ exitCode: code, stdout, stderr });
+    });
+
+    child.on('error', (err) => {
+      const message = (err as Error).message ?? 'process error';
+      resolve({ exitCode: null, stdout, stderr: `${stderr}\n${message}` });
+    });
+  });
+}
+
+function buildPreviewUrl(hostPort: string): string {
+  const base = process.env.LAUNCH_PREVIEW_BASE_URL ?? 'http://127.0.0.1';
+  try {
+    const url = new URL(base);
+    url.port = hostPort;
+    return url.toString().replace(/\/$/, '');
+  } catch {
+    const trimmed = base.replace(/\/$/, '');
+    if (/^https?:\/\//.test(trimmed)) {
+      const withoutPort = trimmed.replace(/:\d+$/, '');
+      return `${withoutPort}:${hostPort}`;
+    }
+    return `${trimmed}:${hostPort}`;
+  }
+}
+
+function parseHostPort(output: string, internalPort: number): string | null {
+  const lines = output.trim().split(/\r?\n/).filter(Boolean);
+  for (const line of lines) {
+    const match = line.match(new RegExp(`${internalPort}\/tcp\s+->\s+[^:]+:(\d+)`));
+    if (match && match[1]) {
+      return match[1];
+    }
+  }
+  return null;
+}
+
+export async function runLaunchStart(launchId: string) {
+  const launch = startLaunch(launchId);
+  if (!launch) {
+    log('Launch not pending', { launchId });
+    return;
+  }
+
+  const build = getBuildById(launch.buildId);
+  if (!build || build.status !== 'succeeded' || !build.imageTag) {
+    const message = 'Launch unavailable: build image missing';
+    failLaunch(launch.id, message);
+    log('Launch failed - build unavailable', { launchId, buildId: launch.buildId });
+    return;
+  }
+
+  const containerPort = Number(process.env.LAUNCH_INTERNAL_PORT ?? 3000);
+  const containerName = `apphub-${sanitizeName(launch.repositoryId)}-${launch.id.slice(0, 8)}`;
+
+  log('Starting container', {
+    launchId,
+    buildId: launch.buildId,
+    imageTag: build.imageTag,
+    containerName,
+    containerPort
+  });
+
+  const runArgs = ['run', '-d', '--name', containerName, '-p', `0:${containerPort}`, build.imageTag];
+  const runResult = await runDocker(runArgs);
+  if (runResult.exitCode !== 0 || runResult.stdout.trim().length === 0) {
+    const message = runResult.stderr || 'docker run failed';
+    failLaunch(launch.id, message.trim().slice(0, 500));
+    log('Launch docker run failed', { launchId, error: message.trim() });
+    return;
+  }
+
+  const containerId = runResult.stdout.trim().split(/\s+/)[0];
+
+  const portResult = await runDocker(['port', containerId, `${containerPort}/tcp`]);
+  if (portResult.exitCode !== 0) {
+    const message = portResult.stderr || 'Failed to determine mapped port';
+    failLaunch(launch.id, message.trim().slice(0, 500));
+    log('Launch port discovery failed', { launchId, error: message.trim() });
+    void runDocker(['rm', '-f', containerId]);
+    return;
+  }
+
+  const hostPort = parseHostPort(portResult.stdout, containerPort);
+  if (!hostPort) {
+    const message = 'Unable to parse docker port output';
+    failLaunch(launch.id, message);
+    log('Launch port parse failed', { launchId, output: portResult.stdout });
+    void runDocker(['rm', '-f', containerId]);
+    return;
+  }
+
+  const instanceUrl = buildPreviewUrl(hostPort);
+  markLaunchRunning(launch.id, {
+    instanceUrl,
+    containerId,
+    port: Number(hostPort)
+  });
+
+  log('Launch running', { launchId, containerId, instanceUrl });
+}
+
+export async function runLaunchStop(launchId: string) {
+  const launch = getLaunchById(launchId);
+  if (!launch) {
+    log('Launch missing for stop', { launchId });
+    return;
+  }
+
+  let current = launch;
+  if (launch.status !== 'stopping') {
+    const requested = requestLaunchStop(launchId);
+    if (!requested) {
+      log('Launch not in stopping state', { launchId, status: launch.status });
+      return;
+    }
+    current = requested;
+  }
+
+  if (!current.containerId) {
+    markLaunchStopped(launchId);
+    log('Launch stop with no container id', { launchId });
+    return;
+  }
+
+  const stopResult = await runDocker(['stop', '--time', '5', current.containerId]);
+  if (stopResult.exitCode !== 0) {
+    const message = stopResult.stderr || 'docker stop failed';
+    log('Launch docker stop failed', { launchId, error: message.trim() });
+  }
+
+  await runDocker(['rm', '-f', current.containerId]);
+  markLaunchStopped(launchId);
+  log('Launch stopped', { launchId });
+}

--- a/services/catalog/src/launchWorker.ts
+++ b/services/catalog/src/launchWorker.ts
@@ -1,0 +1,121 @@
+import { Worker } from 'bullmq';
+import {
+  takeNextLaunchToStart,
+  takeNextLaunchToStop,
+  type LaunchRecord
+} from './db';
+import { runLaunchStart, runLaunchStop } from './launchRunner';
+import { getQueueConnection, isInlineQueueMode, LAUNCH_QUEUE_NAME } from './queue';
+
+const LAUNCH_CONCURRENCY = Number(process.env.LAUNCH_CONCURRENCY ?? 1);
+const useInlineQueue = isInlineQueueMode();
+
+type LaunchJob = { type: 'start' | 'stop'; launchId: string };
+
+function log(message: string, meta?: Record<string, unknown>) {
+  const payload = meta ? ` ${JSON.stringify(meta)}` : '';
+  console.log(`[launch-worker] ${message}${payload}`);
+}
+
+async function runInlineLaunchLoop() {
+  log('Starting inline launch loop');
+  let running = true;
+
+  const poll = async () => {
+    if (!running) {
+      return;
+    }
+    try {
+      let launch: LaunchRecord | null;
+      while (running && (launch = takeNextLaunchToStop())) {
+        await runLaunchStop(launch.id);
+      }
+      while (running && (launch = takeNextLaunchToStart())) {
+        await runLaunchStart(launch.id);
+      }
+    } catch (err) {
+      log('Inline launch error', { error: (err as Error).message });
+    }
+  };
+
+  const interval = setInterval(() => {
+    void poll();
+  }, 500);
+
+  void poll();
+
+  const shutdown = async () => {
+    running = false;
+    clearInterval(interval);
+    log('Shutdown signal received');
+    process.exit(0);
+  };
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+}
+
+async function runQueuedLaunchWorker() {
+  log('Starting queued launch worker', {
+    queue: LAUNCH_QUEUE_NAME,
+    concurrency: LAUNCH_CONCURRENCY
+  });
+
+  const connection = getQueueConnection();
+  const worker = new Worker(
+    LAUNCH_QUEUE_NAME,
+    async (job) => {
+      const data = job.data as LaunchJob;
+      if (data.type === 'stop') {
+        await runLaunchStop(data.launchId);
+        return;
+      }
+      await runLaunchStart(data.launchId);
+    },
+    {
+      connection,
+      concurrency: LAUNCH_CONCURRENCY
+    }
+  );
+
+  worker.on('failed', (job, err) => {
+    log('Launch job failed', {
+      jobId: job?.id ?? 'unknown',
+      error: err?.message ?? 'unknown'
+    });
+  });
+
+  worker.on('completed', (job) => {
+    log('Launch job completed', { jobId: job.id });
+  });
+
+  await worker.waitUntilReady();
+  log('Launch worker ready');
+
+  const shutdown = async () => {
+    log('Shutdown signal received');
+    await worker.close();
+    try {
+      await connection.quit();
+    } catch (err) {
+      log('Error closing Redis connection', { error: (err as Error).message });
+    }
+    process.exit(0);
+  };
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+}
+
+async function main() {
+  if (useInlineQueue) {
+    await runInlineLaunchLoop();
+    return;
+  }
+  await runQueuedLaunchWorker();
+}
+
+main().catch((err) => {
+  console.error('[launch-worker] Worker crashed', err);
+  process.exit(1);
+});

--- a/services/catalog/src/server.ts
+++ b/services/catalog/src/server.ts
@@ -11,6 +11,10 @@ import {
   ALL_INGEST_STATUSES,
   type BuildRecord,
   type RepositoryRecord,
+  type RepositoryRecordWithRelevance,
+  type RepositorySearchMeta,
+  type RepositorySort,
+  type RelevanceWeights,
   type TagKV,
   type IngestStatus,
   createLaunch,
@@ -30,6 +34,8 @@ type SearchQuery = {
   status?: string[];
   ingestedAfter?: string;
   ingestedBefore?: string;
+  sort?: RepositorySort;
+  relevance?: string;
 };
 
 const tagQuerySchema = z
@@ -72,6 +78,12 @@ const searchQuerySchema = z.object({
     .optional(),
   ingestedBefore: z
     .preprocess((val) => (typeof val === 'string' ? val : undefined), isoDateSchema)
+    .optional(),
+  sort: z
+    .preprocess((val) => (typeof val === 'string' ? val : undefined), z.enum(['relevance', 'updated', 'name']))
+    .optional(),
+  relevance: z
+    .preprocess((val) => (typeof val === 'string' ? val : undefined), z.string().trim())
     .optional()
 });
 
@@ -174,7 +186,7 @@ function normalizeIngestedBefore(raw?: string) {
   return date.toISOString();
 }
 
-function serializeRepository(record: RepositoryRecord) {
+function serializeRepository(record: RepositoryRecordWithRelevance) {
   const {
     id,
     name,
@@ -201,8 +213,37 @@ function serializeRepository(record: RepositoryRecord) {
     ingestError,
     ingestAttempts,
     latestBuild: serializeBuild(latestBuild),
-    latestLaunch: serializeLaunch(latestLaunch)
+    latestLaunch: serializeLaunch(latestLaunch),
+    relevance: record.relevance ?? null
   };
+}
+
+function parseRelevanceWeights(raw?: string): Partial<RelevanceWeights> | undefined {
+  if (!raw) {
+    return undefined;
+  }
+  const parts = raw
+    .split(',')
+    .map((chunk) => chunk.trim())
+    .filter(Boolean);
+  if (parts.length === 0) {
+    return undefined;
+  }
+  const weights: Partial<RelevanceWeights> = {};
+  for (const part of parts) {
+    const [key, value] = part.split(':').map((piece) => piece.trim());
+    if (!key || value === undefined) {
+      continue;
+    }
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric) || numeric <= 0) {
+      continue;
+    }
+    if (key === 'name' || key === 'description' || key === 'tags') {
+      weights[key] = numeric;
+    }
+  }
+  return Object.keys(weights).length > 0 ? weights : undefined;
 }
 
 function serializeBuild(build: BuildRecord | null) {
@@ -284,18 +325,23 @@ async function buildServer() {
       }
     }
 
+    const relevanceWeights = parseRelevanceWeights(query.relevance);
+
     const searchResult = listRepositories({
       text: query.q,
       tags,
       statuses: statuses.length > 0 ? statuses : undefined,
       ingestedAfter,
-      ingestedBefore
+      ingestedBefore,
+      sort: query.sort,
+      relevanceWeights
     });
 
     return {
       data: searchResult.records.map(serializeRepository),
       facets: searchResult.facets,
-      total: searchResult.total
+      total: searchResult.total,
+      meta: searchResult.meta satisfies RepositorySearchMeta
     };
   });
 


### PR DESCRIPTION
## Summary
- add launch persistence, queue helpers, and worker routines to manage app containers
- expose REST endpoints for launching, stopping, and listing launches with inline-mode support
- surface launch controls, preview links, and history in the frontend alongside build status

## Testing
- npm run lint (apps/frontend)
- npm run test:e2e (services/catalog)


------
https://chatgpt.com/codex/tasks/task_e_68cd0fdfa75c8333989b9784b0c41af0