### PR TITLE
Add catalog list view toggle

### DIFF
--- a/apps/frontend/src/catalog/CatalogPage.tsx
+++ b/apps/frontend/src/catalog/CatalogPage.tsx
@@ -1,8 +1,9 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useCatalog } from './useCatalog';
 import SearchSection from './components/SearchSection';
 import FilterPanel from './components/FilterPanel';
 import AppGrid from './components/AppGrid';
+import AppList from './components/AppList';
 
 type CatalogPageProps = {
   searchSeed?: string;
@@ -10,6 +11,7 @@ type CatalogPageProps = {
 };
 
 function CatalogPage({ searchSeed, onSeedApplied }: CatalogPageProps) {
+  const [viewMode, setViewMode] = useState<'preview' | 'list'>('preview');
   const {
     inputValue,
     setInputValue,
@@ -93,30 +95,73 @@ function CatalogPage({ searchSeed, onSeedApplied }: CatalogPageProps) {
             onApplyFacet={handlers.applyTagFacet}
           />
         )}
-        <div className="rounded-3xl border border-slate-200/70 bg-white/80 p-6 shadow-[0_30px_70px_-45px_rgba(15,23,42,0.65)] backdrop-blur-md transition-colors dark:border-slate-700/70 dark:bg-slate-900/70">
-          <AppGrid
+        <div className="flex justify-end">
+          <div className="inline-flex rounded-full border border-slate-200/70 bg-white/70 p-1 text-xs font-semibold text-slate-500 shadow-sm dark:border-slate-700/60 dark:bg-slate-800/60 dark:text-slate-300">
+            <button
+              type="button"
+              className={`rounded-full px-3 py-1 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 ${
+                viewMode === 'preview'
+                  ? 'bg-blue-600 text-white shadow hover:bg-blue-500 dark:bg-slate-200/30 dark:text-slate-900'
+                  : 'hover:text-blue-600 dark:hover:text-slate-100'
+              }`}
+              onClick={() => setViewMode('preview')}
+            >
+              Preview view
+            </button>
+            <button
+              type="button"
+              className={`rounded-full px-3 py-1 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 ${
+                viewMode === 'list'
+                  ? 'bg-blue-600 text-white shadow hover:bg-blue-500 dark:bg-slate-200/30 dark:text-slate-900'
+                  : 'hover:text-blue-600 dark:hover:text-slate-100'
+              }`}
+              onClick={() => setViewMode('list')}
+            >
+              List view
+            </button>
+          </div>
+        </div>
+        {viewMode === 'preview' ? (
+          <div className="rounded-3xl border border-slate-200/70 bg-white/80 p-6 shadow-[0_30px_70px_-45px_rgba(15,23,42,0.65)] backdrop-blur-md transition-colors dark:border-slate-700/70 dark:bg-slate-900/70">
+            <AppGrid
+              apps={apps}
+              activeTokens={activeTokens}
+              highlightEnabled={highlightEnabled}
+              retryingId={retryingId}
+              onRetry={handlers.retryIngestion}
+              historyState={historyState}
+              onToggleHistory={handlers.toggleHistory}
+              buildState={buildState}
+              onToggleBuilds={handlers.toggleBuilds}
+              onLoadMoreBuilds={handlers.loadMoreBuilds}
+              onToggleLogs={handlers.toggleLogs}
+              onRetryBuild={handlers.retryBuild}
+              onTriggerBuild={handlers.triggerBuild}
+              launchLists={launchLists}
+              onToggleLaunches={handlers.toggleLaunches}
+              onLaunch={handlers.launchApp}
+              onStopLaunch={handlers.stopLaunch}
+              launchingId={launchingId}
+              stoppingLaunchId={stoppingLaunchId}
+              launchErrors={launchErrors}
+            />
+          </div>
+        ) : (
+          <AppList
             apps={apps}
             activeTokens={activeTokens}
             highlightEnabled={highlightEnabled}
             retryingId={retryingId}
             onRetry={handlers.retryIngestion}
-            historyState={historyState}
-            onToggleHistory={handlers.toggleHistory}
             buildState={buildState}
-            onToggleBuilds={handlers.toggleBuilds}
-            onLoadMoreBuilds={handlers.loadMoreBuilds}
-            onToggleLogs={handlers.toggleLogs}
-            onRetryBuild={handlers.retryBuild}
             onTriggerBuild={handlers.triggerBuild}
-            launchLists={launchLists}
-            onToggleLaunches={handlers.toggleLaunches}
             onLaunch={handlers.launchApp}
             onStopLaunch={handlers.stopLaunch}
             launchingId={launchingId}
             stoppingLaunchId={stoppingLaunchId}
             launchErrors={launchErrors}
           />
-        </div>
+        )}
       </section>
     </>
   );

--- a/apps/frontend/src/catalog/components/AppCard.tsx
+++ b/apps/frontend/src/catalog/components/AppCard.tsx
@@ -1,6 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type FormEvent, type ReactElement } from 'react';
-import { createPortal } from 'react-dom';
-import Navbar from '../../components/Navbar';
+import { useEffect, useMemo, useRef, useState, type FormEvent } from 'react';
 import { buildDockerRunCommandString, createLaunchId } from '../launchCommand';
 import { API_BASE_URL } from '../constants';
 import { normalizePreviewUrl } from '../../utils/url';
