### PR TITLE
frontend: prefill launch env widget

### DIFF
--- a/apps/frontend/src/catalog/types.ts
+++ b/apps/frontend/src/catalog/types.ts
@@ -121,6 +121,9 @@ export type AppRecord = {
   latestLaunch: LaunchSummary | null;
   relevance: RelevanceSummary | null;
   previewTiles: PreviewTile[];
+  availableEnv?: LaunchEnvVar[];
+  availableLaunchEnv?: LaunchEnvVar[];
+  launchEnvTemplates?: LaunchEnvVar[];
 };
 
 export type RelevanceComponent = {


### PR DESCRIPTION
## Summary
- derive available environment variables for a launch from app metadata and tags
- seed the launch form with the combined env list and append newly discovered keys
- add optional catalog types for exposed env hints

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce23cdbcdc8333885ede160b455829