### PR TITLE
docs: add jobs/workflows feature tickets

### DIFF
--- a/JOBS_SPEC.md
+++ b/JOBS_SPEC.md
@@ -1,0 +1,105 @@
+# Jobs & Workflows Integration Specification
+
+## Overview
+This document explores what is required to extend the AppHub platform with two new orchestration concepts:
+
+- **Jobs** – deterministic operations that run to completion without long-lived state. Existing ingestion and build runners are early examples.
+- **Workflows** – composed graphs of services and jobs that collaborate to produce higher-level outcomes (e.g., ingest + build + notify).
+
+The goal is to support declarative registration, execution, tracking, and introspection of both concepts while fitting into the existing Fastify API, BullMQ-powered workers, and service registry.
+
+## Objectives
+1. **Unify orchestration vocabulary** so that ingestion, build, and future automation steps share a consistent lifecycle model.
+2. **Expose workflow composition** that links jobs and registered services into reproducible pipelines.
+3. **Provide operational visibility** through API endpoints and events that mirror current ingestion/build telemetry.
+4. **Remain backward compatible** with existing API consumers and workers.
+
+## Core Concepts
+### Job Definition
+- **Schema**: `id`, `slug`, `name`, `version`, `type` (`batch`, `service-triggered`, `manual`), `entry_point`, `parameters` schema, `timeout_ms`, `retry_policy`, `created_at`.
+- **Lifecycle States**: `pending`, `running`, `succeeded`, `failed`, `canceled`, `expired`.
+- **Execution Context**: references to repo/app, environment variables, secrets (fetched via future secret store integration), resource profile.
+
+### Workflow Definition
+- **Schema**: `id`, `slug`, `name`, `version`, `description`, `steps`, `triggers`, `created_at`.
+- **Steps**: ordered or DAG-based nodes referencing job definitions or registered services. Each step defines dependencies, retry/rollback strategy, and payload mapping.
+- **Triggers**: events (repo registered, service health change), schedules (cron), or manual invocations.
+- **Artifacts**: shared storage for step outputs (Postgres JSONB, object storage pointers) to pass context between jobs/services.
+
+## Data Model Changes
+1. **Tables**
+   - `job_definitions` capturing metadata and default parameters.
+   - `workflow_definitions` storing composition and triggers.
+   - `job_runs` recording each execution attempt with foreign keys to definitions, status timestamps, metrics (duration, logs pointer).
+   - `workflow_runs` capturing orchestration state, current step pointer, aggregated status, emitted events.
+   - `workflow_run_steps` bridging runs to individual job/service executions and storing input/output payloads.
+2. **Indexes** for querying by slug, status, created_at.
+3. **Migration Strategy**: Add tables via new migration files, ensure existing ingestion/build data remains untouched.
+
+## API Surface
+### Job Endpoints
+- `POST /jobs` to register definitions (authorized).
+- `GET /jobs` & `GET /jobs/:slug` for discovery.
+- `POST /jobs/:slug/run` to enqueue manual executions with parameter overrides.
+- `GET /jobs/:slug/runs` for history.
+
+### Workflow Endpoints
+- `POST /workflows` to register composed workflows.
+- `GET /workflows` & `GET /workflows/:slug` for discovery.
+- `POST /workflows/:slug/run` for manual trigger.
+- `GET /workflows/:slug/runs` and `GET /workflow-runs/:id/steps` for monitoring.
+
+### Event Stream Extensions
+- Extend WebSocket feed with `job.run.*` and `workflow.run.*` topics mirroring ingestion event payloads.
+- Include aggregated metrics (duration, step statuses) for UI updates.
+
+## Worker & Scheduler Changes
+1. **BullMQ Queue Strategy**
+   - Create dedicated queues (`job:default`, `workflow:orchestrator`), or reuse existing Redis instance with namespacing.
+   - Support delayed jobs, concurrency limits, and retry policies defined per job.
+2. **Workflow Orchestrator Worker**
+   - Consumes workflow run requests, resolves step graph, enqueues dependent jobs, monitors completion, and applies failure policies (retry, skip, halt).
+   - Manages data hand-off via shared context stored in Postgres or Redis.
+3. **Job Runner Abstractions**
+   - Wrap existing ingestion/build workers with a generic execution adapter so they can be invoked as workflow steps.
+   - Define a contract (`execute(JobRunContext) -> JobResult`) to unify logging and metrics.
+4. **Service Invocation Steps**
+   - For service-type steps, integrate with service registry to discover connection details and authentication requirements.
+   - Provide HTTP/gRPC invocation helpers with standardized timeout/retry behavior.
+
+## Frontend & Operator Experience
+- Add UI sections for job/workflow catalog, run history, and live status updates.
+- Provide launch modals for manual executions with parameter forms generated from JSON schema.
+- Surface workflow DAG visualization, step timelines, and log links.
+- Offer filtering/search by status, repo, service, and tags to aid troubleshooting.
+
+## Observability & Logging
+- Persist structured logs per job run (link to object storage or log aggregation service).
+- Collect metrics: run counts, success rate, average duration, failure reasons.
+- Integrate with existing event stream to notify frontend and CLI tools.
+- Provide alert hooks (webhooks, PagerDuty) when workflows fail repeatedly.
+
+## Security & Permissions
+- Enforce auth on registration and manual execution endpoints (future integration with service tokens or user roles).
+- Validate parameter schemas to prevent arbitrary command execution.
+- Audit log workflow modifications and manual runs.
+
+## Backward Compatibility
+- Existing ingestion/build operations continue to function; their implementations register as default job definitions during migration.
+- API responses maintain current fields, with optional extensions for workflows.
+- UI additions are additive; existing search and repo views remain unchanged.
+
+## Open Questions
+1. How should secrets be managed for jobs/workflows? (Potential secret manager integration.)
+2. What isolation guarantees are required for service steps (namespaces, per-run containers)?
+3. How granular should step rollback semantics be (compensation vs. idempotent retries)?
+4. Should workflows support long-running services with heartbeats, or remain batch-only for MVP?
+5. How will we version and migrate workflow definitions across environments (dev/stage/prod)?
+
+## Implementation Phases
+1. **Foundations**: schema migrations, job definition API, basic job runner abstraction.
+2. **Workflow MVP**: orchestrator worker, workflow definitions, manual triggers, UI read-only views.
+3. **Service Integration**: call registered services within workflows, add health-aware retries.
+4. **Advanced UX**: DAG visualizations, parameterized launch forms, notification preferences.
+5. **Hardening**: auth, secrets, observability integration, SLA monitoring.
+