@@ -11,6 +9,7 @@ import {
   formatScore,
   highlightSegments
 } from '../utils';
+import { FullscreenIcon, FullscreenOverlay, type FullscreenPreviewState } from './FullscreenPreview';
 import type {
   AppRecord,
   BuildTimelineState,
@@ -306,12 +305,6 @@ function PreviewMedia({ tile }: { tile: AppRecord['previewTiles'][number] }) {
   return null;
 }
 
-type PreviewTile = NonNullable<AppRecord['previewTiles']>[number];
-
-type FullscreenPreviewState =
-  | { type: 'live'; url: string; title: string }
-  | { type: 'tile'; tile: PreviewTile; title: string };
-
 function ChannelPreview({
   tiles,
   appName,
@@ -564,134 +557,6 @@ function ChannelPreview({
         <FullscreenOverlay preview={fullscreenPreview} onClose={() => setFullscreenPreview(null)} />
       )}
     </>
-  );
-}
-
-function FullscreenOverlay({
-  preview,
-  onClose
-}: {
-  preview: FullscreenPreviewState;
-  onClose: () => void;
-}) {
-  const containerRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    if (typeof window === 'undefined' || typeof document === 'undefined') {
-      return undefined;
-    }
-    const handleKeydown = (event: KeyboardEvent) => {
-      if (
-        event.key === 'Escape' ||
-        event.key === 'Esc' ||
-        event.code === 'Escape' ||
-        event.keyCode === 27
-      ) {
-        onClose();
-      }
-    };
-    window.addEventListener('keydown', handleKeydown, true);
-    document.addEventListener('keydown', handleKeydown, true);
-    const previousOverflow = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
-    containerRef.current?.focus({ preventScroll: true });
-    return () => {
-      window.removeEventListener('keydown', handleKeydown, true);
-      document.removeEventListener('keydown', handleKeydown, true);
-      document.body.style.overflow = previousOverflow;
-    };
-  }, [onClose]);
-
-  if (typeof document === 'undefined') {
-    return null;
-  }
-
-  let content: ReactElement | null = null;
-
-  if (preview.type === 'live') {
-    content = (
-      <iframe
-        key={preview.url}
-        src={preview.url}
-        title={preview.title}
-        className="h-full w-full border-0 bg-white"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; fullscreen; geolocation; gyroscope; picture-in-picture"
-        allowFullScreen
-      />
-    );
-  } else {
-    const tile = preview.tile;
-    if (tile.kind === 'embed' || tile.kind === 'storybook') {
-      if (!tile.embedUrl) {
-        content = null;
-      } else {
-        content = (
-          <iframe
-            key={tile.embedUrl}
-            src={tile.embedUrl}
-            title={tile.title ?? preview.title}
-            className="h-full w-full border-0 bg-white"
-            loading="lazy"
-            allow="autoplay; fullscreen"
-            sandbox="allow-scripts allow-same-origin allow-popups"
-            allowFullScreen
-          />
-        );
-      }
-    } else {
-      content = tile.src ? (
-        <img
-          key={tile.src}
-          src={tile.src}
-          alt={tile.title ?? preview.title}
-          className="h-full w-full object-contain"
-        />
-      ) : null;
-    }
-  }
-
-  return createPortal(
-    <div
-      ref={containerRef}
-      tabIndex={-1}
-      className="fixed inset-0 z-50 flex flex-col bg-slate-950/95 backdrop-blur-sm"
-      role="dialog"
-      aria-modal="true"
-      onClick={onClose}
-    >
-      <div className="flex h-full w-full flex-col gap-6 px-6 pb-6 pt-6" onClick={(event) => event.stopPropagation()}>
-        <Navbar variant="overlay" onExitFullscreen={onClose} />
-        <div className="relative flex-1 overflow-hidden rounded-3xl border border-slate-800/60 bg-slate-950/60 shadow-[inset_0_0_40px_rgba(15,23,42,0.85)]">
-          {content ?? (
-            <div className="flex h-full w-full items-center justify-center px-6 text-center text-sm text-slate-300">
-              Preview unavailable. Try opening the app preview in a new tab from the card instead.
-            </div>
-          )}
-        </div>
-      </div>
-    </div>,
-    document.body
-  );
-}
-
-function FullscreenIcon() {
-  return (
-    <svg
-      aria-hidden="true"
-      focusable="false"
-      className="h-3.5 w-3.5"
-      viewBox="0 0 20 20"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M6.5 3H3v3.5M13.5 3H17v3.5M3 13.5V17h3.5M17 13.5V17h-3.5"
-        stroke="currentColor"
-        strokeWidth="1.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
   );
 }
 

