### PR TITLE
Add catalog nuke control in navbar

### DIFF
--- a/services/catalog/src/server.ts
+++ b/services/catalog/src/server.ts
@@ -38,6 +38,7 @@ import {
   getServiceBySlug,
   upsertService,
   setServiceStatus,
+  nukeCatalogDatabase,
   type ServiceRecord,
   type ServiceStatusUpdate,
   type ServiceUpsertInput,
@@ -1558,6 +1559,25 @@ export async function buildServer() {
 
     reply.status(202);
     return { data: refreshed ? serializeRepository(refreshed) : null };
+  });
+
+  app.post('/admin/catalog/nuke', async (request, reply) => {
+    try {
+      const result = nukeCatalogDatabase();
+      request.log.warn(
+        {
+          repositoriesDeleted: result.repositoriesDeleted,
+          servicesDeleted: result.servicesDeleted
+        },
+        'Catalog database nuked'
+      );
+      reply.status(200);
+      return { data: result };
+    } catch (err) {
+      request.log.error({ err }, 'Failed to nuke catalog database');
+      reply.status(500);
+      return { error: 'Failed to nuke catalog database' };
+    }
   });
 
   return app;


### PR DESCRIPTION
## Summary
- add a catalog API endpoint that clears all catalog data and reports counts
- expose a destructive control in the navbar that calls the new endpoint with confirmation and inline error handling

## Testing
- npm run lint (apps/frontend)
- npm run build (services/catalog)


------
https://chatgpt.com/codex/tasks/task_e_68ce575d77bc83338b05b4707303072b