### PR TITLE
Fix queued launch stop jobs

### DIFF
--- a/services/catalog/src/queue.ts
+++ b/services/catalog/src/queue.ts
@@ -133,7 +133,7 @@ export async function enqueueLaunchStart(launchId: string) {
     throw new Error('Launch queue not initialised');
   }
 
-  await launchQueue.add('launch-start', { launchId });
+  await launchQueue.add('launch-start', { launchId, type: 'start' });
 }
 
 export async function enqueueLaunchStop(launchId: string) {
@@ -145,5 +145,5 @@ export async function enqueueLaunchStop(launchId: string) {
     throw new Error('Launch queue not initialised');
   }
 
-  await launchQueue.add('launch-stop', { launchId });
+  await launchQueue.add('launch-stop', { launchId, type: 'stop' });
 }


### PR DESCRIPTION
## Summary
- include explicit job types when enqueuing launch start and stop jobs so the launch worker processes stop requests correctly

## Testing
- npm run test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68ce21d5212883339be23429e03f11f0