--- a/tickets/001-foundations.md
+++ b/tickets/001-foundations.md
@@ -1,0 +1,32 @@
+# Ticket 001: Job Foundations
+
+## Summary
+Deliver the foundational capabilities required to treat ingestion/build operations as first-class "jobs" that run to completion. Establish persistence, APIs, and worker abstractions that every later workflow feature depends on.
+
+## Problem Statement
+AppHub currently operates ingestion and build runners with ad hoc metadata and limited history. We need a generalized job model so that any deterministic run-to-completion task can be registered, executed, and tracked through a consistent lifecycle.
+
+## Scope & Requirements
+- Create migrations that add `job_definitions` and `job_runs` tables with the schema outlined in the Jobs & Workflows specification.
+- Seed default job definitions for existing ingestion/build behaviors as part of the migration or bootstrap routine.
+- Implement Fastify handlers for `POST /jobs`, `GET /jobs`, `GET /jobs/:slug`, and `POST /jobs/:slug/run` with validation for parameter schemas, timeouts, and retry policies.
+- Introduce a job execution abstraction that wraps the existing ingestion/build workers (`execute(JobRunContext) -> JobResult` contract) and stores run status, timestamps, metrics, and log pointers.
+- Emit job lifecycle events (`job.run.*`) onto the existing WebSocket/event infrastructure.
+
+## Non-Goals
+- Workflow orchestration, DAG resolution, or service steps.
+- UI updates beyond minimal API documentation.
+- Authentication/authorization hardening (handled in a later ticket).
+
+## Acceptance Criteria
+- Database migrations are reversible and include indexes for job lookup by slug and status.
+- API requests using representative payloads succeed/fail according to validation rules, with run records persisted for manual launches.
+- Existing ingestion/build paths continue to operate via the new abstraction without regressions (smoke test via manual run).
+- Events for job start/success/failure appear on the event stream with payloads matching the spec.
+
+## Dependencies
+- None (entry point for the epic).
+
+## Testing Notes
+- Add integration tests that call the new endpoints and assert run records are created.
+- Exercise an ingestion job via the new API in a development environment.

