### PR TITLE
Remember selected tab across reloads

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import CatalogPage from './catalog/CatalogPage';
 import { ApiTokenProvider } from './auth/ApiTokenContext';
 import Navbar from './components/Navbar';
@@ -9,9 +9,42 @@ import ServiceGallery from './services/ServiceGallery';
 import WorkflowsPage from './workflows/WorkflowsPage';
 import ApiAccessPage from './settings/ApiAccessPage';
 
+const ACTIVE_TAB_STORAGE_KEY = 'apphub-active-tab';
+
+function isActiveTab(value: unknown): value is ActiveTab {
+  return (
+    value === 'catalog' ||
+    value === 'apps' ||
+    value === 'workflows' ||
+    value === 'submit' ||
+    value === 'import-manifest' ||
+    value === 'api-access'
+  );
+}
+
 function App() {
-  const [activeTab, setActiveTab] = useState<ActiveTab>('catalog');
+  const [activeTab, setActiveTab] = useState<ActiveTab>(() => {
+    if (typeof window === 'undefined') {
+      return 'catalog';
+    }
+
+    const storedValue = window.localStorage.getItem(ACTIVE_TAB_STORAGE_KEY);
+
+    if (isActiveTab(storedValue)) {
+      return storedValue;
+    }
+
+    return 'catalog';
+  });
   const [searchSeed, setSearchSeed] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    window.localStorage.setItem(ACTIVE_TAB_STORAGE_KEY, activeTab);
+  }, [activeTab]);
 
   const handleAppRegistered = (id: string) => {
     setSearchSeed(id);


### PR DESCRIPTION
## Summary
- persist the active navigation tab in localStorage so it survives page reloads
- hydrate the tab state from storage on load while validating the stored value

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cfe4a931dc8333a1a157931bb230d7