--- a/apps/frontend/src/catalog/components/AppList.tsx
+++ b/apps/frontend/src/catalog/components/AppList.tsx
@@ -1,0 +1,328 @@
+import { useState } from 'react';
+import {
+  buildDockerRunCommandString,
+  createLaunchId
+} from '../launchCommand';
+import { normalizePreviewUrl } from '../../utils/url';
+import {
+  formatDuration,
+  highlightSegments
+} from '../utils';
+import type {
+  AppRecord,
+  BuildTimelineState,
+  LaunchRequestDraft,
+  LaunchEnvVar
+} from '../types';
+import {
+  FullscreenIcon,
+  FullscreenOverlay,
+  type FullscreenPreviewState
+} from './FullscreenPreview';
+
+type AppListProps = {
+  apps: AppRecord[];
+  activeTokens: string[];
+  highlightEnabled: boolean;
+  retryingId: string | null;
+  onRetry: (id: string) => void;
+  buildState: Record<string, BuildTimelineState>;
+  onTriggerBuild: (appId: string, options: { branch?: string; ref?: string }) => Promise<boolean>;
+  onLaunch: (id: string, draft: LaunchRequestDraft) => void;
+  onStopLaunch: (appId: string, launchId: string) => void;
+  launchingId: string | null;
+  stoppingLaunchId: string | null;
+  launchErrors: Record<string, string | null>;
+};
+
+const STATUS_BADGE_BASE =
+  'inline-flex items-center gap-2 rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.25em]';
+
+const STATUS_BADGE_VARIANTS: Record<string, string> = {
+  seed: 'border-slate-300/70 bg-slate-100/70 text-slate-600 dark:border-slate-600 dark:bg-slate-700/50 dark:text-slate-200',
+  pending: 'border-amber-300/70 bg-amber-50/80 text-amber-700 dark:border-amber-400/60 dark:bg-amber-500/20 dark:text-amber-200',
+  processing: 'border-sky-300/70 bg-sky-50/80 text-sky-700 dark:border-sky-400/60 dark:bg-sky-500/20 dark:text-sky-200',
+  running: 'border-sky-300/70 bg-sky-50/80 text-sky-700 dark:border-sky-400/60 dark:bg-sky-500/20 dark:text-sky-200',
+  succeeded:
+    'border-emerald-400/70 bg-emerald-500/15 text-emerald-700 dark:border-emerald-400/60 dark:bg-emerald-500/20 dark:text-emerald-200',
+  ready:
+    'border-emerald-400/70 bg-emerald-500/15 text-emerald-700 dark:border-emerald-400/60 dark:bg-emerald-500/20 dark:text-emerald-200',
+  failed:
+    'border-rose-400/70 bg-rose-500/15 text-rose-700 dark:border-rose-400/60 dark:bg-rose-500/20 dark:text-rose-200',
+  starting: 'border-sky-300/70 bg-sky-50/80 text-sky-700 dark:border-sky-400/60 dark:bg-sky-500/20 dark:text-sky-200',
+  stopping: 'border-amber-400/70 bg-amber-500/15 text-amber-700 dark:border-amber-400/60 dark:bg-amber-500/20 dark:text-amber-200',
+  stopped: 'border-slate-400/70 bg-slate-200/70 text-slate-700 dark:border-slate-500/60 dark:bg-slate-700/40 dark:text-slate-100'
+};
+
+const PRIMARY_ACTION_BUTTON =
+  'inline-flex items-center justify-center rounded-full px-3 py-1.5 text-xs font-semibold text-white shadow-lg shadow-blue-500/30 transition-all focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-60 bg-blue-600 hover:bg-blue-500 dark:bg-slate-200/20 dark:text-slate-50 dark:hover:bg-slate-200/30';
+
+const SECONDARY_ACTION_BUTTON =
+  'inline-flex items-center justify-center rounded-full border border-slate-200/70 bg-white/80 px-3 py-1.5 text-xs font-semibold text-slate-600 transition-all hover:border-blue-300 hover:bg-blue-500/10 hover:text-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-60 dark:border-slate-700/60 dark:bg-slate-800/60 dark:text-slate-200 dark:hover:bg-slate-200/10 dark:hover:text-slate-100';
+
+const TERTIARY_ACTION_BUTTON =
+  'inline-flex items-center justify-center rounded-full border border-slate-200/70 bg-white/80 px-3 py-1.5 text-xs font-semibold text-slate-600 transition-all hover:border-blue-300 hover:bg-blue-500/10 hover:text-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-60 dark:border-slate-700/60 dark:bg-slate-800/60 dark:text-slate-200 dark:hover:bg-slate-200/10 dark:hover:text-slate-100';
+
+const ACTIVE_LAUNCH_STATUSES = new Set(['pending', 'starting', 'running', 'stopping']);
+
+function getStatusBadgeClasses(status: string) {
+  return `${STATUS_BADGE_BASE} ${STATUS_BADGE_VARIANTS[status] ?? STATUS_BADGE_VARIANTS.seed}`;
+}
+
+function collectLaunchEnv(app: AppRecord): LaunchEnvVar[] {
+  const candidates = [
+    ...(app.availableLaunchEnv ?? []),
+    ...(app.launchEnvTemplates ?? []),
+    ...(app.availableEnv ?? [])
+  ];
+  const seen = new Set<string>();
+  const normalized: LaunchEnvVar[] = [];
+
+  for (const entry of candidates) {
+    if (!entry || typeof entry.key !== 'string') {
+      continue;
+    }
+    const key = entry.key.trim();
+    if (!key || seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    normalized.push({ key, value: typeof entry.value === 'string' ? entry.value : '' });
+  }
+
+  return normalized;
+}
+
+function AppList({
+  apps,
+  activeTokens,
+  highlightEnabled,
+  retryingId,
+  onRetry,
+  buildState,
+  onTriggerBuild,
+  onLaunch,
+  onStopLaunch,
+  launchingId,
+  stoppingLaunchId,
+  launchErrors
+}: AppListProps) {
+  const [fullscreenPreview, setFullscreenPreview] = useState<FullscreenPreviewState | null>(null);
+
+  return (
+    <>
+      <div className="overflow-x-auto rounded-3xl border border-slate-200/70 bg-white/80 shadow-[0_30px_70px_-45px_rgba(15,23,42,0.65)] backdrop-blur-md transition-colors dark:border-slate-700/70 dark:bg-slate-900/70">
+        <table className="min-w-full divide-y divide-slate-200/70 dark:divide-slate-700/60">
+          <thead className="bg-slate-50/70 text-left text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 dark:bg-slate-800/40 dark:text-slate-400">
+            <tr>
+              <th scope="col" className="px-6 py-4">App</th>
+              <th scope="col" className="px-6 py-4">Ingestion</th>
+              <th scope="col" className="px-6 py-4">Latest build</th>
+              <th scope="col" className="px-6 py-4">Latest launch</th>
+              <th scope="col" className="px-6 py-4">Actions</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-200/70 text-sm dark:divide-slate-700/60">
+            {apps.map((app) => {
+              const ingestStatusBadge = (
+                <span className={getStatusBadgeClasses(app.ingestStatus)}>
+                  ingest {app.ingestStatus}
+                </span>
+              );
+              const ingestError = app.ingestError;
+              const build = app.latestBuild;
+              const buildStatusBadge = build ? (
+                <span className={getStatusBadgeClasses(build.status)}>
+                  build {build.status}
+                </span>
+              ) : (
+                <span className="text-xs font-medium text-slate-500 dark:text-slate-400">No builds yet</span>
+              );
+              const buildDuration = build ? formatDuration(build.durationMs) : null;
+              const buildStateEntry = buildState[app.id];
+              const buildCreating = buildStateEntry?.creating ?? false;
+              const launch = app.latestLaunch;
+              const launchStatusBadge = launch ? (
+                <span className={getStatusBadgeClasses(launch.status)}>
+                  launch {launch.status}
+                </span>
+              ) : (
+                <span className="text-xs font-medium text-slate-500 dark:text-slate-400">No launches yet</span>
+              );
+              const launchError = launchErrors[app.id] ?? launch?.errorMessage ?? null;
+              const isLaunching = launchingId === app.id;
+              const canLaunch = app.latestBuild?.status === 'succeeded';
+              const currentLaunchId = launch?.id ?? null;
+              const canStop = Boolean(launch && ACTIVE_LAUNCH_STATUSES.has(launch.status));
+              const isStopping = stoppingLaunchId === currentLaunchId;
+              const livePreviewUrl =
+                launch?.status === 'running' ? normalizePreviewUrl(launch.instanceUrl) : null;
+              const previewTile =
+                app.previewTiles.find((preview) => Boolean(preview.embedUrl || preview.src)) ?? null;
+              const hasPreviewTarget = Boolean(livePreviewUrl || previewTile);
+
+              const handleLaunch = () => {
+                const env = collectLaunchEnv(app);
+                const launchId = createLaunchId();
+                const command = buildDockerRunCommandString({
+                  repositoryId: app.id,
+                  launchId,
+                  imageTag: app.latestBuild?.imageTag ?? null,
+                  env
+                });
+                onLaunch(app.id, { env, command, launchId });
+              };
+
+              const handleStop = () => {
+                if (currentLaunchId) {
+                  onStopLaunch(app.id, currentLaunchId);
+                }
+              };
+
+              const handleBuild = () => {
+                void onTriggerBuild(app.id, {});
+              };
+
+              const handleOpenPreview = () => {
+                if (livePreviewUrl) {
+                  setFullscreenPreview({
+                    type: 'live',
+                    url: livePreviewUrl,
+                    title: `${app.name} live preview`
+                  });
+                  return;
+                }
+                if (previewTile) {
+                  setFullscreenPreview({
+                    type: 'tile',
+                    tile: previewTile,
+                    title: previewTile.title ?? `${app.name} preview`
+                  });
+                }
+              };
+
+              return (
+                <tr key={app.id} className="bg-white/50 transition-colors dark:bg-slate-900/40">
+                  <td className="max-w-xs px-6 py-4 align-top">
+                    <div className="space-y-2">
+                      <div className="text-base font-semibold text-slate-700 dark:text-slate-100">
+                        {highlightSegments(app.name, activeTokens, highlightEnabled)}
+                      </div>
+                      <p className="text-sm text-slate-500 dark:text-slate-400">
+                        {highlightSegments(app.description, activeTokens, highlightEnabled)}
+                      </p>
+                      {ingestError && (
+                        <p className="text-xs font-medium text-rose-600 dark:text-rose-300">{ingestError}</p>
+                      )}
+                      {launchError && (
+                        <p className="text-xs font-medium text-rose-600 dark:text-rose-300">{launchError}</p>
+                      )}
+                    </div>
+                  </td>
+                  <td className="px-6 py-4 align-top">
+                    <div className="flex flex-col gap-2 text-xs text-slate-500 dark:text-slate-400">
+                      {ingestStatusBadge}
+                      <time dateTime={app.updatedAt}>
+                        Updated {new Date(app.updatedAt).toLocaleString()}
+                      </time>
+                      {retryingId === app.id ? (
+                        <span className="text-xs font-medium text-slate-500 dark:text-slate-400">Retrying…</span>
+                      ) : app.ingestStatus === 'failed' ? (
+                        <button
+                          type="button"
+                          className={TERTIARY_ACTION_BUTTON}
+                          onClick={() => onRetry(app.id)}
+                        >
+                          Retry ingestion
+                        </button>
+                      ) : null}
+                    </div>
+                  </td>
+                  <td className="px-6 py-4 align-top">
+                    <div className="flex flex-col gap-2 text-xs text-slate-500 dark:text-slate-400">
+                      {buildStatusBadge}
+                      {build?.gitBranch && <span>branch: {build.gitBranch}</span>}
+                      {build?.gitRef && <span>ref: {build.gitRef}</span>}
+                      {build?.commitSha && <span>commit: {build.commitSha.slice(0, 10)}</span>}
+                      {build?.completedAt && (
+                        <time dateTime={build.completedAt}>
+                          {new Date(build.completedAt).toLocaleString()}
+                        </time>
+                      )}
+                      {buildDuration && <span>duration: {buildDuration}</span>}
+                    </div>
+                  </td>
+                  <td className="px-6 py-4 align-top">
+                    <div className="flex flex-col gap-2 text-xs text-slate-500 dark:text-slate-400">
+                      {launchStatusBadge}
+                      {launch?.instanceUrl && (
+                        <a
+                          className="text-blue-600 underline-offset-4 hover:underline dark:text-slate-200"
+                          href={normalizePreviewUrl(launch.instanceUrl) ?? '#'}
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          Open preview
+                        </a>
+                      )}
+                      {launch?.updatedAt && (
+                        <time dateTime={launch.updatedAt}>
+                          Updated {new Date(launch.updatedAt).toLocaleString()}
+                        </time>
+                      )}
+                    </div>
+                  </td>
+                  <td className="px-6 py-4 align-top">
+                    <div className="flex flex-wrap gap-2">
+                      <button
+                        type="button"
+                        className={PRIMARY_ACTION_BUTTON}
+                        onClick={handleLaunch}
+                        disabled={isLaunching || !canLaunch}
+                      >
+                        {isLaunching ? 'Launching…' : 'Launch'}
+                      </button>
+                      <button
+                        type="button"
+                        className={SECONDARY_ACTION_BUTTON}
+                        onClick={handleStop}
+                        disabled={!canStop || isStopping}
+                      >
+                        {isStopping ? 'Stopping…' : 'Stop'}
+                      </button>
+                      <button
+                        type="button"
+                        className={TERTIARY_ACTION_BUTTON}
+                        onClick={handleBuild}
+                        disabled={buildCreating}
+                      >
+                        {buildCreating ? 'Triggering…' : 'Trigger build'}
+                      </button>
+                      <button
+                        type="button"
+                        className={TERTIARY_ACTION_BUTTON}
+                        onClick={handleOpenPreview}
+                        disabled={!hasPreviewTarget}
+                        aria-label={`Open ${app.name} preview in fullscreen`}
+                      >
+                        <span className="mr-2 inline-flex h-5 w-5 items-center justify-center rounded-full bg-slate-200/70 text-slate-600 dark:bg-slate-700/60 dark:text-slate-200">
+                          <FullscreenIcon />
+                        </span>
+                        Fullscreen
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+      {fullscreenPreview && (
+        <FullscreenOverlay preview={fullscreenPreview} onClose={() => setFullscreenPreview(null)} />
+      )}
+    </>
+  );
+}
+
+export default AppList;

--- a/apps/frontend/src/catalog/components/FullscreenPreview.tsx
+++ b/apps/frontend/src/catalog/components/FullscreenPreview.tsx
@@ -1,0 +1,136 @@
+import { createPortal } from 'react-dom';
+import { useEffect, useRef, type ReactElement } from 'react';
+import Navbar from '../../components/Navbar';
+import type { PreviewTile } from '../types';
+
+type LivePreviewState = { type: 'live'; url: string; title: string };
+type TilePreviewState = { type: 'tile'; tile: PreviewTile; title: string };
+
+export type FullscreenPreviewState = LivePreviewState | TilePreviewState;
+
+type FullscreenOverlayProps = {
+  preview: FullscreenPreviewState;
+  onClose: () => void;
+};
+
+export function FullscreenOverlay({ preview, onClose }: FullscreenOverlayProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof document === 'undefined') {
+      return undefined;
+    }
+    const handleKeydown = (event: KeyboardEvent) => {
+      if (
+        event.key === 'Escape' ||
+        event.key === 'Esc' ||
+        event.code === 'Escape' ||
+        event.keyCode === 27
+      ) {
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handleKeydown, true);
+    document.addEventListener('keydown', handleKeydown, true);
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    containerRef.current?.focus({ preventScroll: true });
+    return () => {
+      window.removeEventListener('keydown', handleKeydown, true);
+      document.removeEventListener('keydown', handleKeydown, true);
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [onClose]);
+
+  if (typeof document === 'undefined') {
+    return null;
+  }
+
+  let content: ReactElement | null = null;
+
+  if (preview.type === 'live') {
+    content = (
+      <iframe
+        key={preview.url}
+        src={preview.url}
+        title={preview.title}
+        className="h-full w-full border-0 bg-white"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; fullscreen; geolocation; gyroscope; picture-in-picture"
+        allowFullScreen
+      />
+    );
+  } else {
+    const tile = preview.tile;
+    if (tile.kind === 'embed' || tile.kind === 'storybook') {
+      if (tile.embedUrl) {
+        content = (
+          <iframe
+            key={tile.embedUrl}
+            src={tile.embedUrl}
+            title={tile.title ?? preview.title}
+            className="h-full w-full border-0 bg-white"
+            loading="lazy"
+            allow="autoplay; fullscreen"
+            sandbox="allow-scripts allow-same-origin allow-popups"
+            allowFullScreen
+          />
+        );
+      } else {
+        content = null;
+      }
+    } else {
+      content = tile.src ? (
+        <img
+          key={tile.src}
+          src={tile.src}
+          alt={tile.title ?? preview.title}
+          className="h-full w-full object-contain"
+        />
+      ) : null;
+    }
+  }
+
+  return createPortal(
+    <div
+      ref={containerRef}
+      tabIndex={-1}
+      className="fixed inset-0 z-50 flex flex-col bg-slate-950/95 backdrop-blur-sm"
+      role="dialog"
+      aria-modal="true"
+      onClick={onClose}
+    >
+      <div className="flex h-full w-full flex-col gap-6 px-6 pb-6 pt-6" onClick={(event) => event.stopPropagation()}>
+        <Navbar variant="overlay" onExitFullscreen={onClose} />
+        <div className="relative flex-1 overflow-hidden rounded-3xl border border-slate-800/60 bg-slate-950/60 shadow-[inset_0_0_40px_rgba(15,23,42,0.85)]">
+          {content ?? (
+            <div className="flex h-full w-full items-center justify-center px-6 text-center text-sm text-slate-300">
+              Preview unavailable. Try opening the app preview in a new tab from the card instead.
+            </div>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}
+
+export function FullscreenIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      focusable="false"
+      className="h-3.5 w-3.5"
+      viewBox="0 0 20 20"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M6.5 3H3v3.5M13.5 3H17v3.5M3 13.5V17h3.5M17 13.5V17h-3.5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- add a view selector on the catalog page for switching between the preview grid and a new list layout
- introduce a table-based list view that surfaces ingestion, build, and launch details with quick actions, including fullscreen preview access
- extract the fullscreen preview overlay so it can be reused by both card and list presentations

## Testing
- npm run lint *(fails: existing eslint errors outside the modified catalog files)*

------
https://chatgpt.com/codex/tasks/task_e_68cfb23c859083339bc9aa55fbcc9b5b