### PR TITLE
Add JSON syntax highlighting to structured previews

### DIFF
--- a/apps/frontend/src/components/JsonSyntaxHighlighter.tsx
+++ b/apps/frontend/src/components/JsonSyntaxHighlighter.tsx
@@ -1,0 +1,103 @@
+import { useMemo } from 'react';
+import type { ReactNode } from 'react';
+
+type JsonSyntaxHighlighterProps = {
+  value: unknown;
+  className?: string;
+  ariaLabel?: string;
+};
+
+type PreparedValue = {
+  text: string;
+  isJson: boolean;
+};
+
+const JSON_TOKEN_REGEX =
+  /("(?:\\u[\da-fA-F]{4}|\\[^u]|[^\\"])*"(?:\s*:)?|\b(?:true|false|null)\b|-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)/g;
+
+function prepareValue(value: unknown): PreparedValue {
+  if (value === null || value === undefined) {
+    return { text: '', isJson: false };
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return { text: value, isJson: false };
+    }
+    try {
+      const parsed = JSON.parse(trimmed) as unknown;
+      const pretty = JSON.stringify(parsed, null, 2);
+      return { text: pretty, isJson: true };
+    } catch {
+      return { text: value, isJson: false };
+    }
+  }
+
+  try {
+    const pretty = JSON.stringify(value, null, 2);
+    return { text: pretty, isJson: true };
+  } catch {
+    return { text: String(value), isJson: false };
+  }
+}
+
+function highlightJson(text: string): ReactNode[] {
+  const nodes: ReactNode[] = [];
+  let lastIndex = 0;
+  let key = 0;
+
+  for (const match of text.matchAll(JSON_TOKEN_REGEX)) {
+    const token = match[0];
+    const index = match.index ?? 0;
+
+    if (index > lastIndex) {
+      nodes.push(text.slice(lastIndex, index));
+    }
+
+    let tokenClass = '';
+    if (token.startsWith('"')) {
+      tokenClass = token.endsWith(':') ? 'text-sky-300' : 'text-emerald-300';
+    } else if (token === 'true' || token === 'false') {
+      tokenClass = 'text-violet-300';
+    } else if (token === 'null') {
+      tokenClass = 'text-rose-300';
+    } else {
+      tokenClass = 'text-amber-200';
+    }
+
+    nodes.push(
+      <span key={`json-token-${key++}`} className={tokenClass}>
+        {token}
+      </span>
+    );
+
+    lastIndex = index + token.length;
+  }
+
+  if (lastIndex < text.length) {
+    nodes.push(text.slice(lastIndex));
+  }
+
+  return nodes;
+}
+
+export default function JsonSyntaxHighlighter({
+  value,
+  className,
+  ariaLabel
+}: JsonSyntaxHighlighterProps) {
+  const prepared = useMemo(() => prepareValue(value), [value]);
+  const highlighted = useMemo(
+    () => (prepared.isJson ? highlightJson(prepared.text) : null),
+    [prepared.isJson, prepared.text]
+  );
+
+  return (
+    <pre aria-label={ariaLabel} className={className}>
+      <code className="block font-mono" style={{ whiteSpace: 'inherit' }}>
+        {prepared.isJson ? highlighted : prepared.text}
+      </code>
+    </pre>
+  );
+}

--- a/apps/frontend/src/import/tabs/ImportJobBundleTab.tsx
+++ b/apps/frontend/src/import/tabs/ImportJobBundleTab.tsx
@@ -6,6 +6,7 @@ import {
   FormFeedback,
   FormSection
 } from '../../components/form';
