### PR TITLE
frontend: add apps gallery tab

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import Navbar from './components/Navbar';
 import { NavigationContext, type ActiveTab } from './components/NavigationContext';
 import ImportServiceManifest from './import/ImportServiceManifest';
 import SubmitApp from './submit/SubmitApp';
+import ServiceGallery from './services/ServiceGallery';
 
 function App() {
   const [activeTab, setActiveTab] = useState<ActiveTab>('catalog');
@@ -30,6 +31,7 @@ function App() {
           {activeTab === 'catalog' && (
             <CatalogPage searchSeed={searchSeed} onSeedApplied={() => setSearchSeed(undefined)} />
           )}
+          {activeTab === 'apps' && <ServiceGallery />}
           {activeTab === 'submit' && <SubmitApp onAppRegistered={handleAppRegistered} />}
           {activeTab === 'import-manifest' && <ImportServiceManifest onImported={handleManifestImported} />}
         </main>

--- a/apps/frontend/src/components/Navbar.tsx
+++ b/apps/frontend/src/components/Navbar.tsx
@@ -9,6 +9,7 @@ interface NavbarProps {
 
 const TAB_LABELS: Record<ActiveTab, string> = {
   catalog: 'Catalog',
+  apps: 'Apps',
   submit: 'Submit App',
   'import-manifest': 'Import Manifest'
 };

--- a/apps/frontend/src/components/NavigationContext.tsx
+++ b/apps/frontend/src/components/NavigationContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext } from 'react';
 
-export type ActiveTab = 'catalog' | 'submit' | 'import-manifest';
+export type ActiveTab = 'catalog' | 'apps' | 'submit' | 'import-manifest';
 
 export interface NavigationContextValue {
   activeTab: ActiveTab;

--- a/apps/frontend/src/services/ServiceGallery.tsx
+++ b/apps/frontend/src/services/ServiceGallery.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useMemo, useState } from 'react';
+import { API_BASE_URL } from '../config';
+import { normalizePreviewUrl } from '../utils/url';
+import { formatFetchError } from '../catalog/utils';
+
+type ServiceSummary = {
+  id: string;
+  slug: string;
+  displayName: string;
+  kind: string;
+  baseUrl: string;
+  status: string;
+  statusMessage: string | null;
+  capabilities: unknown;
+  metadata: unknown;
+  lastHealthyAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type ServicesResponse = {
+  data?: ServiceSummary[];
+};
+
+const REFRESH_INTERVAL_MS = 15000;
+const ACTIVE_STATUSES = new Set(['healthy', 'degraded']);
+
+function extractRuntimeUrl(service: ServiceSummary): string | null {
+  const metadata = service.metadata;
+  if (metadata && typeof metadata === 'object' && !Array.isArray(metadata)) {
+    const runtime = (metadata as Record<string, unknown>).runtime;
+    if (runtime && typeof runtime === 'object' && !Array.isArray(runtime)) {
+      const runtimeRecord = runtime as Record<string, unknown>;
+      const candidates = [runtimeRecord.instanceUrl, runtimeRecord.baseUrl, runtimeRecord.previewUrl];
+      for (const candidate of candidates) {
+        if (typeof candidate === 'string' && candidate.trim().length > 0) {
+          return candidate.trim();
+        }
+      }
+    }
+  }
+  if (typeof service.baseUrl === 'string' && service.baseUrl.trim()) {
+    return service.baseUrl.trim();
+  }
+  return null;
+}
+
+export default function ServiceGallery() {
+  const [services, setServices] = useState<ServiceSummary[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    let timeoutId: number | null = null;
+    let controller: AbortController | null = null;
+    let initialLoad = true;
+
+    const fetchServices = async () => {
+      controller?.abort();
+      controller = new AbortController();
+      const signal = controller.signal;
+
+      if (initialLoad) {
+        setLoading(true);
+      }
+
+      try {
+        const response = await fetch(`${API_BASE_URL}/services`, { signal });
+        if (!response.ok) {
+          throw new Error(`Request failed with status ${response.status}`);
+        }
+        const payload = (await response.json()) as ServicesResponse;
+        if (!mounted) {
+          return;
+        }
+        setServices(Array.isArray(payload.data) ? payload.data : []);
+        setError(null);
+      } catch (err) {
+        if ((err as Error)?.name === 'AbortError') {
+          return;
+        }
+        if (!mounted) {
+          return;
+        }
+        setError(formatFetchError(err, 'Failed to load services', API_BASE_URL));
+      } finally {
+        if (mounted) {
+          if (initialLoad) {
+            setLoading(false);
+            initialLoad = false;
+          }
+          timeoutId = window.setTimeout(fetchServices, REFRESH_INTERVAL_MS);
+        }
+      }
+    };
+
+    fetchServices();
+
+    return () => {
+      mounted = false;
+      if (timeoutId !== null) {
+        window.clearTimeout(timeoutId);
+      }
+      controller?.abort();
+    };
+  }, []);
+
+  const activeServices = useMemo(() => {
+    return services
+      .filter((service) => ACTIVE_STATUSES.has(service.status))
+      .map((service) => ({
+        service,
+        embedUrl: normalizePreviewUrl(extractRuntimeUrl(service))
+      }))
+      .filter(
+        (entry): entry is { service: ServiceSummary; embedUrl: string } =>
+          typeof entry.embedUrl === 'string' && entry.embedUrl.length > 0
+      );
+  }, [services]);
+
+  return (
+    <section className="flex flex-col gap-6">
+      <div className="rounded-3xl border border-slate-200/70 bg-white/80 p-4 shadow-[0_30px_70px_-45px_rgba(15,23,42,0.65)] backdrop-blur-md transition-colors dark:border-slate-700/70 dark:bg-slate-900/70 sm:p-6">
+        {error ? (
+          <div className="rounded-2xl border border-rose-300/70 bg-rose-50/70 px-5 py-4 text-sm font-semibold text-rose-600 shadow-sm dark:border-rose-500/40 dark:bg-rose-500/10 dark:text-rose-300">
+            {error}
+          </div>
+        ) : loading ? (
+          <div className="rounded-2xl border border-slate-200/70 bg-slate-50/70 px-5 py-4 text-sm font-medium text-slate-600 shadow-sm dark:border-slate-700/70 dark:bg-slate-800/70 dark:text-slate-300">
+            Loading services…
+          </div>
+        ) : activeServices.length === 0 ? (
+          <div className="rounded-2xl border border-slate-200/70 bg-slate-50/70 px-5 py-4 text-sm font-medium text-slate-600 shadow-sm dark:border-slate-700/70 dark:bg-slate-800/70 dark:text-slate-300">
+            No running services detected.
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 gap-4 sm:gap-6 md:grid-cols-2 xl:grid-cols-3">
+            {activeServices.map(({ service, embedUrl }) => (
+              <article
+                key={service.id}
+                className="overflow-hidden rounded-3xl border border-slate-200/70 bg-slate-950/60 shadow-lg shadow-slate-900/30 transition-transform duration-300 ease-out hover:-translate-y-1 hover:shadow-2xl dark:border-slate-700/60 dark:bg-slate-900/80"
+                aria-label={service.displayName}
+              >
+                <div className="aspect-video">
+                  <iframe
+                    src={embedUrl ?? undefined}
+                    title={service.displayName}
+                    loading="lazy"
+                    allow="autoplay; fullscreen; clipboard-read; clipboard-write"
+                    sandbox="allow-scripts allow-same-origin allow-popups allow-forms allow-downloads"
+                    className="h-full w-full border-0"
+                  />
+                </div>
+                <span className="sr-only">{service.displayName}</span>
+              </article>
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/frontend/src/services/ServiceGallery.tsx
+++ b/apps/frontend/src/services/ServiceGallery.tsx
@@ -148,7 +148,7 @@ export default function ServiceGallery() {
                     title={service.displayName}
                     loading="lazy"
                     allow="autoplay; fullscreen; clipboard-read; clipboard-write"
-                    sandbox="allow-scripts allow-same-origin allow-popups allow-forms allow-downloads"
+                    sandbox="allow-scripts"
                     className="h-full w-full border-0"
                   />
                 </div>

--- a/apps/frontend/src/utils/url.ts
+++ b/apps/frontend/src/utils/url.ts
@@ -52,7 +52,7 @@ export function normalizePreviewUrl(rawUrl: string | null | undefined): string |
       parsed = new URL(trimmedUrl);
     }
   } catch {
-    return trimmedUrl;
+    return null;
   }
 
   if (!isLoopbackHost(parsed.hostname)) {
@@ -61,7 +61,9 @@ export function normalizePreviewUrl(rawUrl: string | null | undefined): string |
 
   for (const base of candidates) {
     if (!isLoopbackHost(base.hostname)) {
+      parsed.protocol = base.protocol;
       parsed.hostname = base.hostname;
+      parsed.port = base.port;
       return parsed.toString();
     }
   }

--- a/apps/frontend/src/utils/url.ts
+++ b/apps/frontend/src/utils/url.ts
@@ -1,0 +1,70 @@
+import { API_BASE_URL } from '../config';
+
+const LOOPBACK_HOST_PREFIX = /^127\./;
+const LOOPBACK_HOSTS = new Set(['127.0.0.1', 'localhost', '::1', '::ffff:127.0.0.1', '0.0.0.0']);
+
+function isLoopbackHost(host: string): boolean {
+  const normalized = host.replace(/^\[(.*)\]$/, '$1').toLowerCase();
+  return LOOPBACK_HOSTS.has(normalized) || LOOPBACK_HOST_PREFIX.test(normalized);
+}
+
+function getPreviewBaseCandidates(): URL[] {
+  const bases: URL[] = [];
+
+  try {
+    bases.push(new URL(API_BASE_URL));
+  } catch {
+    // ignore invalid API base URL
+  }
+
+  if (typeof window !== 'undefined' && window.location?.origin) {
+    try {
+      bases.push(new URL(window.location.origin));
+    } catch {
+      // ignore invalid browser origin
+    }
+  }
+
+  return bases;
+}
+
+export function normalizePreviewUrl(rawUrl: string | null | undefined): string | null {
+  if (!rawUrl) {
+    return null;
+  }
+
+  const trimmedUrl = rawUrl.trim();
+  if (!trimmedUrl) {
+    return null;
+  }
+
+  const candidates = getPreviewBaseCandidates();
+  let parsed: URL;
+
+  try {
+    if (trimmedUrl.startsWith('http://') || trimmedUrl.startsWith('https://')) {
+      parsed = new URL(trimmedUrl);
+    } else if (candidates.length > 0) {
+      parsed = new URL(trimmedUrl, candidates[0]);
+    } else if (typeof window !== 'undefined' && window.location?.origin) {
+      parsed = new URL(trimmedUrl, window.location.origin);
+    } else {
+      parsed = new URL(trimmedUrl);
+    }
+  } catch {
+    return trimmedUrl;
+  }
+
+  if (!isLoopbackHost(parsed.hostname)) {
+    return parsed.toString();
+  }
+
+  for (const base of candidates) {
+    if (!isLoopbackHost(base.hostname)) {
+      parsed.hostname = base.hostname;
+      return parsed.toString();
+    }
+  }
+
+  return parsed.toString();
+}


### PR DESCRIPTION
## Summary
- add an Apps tab to the frontend navigation and route it to a new service gallery
- refactor preview URL normalization so catalog previews and the gallery share the same logic
- fetch running services from the catalog API and render them as iframe tiles in a compact grid

## Testing
- npm run lint (apps/frontend)


------
https://chatgpt.com/codex/tasks/task_e_68ce8c0bdcb48333a10269c0feaff4a3