--- a/tickets/002-workflow-mvp.md
+++ b/tickets/002-workflow-mvp.md
@@ -1,0 +1,32 @@
+# Ticket 002: Workflow MVP Orchestrator
+
+## Summary
+Implement the first version of workflow orchestration so operators can register workflows, trigger them manually, and observe step-by-step progress across jobs and services.
+
+## Problem Statement
+With foundational job primitives in place, AppHub lacks a way to compose jobs into higher-order workflows. We must provide definition storage, orchestration logic, and read APIs to make multi-step pipelines possible.
+
+## Scope & Requirements
+- Add migrations for `workflow_definitions`, `workflow_runs`, and `workflow_run_steps` with fields described in the specification (steps, triggers, current status, payloads).
+- Build Fastify handlers for `POST /workflows`, `GET /workflows`, `GET /workflows/:slug`, `POST /workflows/:slug/run`, and read endpoints for run histories and step details.
+- Introduce a workflow orchestrator worker (BullMQ queue) that resolves step dependencies, enqueues job runs, tracks completion, and records outputs in shared context storage.
+- Emit workflow lifecycle events (`workflow.run.*`) including aggregated status, current step, and metrics.
+- Provide minimal operator UX in the frontend to list workflows and view run history (read-only) leveraging the new APIs/events.
+
+## Non-Goals
+- Service invocation helpers beyond simple HTTP triggers.
+- Scheduling/trigger automation (cron, repo events) beyond manual launches.
+- Advanced visualization or parameterized forms.
+
+## Acceptance Criteria
+- Workflows with linear steps can be created, manually triggered, and complete successfully when dependent jobs finish.
+- Workflow and step run records persist accurate timing, status, and output metadata.
+- Event stream includes workflow start/success/failure updates consumable by the frontend.
+- Frontend exposes a list/detail view showing workflow definitions and run history without regressions to existing pages.
+
+## Dependencies
+- Ticket 001 (Job Foundations) for job definitions, run API, and execution abstraction.
+
+## Testing Notes
+- Add orchestrator unit/integration tests covering success and failure paths, including retries.
+- Exercise a two-step workflow locally and verify API/event payloads.

--- a/tickets/003-service-integration.md
+++ b/tickets/003-service-integration.md
@@ -1,0 +1,31 @@
+# Ticket 003: Service Step Integration
+
+## Summary
+Extend workflow orchestration with the ability to call registered services as workflow steps, applying health-aware retries and standard invocation patterns.
+
+## Problem Statement
+Workflows must interleave run-to-completion jobs with live services. We need a generalized service step execution layer that consults the service registry, invokes endpoints securely, and cooperates with the orchestrator for retries and failure handling.
+
+## Scope & Requirements
+- Enhance workflow step schema and orchestrator logic to support `service` step types referencing registered services.
+- Implement service invocation helpers (HTTP/gRPC based on service metadata) that respect timeout/retry configuration and record responses into workflow context storage.
+- Integrate service health checks so the orchestrator can skip or delay steps when dependent services are unhealthy.
+- Provide configuration for authentication secrets/tokens required to call services, leveraging existing secret storage placeholders.
+- Update event payloads and run records to capture service invocation metadata (latency, status code, error details).
+
+## Non-Goals
+- UI visualization upgrades beyond displaying service step status in existing views.
+- Full secret manager integration (stub interfaces acceptable but must not leak credentials).
+
+## Acceptance Criteria
+- A workflow combining job and service steps executes successfully, retrying service calls per policy and halting when thresholds are exceeded.
+- Service invocation logs, metrics, and responses are persisted and visible via API endpoints.
+- Health-aware scheduling prevents immediate invocation when services are marked degraded in the registry.
+- Security review confirms sensitive tokens are not stored in plaintext logs.
+
+## Dependencies
+- Ticket 002 (Workflow MVP Orchestrator) for baseline workflow execution.
+
+## Testing Notes
+- Add integration tests simulating success/failure responses from services, asserting retries and context propagation.
+- Verify workflow events show service step metadata without exposing secrets.