+import JsonSyntaxHighlighter from '../../components/JsonSyntaxHighlighter';
 import { useToasts } from '../../components/toast';
 import { useAnalytics } from '../../utils/useAnalytics';
 import {
@@ -419,9 +420,10 @@ export default function ImportJobBundleTab() {
             {parametersSchema && (
               <div className="rounded-2xl border border-slate-200/70 bg-white/60 p-4 text-sm shadow-sm dark:border-slate-700/60 dark:bg-slate-900/60">
                 <h4 className="text-sm font-semibold text-slate-700 dark:text-slate-200">Parameter schema</h4>
-                <pre className="mt-3 max-h-72 overflow-auto whitespace-pre-wrap text-xs text-slate-600 dark:text-slate-200">
-                  {parametersSchema}
-                </pre>
+                <JsonSyntaxHighlighter
+                  value={parametersSchema}
+                  className="mt-3 max-h-72 overflow-auto whitespace-pre-wrap text-xs text-slate-600 dark:text-slate-200"
+                />
               </div>
             )}
             <DryRunDetails dryRun={previewResult.dryRun} />

--- a/apps/frontend/src/workflows/WorkflowsPage.tsx
+++ b/apps/frontend/src/workflows/WorkflowsPage.tsx
@@ -9,6 +9,7 @@ import { API_BASE_URL } from '../config';
 import { useAuthorizedFetch } from '../auth/useAuthorizedFetch';
 import { useApiTokens } from '../auth/useApiTokens';
 import { useToasts } from '../components/toast';
+import JsonSyntaxHighlighter from '../components/JsonSyntaxHighlighter';
 import ManualRunPanel from './components/ManualRunPanel';
 import StatusBadge from './components/StatusBadge';
 import WorkflowFilters from './components/WorkflowFilters';
@@ -68,18 +69,6 @@ const INITIAL_FILTERS: WorkflowFiltersState = {
   services: [],
   tags: []
 };
-
-function formatJson(value: unknown): string {
-  try {
-    const text = JSON.stringify(value, null, 2);
-    if (typeof text === 'string') {
-      return text;
-    }
-  } catch {
-    // Fall through to string coercion when serialization fails.
-  }
-  return String(value);
-}
 
 function resolveWorkflowWebsocketUrl(): string {
   try {
@@ -1148,9 +1137,10 @@ export default function WorkflowsPage() {
               {selectedRun.output !== null && selectedRun.output !== undefined ? (
                 <div className="mt-4 rounded-2xl border border-slate-200/60 bg-slate-50/80 px-4 py-3 text-xs text-slate-600 shadow-inner dark:border-slate-700/60 dark:bg-slate-800/80 dark:text-slate-300">
                   <p className="font-semibold">Workflow Output</p>
-                  <pre className="mt-2 max-h-64 overflow-auto rounded-xl bg-slate-900/80 px-3 py-2 text-[11px] leading-relaxed text-slate-200">
-                    {formatJson(selectedRun.output)}
-                  </pre>
+                  <JsonSyntaxHighlighter
+                    value={selectedRun.output}
+                    className="mt-2 max-h-64 overflow-auto rounded-xl bg-slate-900/80 px-3 py-2 text-[11px] leading-relaxed text-slate-200"
+                  />
                 </div>
               ) : selectedRun.status === 'succeeded' ? (
                 <p className="mt-4 text-xs text-slate-500 dark:text-slate-400">No output captured for this run.</p>
@@ -1199,9 +1189,10 @@ export default function WorkflowsPage() {
                           </span>
                         </div>
                         {metrics && (
-                          <pre className="mt-2 max-h-40 overflow-auto rounded-xl bg-slate-900/80 px-3 py-2 text-xs text-slate-200">
-                            {JSON.stringify(metrics, null, 2)}
-                          </pre>
+                          <JsonSyntaxHighlighter
+                            value={metrics}
+                            className="mt-2 max-h-40 overflow-auto rounded-xl bg-slate-900/80 px-3 py-2 text-xs text-slate-200"
+                          />
                         )}
                         {step.errorMessage && (
                           <p className="mt-2 text-xs font-semibold text-rose-600 dark:text-rose-300">

--- a/apps/frontend/src/workflows/builder/WorkflowBuilderDialog.tsx
+++ b/apps/frontend/src/workflows/builder/WorkflowBuilderDialog.tsx
@@ -6,6 +6,7 @@ import {
   type FormEvent
 } from 'react';
 import { FormSection, FormField, FormActions, FormButton, FormFeedback } from '../../components/form';
+import JsonSyntaxHighlighter from '../../components/JsonSyntaxHighlighter';
 import { useWorkflowResources } from '../WorkflowResourcesContext';
 import type { WorkflowDefinition, WorkflowDraft, WorkflowDraftStep } from '../types';
 import type { WorkflowCreateInput, WorkflowUpdateInput } from '../api';
@@ -141,7 +142,6 @@ export function WorkflowBuilderDialog({
   );
 
   const previewSpec = useMemo(() => draftToCreateInput(draft), [draft]);
-  const previewJson = useMemo(() => JSON.stringify(previewSpec, null, 2), [previewSpec]);
 
   const handleTagsChange = (value: string) => {
     const tags = value
@@ -531,12 +531,10 @@ export function WorkflowBuilderDialog({
                 </ul>
               </FormFeedback>
             )}
-            <textarea
-              value={previewJson}
-              readOnly
-              rows={20}
-              className="w-full rounded-2xl border border-slate-200/70 bg-slate-950/90 px-3 py-2 text-xs font-mono text-emerald-100 focus:outline-none dark:border-slate-700/60"
-              spellCheck={false}
+            <JsonSyntaxHighlighter
+              value={previewSpec}
+              ariaLabel="Workflow preview JSON"
+              className="w-full min-h-[320px] overflow-auto rounded-2xl border border-slate-200/70 bg-slate-950/90 px-3 py-2 text-xs font-mono text-emerald-100 focus:outline-none dark:border-slate-700/60"
             />
           </FormSection>
 

--- a/apps/frontend/src/workflows/components/StatusBadge.tsx
+++ b/apps/frontend/src/workflows/components/StatusBadge.tsx
@@ -1,22 +1,6 @@
-export function getStatusBadgeClasses(status: string): string {
-  switch (status) {
-    case 'succeeded':
-      return 'bg-emerald-500/10 text-emerald-600 border-emerald-500/40 dark:border-emerald-400/40 dark:text-emerald-300';
-    case 'running':
-      return 'bg-sky-500/10 text-sky-600 border-sky-500/40 dark:border-sky-400/40 dark:text-sky-300';
-    case 'failed':
-      return 'bg-rose-500/10 text-rose-600 border-rose-500/40 dark:border-rose-400/40 dark:text-rose-300';
-    case 'canceled':
-    case 'skipped':
-      return 'bg-amber-500/10 text-amber-600 border-amber-500/40 dark:border-amber-400/40 dark:text-amber-300';
-    case 'pending':
-      return 'bg-slate-400/10 text-slate-600 border-slate-400/40 dark:border-slate-400/40 dark:text-slate-300';
-    default:
-      return 'bg-slate-500/10 text-slate-600 border-slate-500/40 dark:border-slate-400/40 dark:text-slate-300';
-  }
-}
+import { getStatusBadgeClasses } from './statusBadgeClasses';
 
-export function StatusBadge({ status }: { status: string }) {
+function StatusBadge({ status }: { status: string }) {
   return (
     <span
       className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold capitalize ${getStatusBadgeClasses(status)}`}

--- a/apps/frontend/src/workflows/components/statusBadgeClasses.ts
+++ b/apps/frontend/src/workflows/components/statusBadgeClasses.ts
@@ -1,0 +1,17 @@
+export function getStatusBadgeClasses(status: string): string {
+  switch (status) {
+    case 'succeeded':
+      return 'bg-emerald-500/10 text-emerald-600 border-emerald-500/40 dark:border-emerald-400/40 dark:text-emerald-300';
+    case 'running':
+      return 'bg-sky-500/10 text-sky-600 border-sky-500/40 dark:border-sky-400/40 dark:text-sky-300';
+    case 'failed':
+      return 'bg-rose-500/10 text-rose-600 border-rose-500/40 dark:border-rose-400/40 dark:text-rose-300';
+    case 'canceled':
+    case 'skipped':
+      return 'bg-amber-500/10 text-amber-600 border-amber-500/40 dark:border-amber-400/40 dark:text-amber-300';
+    case 'pending':
+      return 'bg-slate-400/10 text-slate-600 border-slate-400/40 dark:border-slate-400/40 dark:text-slate-300';
+    default:
+      return 'bg-slate-500/10 text-slate-600 border-slate-500/40 dark:border-slate-400/40 dark:text-slate-300';
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable `JsonSyntaxHighlighter` component to render prettified JSON with inline token colors
- apply syntax highlighting across workflow detail panels and job bundle previews when showing structured payloads
- relocate workflow status badge styling helpers into a utility module to keep component files lint-compliant

## Testing
- npm run lint --prefix apps/frontend

------
https://chatgpt.com/codex/tasks/task_e_68d0ebf0ccbc8333a9b8d0b0f5401e40