### PR TITLE
frontend: streamline catalog list view controls

### DIFF
--- a/apps/frontend/src/catalog/CatalogPage.tsx
+++ b/apps/frontend/src/catalog/CatalogPage.tsx
@@ -65,6 +65,8 @@ function CatalogPage({ searchSeed, onSeedApplied }: CatalogPageProps) {
         onToggleHighlights={handlers.toggleHighlights}
         activeTokens={activeTokens}
         searchMeta={searchMeta}
+        viewMode={viewMode}
+        onViewModeChange={setViewMode}
       />
       <section className="flex flex-col gap-6">
         {loading && (
@@ -95,32 +97,6 @@ function CatalogPage({ searchSeed, onSeedApplied }: CatalogPageProps) {
             onApplyFacet={handlers.applyTagFacet}
           />
         )}
-        <div className="flex justify-end">
-          <div className="inline-flex rounded-full border border-slate-200/70 bg-white/70 p-1 text-xs font-semibold text-slate-500 shadow-sm dark:border-slate-700/60 dark:bg-slate-800/60 dark:text-slate-300">
-            <button
-              type="button"
-              className={`rounded-full px-3 py-1 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 ${
-                viewMode === 'preview'
-                  ? 'bg-blue-600 text-white shadow hover:bg-blue-500 dark:bg-slate-200/30 dark:text-slate-900'
-                  : 'hover:text-blue-600 dark:hover:text-slate-100'
-              }`}
-              onClick={() => setViewMode('preview')}
-            >
-              Preview view
-            </button>
-            <button
-              type="button"
-              className={`rounded-full px-3 py-1 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 ${
-                viewMode === 'list'
-                  ? 'bg-blue-600 text-white shadow hover:bg-blue-500 dark:bg-slate-200/30 dark:text-slate-900'
-                  : 'hover:text-blue-600 dark:hover:text-slate-100'
-              }`}
-              onClick={() => setViewMode('list')}
-            >
-              List view
-            </button>
-          </div>
-        </div>
         {viewMode === 'preview' ? (
           <div className="rounded-3xl border border-slate-200/70 bg-white/80 p-6 shadow-[0_30px_70px_-45px_rgba(15,23,42,0.65)] backdrop-blur-md transition-colors dark:border-slate-700/70 dark:bg-slate-900/70">
             <AppGrid

--- a/apps/frontend/src/catalog/components/AppList.tsx
+++ b/apps/frontend/src/catalog/components/AppList.tsx
@@ -192,9 +192,6 @@ function AppList({
                       <div className="text-base font-semibold text-slate-700 dark:text-slate-100">
                         {highlightSegments(app.name, activeTokens, highlightEnabled)}
                       </div>
-                      <p className="text-sm text-slate-500 dark:text-slate-400">
-                        {highlightSegments(app.description, activeTokens, highlightEnabled)}
-                      </p>
                       {ingestError && (
                         <p className="text-xs font-medium text-rose-600 dark:text-rose-300">{ingestError}</p>
                       )}

--- a/apps/frontend/src/catalog/components/SearchSection.tsx
+++ b/apps/frontend/src/catalog/components/SearchSection.tsx
@@ -21,6 +21,8 @@ type SearchSectionProps = {
   onToggleHighlights: (enabled: boolean) => void;
   activeTokens: string[];
   searchMeta: SearchMeta | null;
+  viewMode: 'preview' | 'list';
+  onViewModeChange: (mode: 'preview' | 'list') => void;
 };
 
 function SearchSection({
@@ -35,23 +37,25 @@ function SearchSection({
   showHighlights,
   onToggleHighlights,
   activeTokens,
-  searchMeta
+  searchMeta,
+  viewMode,
+  onViewModeChange
 }: SearchSectionProps) {
   const highlightToggleDisabled = activeTokens.length === 0;
 
   return (
     <section className="flex flex-col gap-4 rounded-3xl border border-slate-200/70 bg-white/80 p-6 shadow-[0_30px_70px_-45px_rgba(15,23,42,0.7)] backdrop-blur-md transition-colors dark:border-slate-700/70 dark:bg-slate-900/70">
-      <div className="flex flex-col gap-3 md:flex-row md:items-center md:gap-4">
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:gap-6">
         <div className="relative flex-1">
           <input
-          type="text"
-          value={inputValue}
-          onChange={(event) => onInputChange(event.target.value)}
-          onKeyDown={onKeyDown}
-          placeholder="Type tags like framework:nextjs runtime:node18 or free text"
-          spellCheck={false}
-          autoFocus
-          className="w-full rounded-2xl border border-slate-200/70 bg-white/80 px-4 py-3 text-base text-slate-900 shadow-sm outline-none transition-colors focus:border-blue-500 focus:ring-4 focus:ring-blue-200/40 dark:border-slate-700/70 dark:bg-slate-800/80 dark:text-slate-100 dark:focus:border-slate-400 dark:focus:ring-slate-500/30"
+            type="text"
+            value={inputValue}
+            onChange={(event) => onInputChange(event.target.value)}
+            onKeyDown={onKeyDown}
+            placeholder="Type tags like framework:nextjs runtime:node18 or free text"
+            spellCheck={false}
+            autoFocus
+            className="w-full rounded-2xl border border-slate-200/70 bg-white/80 px-4 py-3 text-base text-slate-900 shadow-sm outline-none transition-colors focus:border-blue-500 focus:ring-4 focus:ring-blue-200/40 dark:border-slate-700/70 dark:bg-slate-800/80 dark:text-slate-100 dark:focus:border-slate-400 dark:focus:ring-slate-500/30"
           />
           {suggestions.length > 0 && (
             <ul className="absolute left-0 right-0 top-full z-10 mt-2 max-h-64 overflow-y-auto rounded-2xl border border-slate-200/80 bg-white/95 p-1 shadow-xl ring-1 ring-slate-900/5 dark:border-slate-700/70 dark:bg-slate-900/95">
@@ -75,25 +79,51 @@ function SearchSection({
             </ul>
           )}
         </div>
-        <div className="flex flex-col gap-2 md:w-auto md:flex-none md:items-end">
-          <span className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400 md:hidden">
-            Sort by
-          </span>
-          <div className="inline-flex items-center gap-1 rounded-full border border-slate-200/70 bg-slate-100/70 p-1 dark:border-slate-700/60 dark:bg-slate-800/60">
-            {SORT_OPTIONS.map((option) => (
-              <button
-                key={option.key}
-                type="button"
-                className={`rounded-full px-4 py-1.5 text-sm font-semibold transition-colors transition-shadow focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 ${
-                  sortMode === option.key
-                    ? 'bg-blue-600 text-white shadow-lg shadow-blue-500/30 dark:bg-slate-200/20 dark:text-slate-50 dark:shadow-[0_20px_50px_-28px_rgba(15,23,42,0.85)]'
-                    : 'text-slate-600 hover:bg-blue-600/10 hover:text-blue-700 dark:text-slate-300 dark:hover:bg-slate-200/10 dark:hover:text-slate-100'
-                }`}
-                onClick={() => onSortChange(option.key)}
-              >
-                {option.label}
-              </button>
-            ))}
+        <div className="flex flex-col gap-3 md:w-auto md:flex-none md:items-end">
+          <div className="flex flex-col gap-2 md:items-end">
+            <span className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400 md:hidden">
+              Sort by
+            </span>
+            <div className="inline-flex items-center gap-1 rounded-full border border-slate-200/70 bg-slate-100/70 p-1 dark:border-slate-700/60 dark:bg-slate-800/60">
+              {SORT_OPTIONS.map((option) => (
+                <button
+                  key={option.key}
+                  type="button"
+                  className={`rounded-full px-4 py-1.5 text-sm font-semibold transition-colors transition-shadow focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 ${
+                    sortMode === option.key
+                      ? 'bg-blue-600 text-white shadow-lg shadow-blue-500/30 dark:bg-slate-200/20 dark:text-slate-50 dark:shadow-[0_20px_50px_-28px_rgba(15,23,42,0.85)]'
+                      : 'text-slate-600 hover:bg-blue-600/10 hover:text-blue-700 dark:text-slate-300 dark:hover:bg-slate-200/10 dark:hover:text-slate-100'
+                  }`}
+                  onClick={() => onSortChange(option.key)}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="inline-flex rounded-full border border-slate-200/70 bg-white/70 p-1 text-xs font-semibold text-slate-500 shadow-sm dark:border-slate-700/60 dark:bg-slate-800/60 dark:text-slate-300">
+            <button
+              type="button"
+              className={`rounded-full px-3 py-1 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 ${
+                viewMode === 'preview'
+                  ? 'bg-blue-600 text-white shadow hover:bg-blue-500 dark:bg-slate-200/30 dark:text-slate-900'
+                  : 'hover:text-blue-600 dark:hover:text-slate-100'
+              }`}
+              onClick={() => onViewModeChange('preview')}
+            >
+              Preview view
+            </button>
+            <button
+              type="button"
+              className={`rounded-full px-3 py-1 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 ${
+                viewMode === 'list'
+                  ? 'bg-blue-600 text-white shadow hover:bg-blue-500 dark:bg-slate-200/30 dark:text-slate-900'
+                  : 'hover:text-blue-600 dark:hover:text-slate-100'
+              }`}
+              onClick={() => onViewModeChange('list')}
+            >
+              List view
+            </button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- move the catalog view mode toggle alongside the search controls
- remove app descriptions from the catalog list view rows

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cfd8d518b08333bd3f16398528de18