### PR TITLE
Store OpenAPI schemas for discovered services

### DIFF
--- a/services/catalog/src/server.ts
+++ b/services/catalog/src/server.ts
@@ -688,6 +688,18 @@ function serializeLaunch(launch: LaunchRecord | null) {
   };
 }
 
+function extractOpenApiMetadata(metadata: JsonValue | null): JsonValue | null {
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    return null;
+  }
+  const metadataObject = metadata as Record<string, JsonValue>;
+  const openapi = metadataObject.openapi;
+  if (!openapi || typeof openapi !== 'object' || Array.isArray(openapi)) {
+    return null;
+  }
+  return openapi;
+}
+
 function serializeService(service: ServiceRecord) {
   return {
     id: service.id,
@@ -699,6 +711,7 @@ function serializeService(service: ServiceRecord) {
     statusMessage: service.statusMessage,
     capabilities: service.capabilities,
     metadata: service.metadata,
+    openapi: extractOpenApiMetadata(service.metadata),
     lastHealthyAt: service.lastHealthyAt,
     createdAt: service.createdAt,
     updatedAt: service.updatedAt


### PR DESCRIPTION
## Summary
- parse OpenAPI specifications when refreshing service health metadata and capture JSON-compatible schemas
- persist the parsed OpenAPI payload and expose it from the service discovery API responses

## Testing
- npm run build (services/catalog)


------
https://chatgpt.com/codex/tasks/task_e_68cfa168d5fc8333a808f20ee7543dc7