### PR TITLE
Add workflow analytics dashboards

### DIFF
--- a/apps/frontend/src/workflows/components/RunOutcomeChart.tsx
+++ b/apps/frontend/src/workflows/components/RunOutcomeChart.tsx
@@ -1,0 +1,113 @@
+import type { WorkflowRunStatsSummary } from '../types';
+
+type RunOutcomeChartProps = {
+  stats: WorkflowRunStatsSummary | null;
+  selectedOutcomes: string[];
+  onChange: (next: string[]) => void;
+};
+
+function formatDuration(ms: number | null): string {
+  if (ms === null || !Number.isFinite(ms)) {
+    return '—';
+  }
+  if (ms < 1000) {
+    return `${Math.round(ms)} ms`;
+  }
+  const seconds = ms / 1000;
+  if (seconds < 60) {
+    return `${seconds.toFixed(1)} s`;
+  }
+  const minutes = seconds / 60;
+  if (minutes < 60) {
+    return `${minutes.toFixed(1)} min`;
+  }
+  const hours = minutes / 60;
+  return `${hours.toFixed(1)} h`;
+}
+
+export default function RunOutcomeChart({ stats, selectedOutcomes, onChange }: RunOutcomeChartProps) {
+  if (!stats) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 rounded-xl border border-dashed border-slate-300 bg-slate-50/60 p-6 text-sm text-slate-500 dark:border-slate-700 dark:bg-slate-900/20 dark:text-slate-400">
+        <span>No analytics available yet.</span>
+        <span>Trigger runs to populate outcome insights.</span>
+      </div>
+    );
+  }
+
+  const statuses = Object.entries(stats.statusCounts)
+    .map(([status, count]) => ({ status, count: Number(count ?? 0) }))
+    .sort((a, b) => b.count - a.count);
+  const maxCount = statuses.reduce((max, entry) => (entry.count > max ? entry.count : max), 0) || 1;
+  const normalizedSelection = selectedOutcomes.length > 0 ? selectedOutcomes.map((status) => status.toLowerCase()) : [];
+  const selectedSet = new Set(normalizedSelection);
+
+  const toggleOutcome = (status: string) => {
+    const normalized = status.toLowerCase();
+    const next = new Set(selectedSet);
+    if (next.has(normalized)) {
+      next.delete(normalized);
+    } else {
+      next.add(normalized);
+    }
+    onChange(Array.from(next));
+  };
+
+  const renderedStatuses = statuses.map(({ status, count }) => {
+    const normalized = status.toLowerCase();
+    const isSelected = selectedSet.size === 0 || selectedSet.has(normalized);
+    const width = Math.max(4, Math.round((count / maxCount) * 100));
+    return (
+      <label
+        key={status}
+        className="flex cursor-pointer items-center gap-3 rounded-lg border border-transparent px-2 py-1 transition hover:border-slate-200 hover:bg-slate-50 dark:hover:border-slate-700 dark:hover:bg-slate-800/40"
+      >
+        <input
+          type="checkbox"
+          checked={isSelected}
+          onChange={() => toggleOutcome(status)}
+          className="h-3.5 w-3.5 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500 dark:border-slate-600"
+        />
+        <div className="flex-1">
+          <div className="flex items-baseline justify-between text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            <span>{status}</span>
+            <span>{count}</span>
+          </div>
+          <div className="mt-1 h-2 overflow-hidden rounded-full bg-slate-200 dark:bg-slate-700">
+            <div
+              className={`h-full rounded-full ${isSelected ? 'bg-indigo-500 dark:bg-indigo-400' : 'bg-slate-400/70 dark:bg-slate-500/60'}`}
+              style={{ width: `${width}%` }}
+            />
+          </div>
+        </div>
+      </label>
+    );
+  });
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        <h4 className="text-sm font-semibold text-slate-700 dark:text-slate-100">Run outcomes</h4>
+        <p className="text-xs text-slate-500 dark:text-slate-400">
+          {stats.totalRuns} runs between {new Date(stats.range.from).toLocaleString()} and{' '}
+          {new Date(stats.range.to).toLocaleString()}
+        </p>
+      </div>
+      <div className="space-y-2">{renderedStatuses}</div>
+      <div className="rounded-lg bg-slate-100/70 px-3 py-2 text-xs text-slate-600 dark:bg-slate-800/50 dark:text-slate-300">
+        <div className="flex justify-between">
+          <span>Success rate</span>
+          <span>{(stats.successRate * 100).toFixed(1)}%</span>
+        </div>
+        <div className="flex justify-between">
+          <span>Failure rate</span>
+          <span>{(stats.failureRate * 100).toFixed(1)}%</span>
+        </div>
+        <div className="flex justify-between">
+          <span>Average duration</span>
+          <span>{formatDuration(stats.averageDurationMs)}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/workflows/components/WorkflowRunTrends.tsx
+++ b/apps/frontend/src/workflows/components/WorkflowRunTrends.tsx
@@ -1,0 +1,142 @@
+import { useMemo } from 'react';
+import type { WorkflowRunMetricsSummary } from '../types';
+
+type WorkflowRunTrendsProps = {
+  metrics: WorkflowRunMetricsSummary | null;
+  history: WorkflowRunMetricsSummary[];
+  selectedOutcomes: string[];
+};
+
+function buildSeriesPoints(
+  metrics: WorkflowRunMetricsSummary | null,
+  selectedOutcomes: string[]
+) {
+  if (!metrics || metrics.series.length === 0) {
+    return [];
+  }
+  const lowered = selectedOutcomes.map((entry) => entry.toLowerCase());
+  return metrics.series.map((point, index) => {
+    const keys = lowered.length > 0 ? lowered : Object.keys(point.statusCounts);
+    const total = keys.reduce((sum, key) => sum + (point.statusCounts[key] ?? 0), 0);
+    return {
+      index,
+      count: total,
+      duration: point.averageDurationMs ?? 0,
+      label: new Date(point.bucketEnd).toLocaleTimeString()
+    };
+  });
+}
+
+function computeMax(values: number[]): number {
+  return values.reduce((max, value) => (value > max ? value : max), 0);
+}
+
+function formatBucket(bucket: WorkflowRunMetricsSummary['bucket']): string {
+  if (!bucket) {
+    return 'auto';
+  }
+  if (bucket.key === '15m') {
+    return '15 minutes';
+  }
+  if (bucket.key === 'hour') {
+    return 'Hourly';
+  }
+  if (bucket.key === 'day') {
+    return 'Daily';
+  }
+  return bucket.interval;
+}
+
+function formatHistoryEntry(entry: WorkflowRunMetricsSummary): string {
+  const last = entry.series[entry.series.length - 1];
+  if (!last) {
+    return `${new Date(entry.range.to).toLocaleString()}: no runs`;
+  }
+  return `${new Date(entry.range.to).toLocaleString()}: ${last.rollingSuccessCount} successes`;
+}
+
+export default function WorkflowRunTrends({ metrics, history, selectedOutcomes }: WorkflowRunTrendsProps) {
+  const points = useMemo(() => buildSeriesPoints(metrics, selectedOutcomes), [
+    metrics,
+    selectedOutcomes
+  ]);
+
+  const counts = points.map((point) => point.count);
+  const durations = points.map((point) => point.duration ?? 0);
+  const maxCount = computeMax(counts) || 1;
+  const maxDuration = computeMax(durations) || 1;
+  const chartHeight = 80;
+
+  const polylinePath = points
+    .map((point, index) => {
+      const x = points.length > 1 ? (index / (points.length - 1)) * 100 : 50;
+      const y = chartHeight - (point.count / maxCount) * chartHeight;
+      return `${x},${y}`;
+    })
+    .join(' ');
+
+  const durationPath = points
+    .map((point, index) => {
+      const x = points.length > 1 ? (index / (points.length - 1)) * 100 : 50;
+      const y = chartHeight - (point.duration / maxDuration) * chartHeight;
+      return `${x},${y}`;
+    })
+    .join(' ');
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        <h4 className="text-sm font-semibold text-slate-700 dark:text-slate-100">Trend overview</h4>
+        {metrics ? (
+          <p className="text-xs text-slate-500 dark:text-slate-400">
+            Bucket: {formatBucket(metrics.bucket)} · Range: {new Date(metrics.range.from).toLocaleString()} –{' '}
+            {new Date(metrics.range.to).toLocaleString()}
+          </p>
+        ) : (
+          <p className="text-xs text-slate-500 dark:text-slate-400">No trend data available.</p>
+        )}
+      </div>
+      <div className="rounded-xl border border-slate-200 bg-white p-3 shadow-sm dark:border-slate-700/40 dark:bg-slate-900/40">
+        {points.length > 0 ? (
+          <svg viewBox="0 0 100 80" className="h-36 w-full">
+            <polyline
+              fill="none"
+              stroke="url(#count-gradient)"
+              strokeWidth="2"
+              points={polylinePath}
+              strokeLinecap="round"
+            />
+            <polyline
+              fill="none"
+              stroke="rgba(99,102,241,0.5)"
+              strokeWidth="1.5"
+              strokeDasharray="4 3"
+              points={durationPath}
+              strokeLinecap="round"
+            />
+            <defs>
+              <linearGradient id="count-gradient" x1="0" x2="0" y1="0" y2="1">
+                <stop offset="0%" stopColor="rgb(79,70,229)" />
+                <stop offset="100%" stopColor="rgba(79,70,229,0.2)" />
+              </linearGradient>
+            </defs>
+          </svg>
+        ) : (
+          <div className="flex h-32 items-center justify-center text-sm text-slate-500 dark:text-slate-400">
+            No recent runs in this range.
+          </div>
+        )}
+      </div>
+      {history.length > 0 && (
+        <div className="rounded-lg bg-slate-100/70 p-3 text-xs text-slate-600 dark:bg-slate-800/50 dark:text-slate-300">
+          <p className="mb-2 font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Snapshots</p>
+          <ul className="space-y-1">
+            {history.slice(-3).map((entry, index) => (
+              <li key={`${entry.range.to}-${index}`}>{formatHistoryEntry(entry)}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/workflows/types.ts
+++ b/apps/frontend/src/workflows/types.ts
@@ -186,3 +186,40 @@ export type WorkflowDraft = {
   defaultParametersText?: string;
   defaultParametersError?: string | null;
 };
+
+export type WorkflowAnalyticsRangeKey = '24h' | '7d' | '30d' | 'custom';
+
+export type WorkflowRunFailureCategory = {
+  category: string;
+  count: number;
+};
+
+export type WorkflowRunStatsSummary = {
+  workflowId: string;
+  slug: string;
+  range: { from: string; to: string; key: string };
+  totalRuns: number;
+  statusCounts: Record<string, number>;
+  successRate: number;
+  failureRate: number;
+  averageDurationMs: number | null;
+  failureCategories: WorkflowRunFailureCategory[];
+};
+
+export type WorkflowRunMetricsPoint = {
+  bucketStart: string;
+  bucketEnd: string;
+  totalRuns: number;
+  statusCounts: Record<string, number>;
+  averageDurationMs: number | null;
+  rollingSuccessCount: number;
+};
+
+export type WorkflowRunMetricsSummary = {
+  workflowId: string;
+  slug: string;
+  range: { from: string; to: string; key: string };
+  bucketInterval: string;
+  bucket?: { interval: string; key: string | null };
+  series: WorkflowRunMetricsPoint[];
+};

--- a/services/catalog/src/db/workflows.ts
+++ b/services/catalog/src/db/workflows.ts
@@ -27,6 +27,78 @@ import type {
 } from './rowTypes';
 import { useConnection, useTransaction } from './utils';
 
+type AnalyticsTimeRange = {
+  from: Date;
+  to: Date;
+};
+
+type WorkflowRunStatusCounts = Record<string, number>;
+
+export type WorkflowRunStats = {
+  workflowId: string;
+  slug: string;
+  range: AnalyticsTimeRange;
+  totalRuns: number;
+  statusCounts: WorkflowRunStatusCounts;
+  successRate: number;
+  failureRate: number;
+  averageDurationMs: number | null;
+  failureCategories: { category: string; count: number }[];
+};
+
+export type WorkflowRunMetricsPoint = {
+  bucketStart: string;
+  bucketEnd: string;
+  totalRuns: number;
+  statusCounts: WorkflowRunStatusCounts;
+  averageDurationMs: number | null;
+  rollingSuccessCount: number;
+};
+
+export type WorkflowRunMetrics = {
+  workflowId: string;
+  slug: string;
+  range: AnalyticsTimeRange;
+  bucketInterval: string;
+  series: WorkflowRunMetricsPoint[];
+};
+
+type AnalyticsOptions = {
+  from?: Date;
+  to?: Date;
+};
+
+type MetricsOptions = AnalyticsOptions & {
+  bucketInterval?: string;
+};
+
+function normalizeTimeRange({ from, to }: AnalyticsOptions): AnalyticsTimeRange {
+  const resolvedTo = to ?? new Date();
+  const resolvedFrom = from ?? new Date(resolvedTo.getTime() - 7 * 24 * 60 * 60 * 1000);
+  if (resolvedFrom.getTime() >= resolvedTo.getTime()) {
+    return {
+      from: new Date(resolvedTo.getTime() - 60 * 60 * 1000),
+      to: resolvedTo
+    } satisfies AnalyticsTimeRange;
+  }
+  return { from: resolvedFrom, to: resolvedTo } satisfies AnalyticsTimeRange;
+}
+
+function resolveBucketInterval(range: AnalyticsTimeRange, bucketInterval?: string): string {
+  if (bucketInterval) {
+    return bucketInterval;
+  }
+  const durationMs = range.to.getTime() - range.from.getTime();
+  const hourMs = 60 * 60 * 1000;
+  if (durationMs <= 24 * hourMs) {
+    return '15 minutes';
+  }
+  if (durationMs <= 7 * 24 * hourMs) {
+    return '1 hour';
+  }
+  return '1 day';
+}
+
 const MANUAL_TRIGGER: Record<string, unknown> = { type: 'manual' };
 
 function serializeJson(value: JsonValue | null | undefined): string | null {
@@ -829,4 +901,193 @@ export async function updateWorkflowRunStep(
   });
 
   return updated;
+}
+
+async function fetchWorkflowDefinitionBySlugOrThrow(client: PoolClient, slug: string) {
+  const definition = await fetchWorkflowDefinitionBySlug(client, slug);
+  if (!definition) {
+    throw new Error(`Workflow with slug ${slug} not found`);
+  }
+  return definition;
+}
+
+export async function getWorkflowRunStatsBySlug(
+  slug: string,
+  options: AnalyticsOptions = {}
+): Promise<WorkflowRunStats> {
+  return useConnection(async (client) => {
+    const definition = await fetchWorkflowDefinitionBySlugOrThrow(client, slug);
+    const range = normalizeTimeRange(options);
+
+    const { rows: statusRows } = await client.query<{ status: string | null; count: string }>(
+      `SELECT status, COUNT(*)::bigint AS count
+         FROM workflow_runs
+        WHERE workflow_definition_id = $1
+          AND created_at >= $2
+          AND created_at < $3
+        GROUP BY status`,
+      [definition.id, range.from.toISOString(), range.to.toISOString()]
+    );
+
+    const statusCounts: WorkflowRunStatusCounts = {};
+    let totalRuns = 0;
+    for (const row of statusRows) {
+      const status = (row.status ?? 'unknown').toLowerCase();
+      const count = Number(row.count ?? 0);
+      totalRuns += Number.isFinite(count) ? count : 0;
+      statusCounts[status] = Number.isFinite(count) ? count : 0;
+    }
+
+    const { rows: averageRows } = await client.query<{ avg: string | null }>(
+      `SELECT AVG(duration_ms)::numeric AS avg
+         FROM workflow_runs
+        WHERE workflow_definition_id = $1
+          AND duration_ms IS NOT NULL
+          AND created_at >= $2
+          AND created_at < $3`,
+      [definition.id, range.from.toISOString(), range.to.toISOString()]
+    );
+
+    const averageDurationMs = (() => {
+      const raw = averageRows[0]?.avg;
+      if (!raw) {
+        return null;
+      }
+      const value = Number(raw);
+      return Number.isFinite(value) ? value : null;
+    })();
+
+    const { rows: failureRows } = await client.query<{
+      category: string | null;
+      count: string;
+    }>(
+      `SELECT
+         COALESCE(NULLIF(TRIM(SPLIT_PART(error_message, ':', 1)), ''), 'unknown') AS category,
+         COUNT(*)::bigint AS count
+       FROM workflow_runs
+      WHERE workflow_definition_id = $1
+        AND status = 'failed'
+        AND created_at >= $2
+        AND created_at < $3
+      GROUP BY category
+      ORDER BY count DESC
+      LIMIT 20`,
+      [definition.id, range.from.toISOString(), range.to.toISOString()]
+    );
+
+    const failureCategories = failureRows.map((row) => ({
+      category: (row.category ?? 'unknown').toLowerCase(),
+      count: Number(row.count ?? 0)
+    }));
+
+    const successCount = statusCounts.succeeded ?? 0;
+    const failureCount = statusCounts.failed ?? 0;
+    const successRate = totalRuns === 0 ? 0 : successCount / totalRuns;
+    const failureRate = totalRuns === 0 ? 0 : failureCount / totalRuns;
+
+    return {
+      workflowId: definition.id,
+      slug: definition.slug,
+      range,
+      totalRuns,
+      statusCounts,
+      successRate,
+      failureRate,
+      averageDurationMs,
+      failureCategories
+    } satisfies WorkflowRunStats;
+  });
+}
+
+export async function getWorkflowRunMetricsBySlug(
+  slug: string,
+  options: MetricsOptions = {}
+): Promise<WorkflowRunMetrics> {
+  return useConnection(async (client) => {
+    const definition = await fetchWorkflowDefinitionBySlugOrThrow(client, slug);
+    const range = normalizeTimeRange(options);
+    const bucketInterval = resolveBucketInterval(range, options.bucketInterval);
+
+    const { rows } = await client.query<{
+      bucket_start: Date;
+      bucket_end: Date;
+      total_runs: string;
+      succeeded: string;
+      failed: string;
+      running: string;
+      canceled: string;
+      avg_duration_ms: string | null;
+    }>(
+      `WITH bucket_series AS (
+         SELECT generate_series($2::timestamptz, $3::timestamptz, $4::interval) AS bucket_start
+       ),
+       run_source AS (
+         SELECT created_at, status, duration_ms
+           FROM workflow_runs
+          WHERE workflow_definition_id = $1
+            AND created_at >= $2
+            AND created_at < $3
+       )
+       SELECT
+         bucket_start,
+         bucket_start + $4::interval AS bucket_end,
+         COUNT(run_source.*)::bigint AS total_runs,
+         COUNT(*) FILTER (WHERE run_source.status = 'succeeded')::bigint AS succeeded,
+         COUNT(*) FILTER (WHERE run_source.status = 'failed')::bigint AS failed,
+         COUNT(*) FILTER (WHERE run_source.status = 'running')::bigint AS running,
+         COUNT(*) FILTER (WHERE run_source.status = 'canceled')::bigint AS canceled,
+         AVG(run_source.duration_ms)::numeric AS avg_duration_ms
+       FROM bucket_series
+       LEFT JOIN run_source
+         ON run_source.created_at >= bucket_start
+        AND run_source.created_at < bucket_start + $4::interval
+       GROUP BY bucket_start
+       ORDER BY bucket_start`,
+      [
+        definition.id,
+        range.from.toISOString(),
+        range.to.toISOString(),
+        bucketInterval
+      ]
+    );
+
+    const series: WorkflowRunMetricsPoint[] = [];
+    let rollingSuccessCount = 0;
+
+    for (const row of rows) {
+      const bucketStartIso = row.bucket_start.toISOString();
+      const bucketEndIso = row.bucket_end.toISOString();
+      const succeeded = Number(row.succeeded ?? 0);
+      rollingSuccessCount += Number.isFinite(succeeded) ? succeeded : 0;
+      const failed = Number(row.failed ?? 0);
+      const running = Number(row.running ?? 0);
+      const canceled = Number(row.canceled ?? 0);
+      const totalRuns = Number(row.total_runs ?? 0);
+      const avgDuration = row.avg_duration_ms ? Number(row.avg_duration_ms) : null;
+
+      const statusCounts: WorkflowRunStatusCounts = {
+        succeeded: Number.isFinite(succeeded) ? succeeded : 0,
+        failed: Number.isFinite(failed) ? failed : 0,
+        running: Number.isFinite(running) ? running : 0,
+        canceled: Number.isFinite(canceled) ? canceled : 0
+      };
+
+      series.push({
+        bucketStart: bucketStartIso,
+        bucketEnd: bucketEndIso,
+        totalRuns: Number.isFinite(totalRuns) ? totalRuns : 0,
+        statusCounts,
+        averageDurationMs: avgDuration && Number.isFinite(avgDuration) ? avgDuration : null,
+        rollingSuccessCount
+      });
+    }
+
+    return {
+      workflowId: definition.id,
+      slug: definition.slug,
+      range,
+      bucketInterval,
+      series
+    } satisfies WorkflowRunMetrics;
+  });
 }

--- a/services/catalog/src/routes/core.ts
+++ b/services/catalog/src/routes/core.ts
@@ -20,6 +20,11 @@ import {
 } from './shared/serializers';
 import type { IngestionEvent } from '../db/index';
 
+type WorkflowAnalyticsSnapshotData = Extract<
+  ApphubEvent,
+  { type: 'workflow.analytics.snapshot' }
+>['data'];
+
 type WorkflowRunEventType =
   | 'workflow.run.updated'
   | 'workflow.run.pending'
@@ -35,7 +40,8 @@ type OutboundEvent =
   | { type: 'launch.updated'; data: { repositoryId: string; launch: SerializedLaunch } }
   | { type: 'service.updated'; data: { service: SerializedService } }
   | { type: 'workflow.definition.updated'; data: { workflow: SerializedWorkflowDefinition } }
-  | { type: WorkflowRunEventType; data: { run: SerializedWorkflowRun } };
+  | { type: WorkflowRunEventType; data: { run: SerializedWorkflowRun } }
+  | { type: 'workflow.analytics.snapshot'; data: WorkflowAnalyticsSnapshotData };
 
 function toOutboundEvent(event: ApphubEvent): OutboundEvent | null {
   switch (event.type) {
@@ -81,6 +87,11 @@ function toOutboundEvent(event: ApphubEvent): OutboundEvent | null {
       return {
         type: event.type,
         data: { run: serializeWorkflowRun(event.data.run) }
+      };
+    case 'workflow.analytics.snapshot':
+      return {
+        type: 'workflow.analytics.snapshot',
+        data: event.data
       };
     default:
       return null;

--- a/services/catalog/src/routes/shared/serializers.ts
+++ b/services/catalog/src/routes/shared/serializers.ts
@@ -10,6 +10,8 @@ import {
   type ServiceRecord,
   type WorkflowDefinitionRecord,
   type WorkflowRunRecord,
+  type WorkflowRunMetrics,
+  type WorkflowRunStats,
   type WorkflowRunStepRecord
 } from '../../db/index';
 import type { BundleDownloadInfo } from '../../jobs/bundleStorage';
@@ -336,6 +338,46 @@ export function serializeWorkflowRunStep(step: WorkflowRunStepRecord) {
   };
 }
 
+export function serializeWorkflowRunStats(stats: WorkflowRunStats) {
+  return {
+    workflowId: stats.workflowId,
+    slug: stats.slug,
+    range: {
+      from: stats.range.from.toISOString(),
+      to: stats.range.to.toISOString()
+    },
+    totalRuns: stats.totalRuns,
+    statusCounts: { ...stats.statusCounts },
+    successRate: stats.successRate,
+    failureRate: stats.failureRate,
+    averageDurationMs: stats.averageDurationMs,
+    failureCategories: stats.failureCategories.map((category) => ({
+      category: category.category,
+      count: category.count
+    }))
+  };
+}
+
+export function serializeWorkflowRunMetrics(metrics: WorkflowRunMetrics) {
+  return {
+    workflowId: metrics.workflowId,
+    slug: metrics.slug,
+    range: {
+      from: metrics.range.from.toISOString(),
+      to: metrics.range.to.toISOString()
+    },
+    bucketInterval: metrics.bucketInterval,
+    series: metrics.series.map((point) => ({
+      bucketStart: point.bucketStart,
+      bucketEnd: point.bucketEnd,
+      totalRuns: point.totalRuns,
+      statusCounts: { ...point.statusCounts },
+      averageDurationMs: point.averageDurationMs,
+      rollingSuccessCount: point.rollingSuccessCount
+    }))
+  };
+}
+
 export type SerializedRepository = ReturnType<typeof serializeRepository>;
 export type SerializedBuild = ReturnType<typeof serializeBuild>;
 export type SerializedLaunch = ReturnType<typeof serializeLaunch>;
@@ -343,5 +385,7 @@ export type SerializedService = ReturnType<typeof serializeService>;
 export type SerializedWorkflowDefinition = ReturnType<typeof serializeWorkflowDefinition>;
 export type SerializedWorkflowRun = ReturnType<typeof serializeWorkflowRun>;
 export type SerializedWorkflowRunStep = ReturnType<typeof serializeWorkflowRunStep>;
+export type SerializedWorkflowRunStats = ReturnType<typeof serializeWorkflowRunStats>;
+export type SerializedWorkflowRunMetrics = ReturnType<typeof serializeWorkflowRunMetrics>;
 export type SerializedJobBundle = ReturnType<typeof serializeJobBundle>;
 export type SerializedJobBundleVersion = ReturnType<typeof serializeJobBundleVersion>;


### PR DESCRIPTION
## Summary
- add workflow analytics queries, serializers, endpoints, and websocket snapshots to surface stats and metrics
- extend the workflows controller + API client to normalize analytics payloads and maintain historical series
- add analytics visualizations and integrate them into the workflows page alongside updated tests

## Testing
- `npx tsx tests/workflows.e2e.ts` *(fails: Embedded Postgres refuses to run as root)*
- `npx vitest run src/workflows/__tests__/WorkflowsPage.test.tsx src/workflows/hooks/__tests__/useWorkflowsController.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68d110148c78833396a930aa1ae57e39