--- a/tickets/004-advanced-ux.md
+++ b/tickets/004-advanced-ux.md
@@ -1,0 +1,31 @@
+# Ticket 004: Advanced Workflow & Job UX
+
+## Summary
+Deliver operator-facing UX improvements that make jobs and workflows discoverable, configurable, and understandable, including DAG visualizations and launch forms.
+
+## Problem Statement
+With core orchestration working, operators lack ergonomic tooling to inspect complex workflows, launch jobs with parameters, and monitor progress visually. Rich UX is required to unlock day-to-day adoption.
+
+## Scope & Requirements
+- Implement frontend pages/components for job catalog browsing, manual run initiation with JSON schema–driven forms, and run detail views.
+- Build workflow visualization (DAG graph) showing dependencies, current statuses, and timing data leveraging the event stream.
+- Add filtering/search UI for jobs and workflows by status, repo, service, and tags.
+- Expose log links and aggregated metrics in the UI for both job runs and workflow steps.
+- Update documentation to guide operators through the new UI surfaces.
+
+## Non-Goals
+- Backend API or orchestrator changes beyond what is necessary to support the UI (e.g., new endpoints should already exist from prior tickets).
+- Alerting/notification configuration (handled later).
+
+## Acceptance Criteria
+- UI allows an operator to discover a workflow, inspect its DAG, and follow a running execution with live updates.
+- Manual launch forms validate parameters client-side and submit to the existing APIs.
+- Filtering/search respond in under 250ms against representative datasets.
+- Documentation includes screenshots or walkthroughs of the new UX.
+
+## Dependencies
+- Tickets 001–003 to supply APIs/events and workflow context data.
+
+## Testing Notes
+- Add frontend integration tests (React Testing Library/Cypress) covering manual launch flows and DAG rendering.
+- Run accessibility checks on new UI components.

--- a/tickets/005-hardening.md
+++ b/tickets/005-hardening.md
@@ -1,0 +1,31 @@
+# Ticket 005: Security, Observability & Rollout Hardening
+
+## Summary
+Finalize the jobs and workflows platform with enterprise-grade security controls, observability integrations, and a staged rollout plan.
+
+## Problem Statement
+After implementing orchestration and UX, the platform still needs rigorous auth, secret handling, alerting, and deployment safeguards before production rollout. This ticket consolidates the hardening tasks required for operational readiness.
+
+## Scope & Requirements
+- Enforce authentication/authorization for job/workflow registration and manual execution endpoints, integrating with existing user/service token mechanisms.
+- Implement secret management hooks for job and service steps (pulling runtime credentials from the chosen secret store) and audit access.
+- Expand observability: structured logs routed to aggregation service, metrics exported for run counts/durations/failure rates, and alerting hooks (webhooks/PagerDuty) when workflows fail repeatedly.
+- Document rollback strategies and migration/versioning flows for workflow definitions across environments (dev/stage/prod).
+- Define and execute a phased rollout plan including canary testing, monitoring dashboards, and SLA commitments.
+
+## Non-Goals
+- Redesigning the orchestrator core logic (only hardening).
+- Introducing new workflow features beyond security/observability.
+
+## Acceptance Criteria
+- AuthZ checks prevent unauthorized job/workflow creation and manual execution attempts, with audit logs capturing who initiated actions.
+- Secrets required by steps are fetched securely at runtime without persisting plaintext in databases or logs.
+- Metrics and alerts integrate with existing monitoring stacks and fire on defined thresholds.
+- Documentation includes rollout checklist, rollback steps, and guidance for migrating workflow definitions between environments.
+
+## Dependencies
+- Tickets 001–004 to provide full functionality and UX for jobs/workflows.
+
+## Testing Notes
+- Add security-focused tests (unit/integration) verifying permission enforcement and secret access patterns.
+- Run load tests or simulations to validate monitoring/alert triggers.


### PR DESCRIPTION
## Summary
- create a `tickets/` directory for jobs/workflows feature planning
- add five implementation tickets aligned to the Jobs & Workflows specification phases

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68cf53c10b6083338e50770781ae3e0f