### PR TITLE
Add workflow update endpoint

### DIFF
--- a/services/catalog/src/db/types.ts
+++ b/services/catalog/src/db/types.ts
@@ -541,6 +541,17 @@ export type WorkflowDefinitionCreateInput = {
   metadata?: JsonValue | null;
 };
 
+export type WorkflowDefinitionUpdateInput = {
+  name?: string;
+  version?: number;
+  description?: string | null;
+  steps?: WorkflowStepDefinition[];
+  triggers?: WorkflowTriggerDefinition[];
+  parametersSchema?: JsonValue;
+  defaultParameters?: JsonValue;
+  metadata?: JsonValue | null;
+};
+
 export type WorkflowRunStatus = 'pending' | 'running' | 'succeeded' | 'failed' | 'canceled';
 
 export type WorkflowRunRecord = {


### PR DESCRIPTION
## Summary
- add a database update routine and input type for workflow definitions
- share step/trigger normalization helpers and expose a PATCH /workflows/:slug endpoint
- extend the workflow end-to-end test to cover unauthorized and successful update flows

## Testing
- npm run lint
- npm run test:e2e *(fails: embedded Postgres refuses to run as root)*

------
https://chatgpt.com/codex/tasks/task_e_68d00705790883339d0f8e5be2d207ce