### PR TITLE
Add job detail view in workflow DAG

### DIFF
--- a/apps/frontend/src/workflows/__tests__/WorkflowsPage.test.tsx
+++ b/apps/frontend/src/workflows/__tests__/WorkflowsPage.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import WorkflowsPage from '../WorkflowsPage';
 import { ApiTokenProvider } from '../../auth/ApiTokenContext';
+import { ToastProvider } from '../../components/toast';
 import type { WorkflowDefinition, WorkflowRun, WorkflowRunStep } from '../types';
 
 type FetchArgs = Parameters<typeof fetch>;
@@ -197,9 +198,11 @@ describe('WorkflowsPage manual run flow', () => {
     vi.spyOn(globalThis, 'fetch').mockImplementation(fetchMock as unknown as typeof fetch);
 
     render(
-      <ApiTokenProvider>
-        <WorkflowsPage />
-      </ApiTokenProvider>
+      <ToastProvider>
+        <ApiTokenProvider>
+          <WorkflowsPage />
+        </ApiTokenProvider>
+      </ToastProvider>
     );
 
     await waitFor(() => {
@@ -259,9 +262,11 @@ describe('WorkflowsPage manual run flow', () => {
     vi.spyOn(globalThis, 'fetch').mockImplementation(fetchMock as unknown as typeof fetch);
 
     render(
-      <ApiTokenProvider>
-        <WorkflowsPage />
-      </ApiTokenProvider>
+      <ToastProvider>
+        <ApiTokenProvider>
+          <WorkflowsPage />
+        </ApiTokenProvider>
+      </ToastProvider>
     );
 
     await waitFor(() => {


### PR DESCRIPTION
## Summary
- add selectable workflow DAG nodes that populate a detailed step panel with timing, run metadata, and structured input/output payloads
- highlight the chosen step in the graph and keep details accessible via keyboard interaction
- update workflow graph and page tests to cover the new detail view and wrap page tests in the toast provider

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d0d99337e083338a4e49c7b49d1eeb