### PR TITLE
Add Python tooling to runtime image and document deployment workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,20 @@ RUN apt-get update \
   && chmod a+r /etc/apt/keyrings/docker.gpg \
   && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian $(. /etc/os-release && echo $VERSION_CODENAME) stable" > /etc/apt/sources.list.d/docker.list \
   && apt-get update \
-  && apt-get install -y --no-install-recommends git redis-server docker-ce-cli supervisor postgresql postgresql-contrib \
+  && apt-get install -y --no-install-recommends \
+    git \
+    redis-server \
+    docker-ce-cli \
+    supervisor \
+    postgresql \
+    postgresql-contrib \
+    python3 \
+    python3-pip \
+    python3-venv \
+    python-is-python3 \
   && rm -rf /var/lib/apt/lists/* \
+  && python3 --version \
+  && pip3 --version \
   && npm install -g serve \
   && mkdir -p /app/data /app/services
 

--- a/README.md
+++ b/README.md
@@ -357,8 +357,21 @@ Notes:
 - Start `services/codex-proxy` on the host before launching the container so the AI builder can reach Codex via `APPHUB_CODEX_PROXY_URL`.
 - `apphub-data` persists PostgreSQL (`/app/data/postgres`) and local job-bundle artifacts (`/app/data/job-bundles`). Remove the volume for a clean slate.
 - The compiled frontend is served from http://localhost:4173 and the API remains at http://localhost:4000. External service manifests are **not** bundled—load them dynamically through the API at runtime.
+- Python 3.11 (via `python3`, `python`, and `pip3`) ships in the runtime image for bundle authors that need Python tooling. Install dependencies inside a per-run virtual environment or vendor wheels alongside the bundle rather than modifying global site packages.
 
 Stop the container with `Ctrl+C` or `docker stop` when running detached.
+
+### Publishing the Runtime Image
+
+Use the helper script to rebuild and publish the multi-service runtime image after making Dockerfile changes:
+
+```bash
+APPHUB_RUNTIME_IMAGE=ghcr.io/apphub/runtime \
+APPHUB_RUNTIME_LATEST_TAG=latest \
+./scripts/publish-runtime.sh
+```
+
+The script tags the image with the current Git SHA by default and optionally applies an alias (such as `latest`). Set `APPHUB_RUNTIME_PUSH=0` to skip pushing when testing locally.
 
 ## Testing
 

--- a/docs/job-bundles.md
+++ b/docs/job-bundles.md
@@ -2,6 +2,12 @@
 
 AppHub job bundles are portable archives that ship a manifest, compiled handler code, and any assets the job requires at runtime. The developer CLI (`apphub`) streamlines scaffolding, validation, packaging, testing, and publishing these bundles to the job registry introduced in ticket 006.
 
+## Runtime Environment
+
+- **Node.js**: Bundles execute inside the `apphub` runtime container that ships with Node.js 20 (matching the workers).
+- **Python**: The same container now installs Python 3.11 (`python3`, `python`, and `pip3` live on the default `$PATH`). Bundles can invoke Python helpers or ship Python entry points without needing additional system packages.
+- **Dependency management**: Workers unpack each bundle into an isolated, ephemeral directory. When Python dependencies are required, create a virtual environment inside that directory (for example `python3 -m venv .venv && source .venv/bin/activate`) or vendor prebuilt wheels inside the bundle. Installing global packages is not supported; use the per-run virtualenv or bundle-provided modules instead.
+
 ## CLI Overview
 
 | Command | Description |

--- a/scripts/publish-runtime.sh
+++ b/scripts/publish-runtime.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "[publish-runtime] docker CLI is required" >&2
+  exit 1
+fi
+
+IMAGE_REF=${APPHUB_RUNTIME_IMAGE:-}
+if [[ -z "${IMAGE_REF}" ]]; then
+  echo "[publish-runtime] Set APPHUB_RUNTIME_IMAGE (e.g. ghcr.io/apphub/runtime)" >&2
+  exit 1
+fi
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "[publish-runtime] git CLI is required to derive the default tag" >&2
+  exit 1
+fi
+
+TAG=${APPHUB_RUNTIME_TAG:-$(git rev-parse --short HEAD)}
+PUSH_FLAG=${APPHUB_RUNTIME_PUSH:-1}
+ALIAS_TAG=${APPHUB_RUNTIME_LATEST_TAG:-}
+
+FULL_REF="${IMAGE_REF}:${TAG}"
+
+echo "[publish-runtime] Building runtime image ${FULL_REF}"
+docker build --target runtime -t "${FULL_REF}" .
+
+if [[ -n "${ALIAS_TAG}" ]]; then
+  echo "[publish-runtime] Tagging runtime image as ${IMAGE_REF}:${ALIAS_TAG}"
+  docker tag "${FULL_REF}" "${IMAGE_REF}:${ALIAS_TAG}"
+fi
+
+if [[ "${PUSH_FLAG}" != "0" ]]; then
+  echo "[publish-runtime] Pushing ${FULL_REF}"
+  docker push "${FULL_REF}"
+  if [[ -n "${ALIAS_TAG}" ]]; then
+    echo "[publish-runtime] Pushing ${IMAGE_REF}:${ALIAS_TAG}"
+    docker push "${IMAGE_REF}:${ALIAS_TAG}"
+  fi
+else
+  echo "[publish-runtime] Skipping push (APPHUB_RUNTIME_PUSH=${PUSH_FLAG})"
+fi


### PR DESCRIPTION
## Summary
- install Python 3.11 and pip in the runtime Docker image so job workers can call Python
- document the runtime language support and dependency isolation expectations for bundle authors
- add a helper script and README instructions for rebuilding and publishing the updated runtime container

## Testing
- not run (documentation and container definition changes only)

------
https://chatgpt.com/codex/tasks/task_e_68d114a360388333a1298a52d89b2aaf