### PR TITLE
catalog: add schema introspection tests

### DIFF
--- a/apps/frontend/src/jobs/JobCreateDialog.tsx
+++ b/apps/frontend/src/jobs/JobCreateDialog.tsx
@@ -1,0 +1,550 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { AuthorizedFetch, JobDefinitionSummary } from '../workflows/api';
+import { createJobDefinition } from '../workflows/api';
+import type { JobRuntimeStatus, SchemaPreview } from './api';
+import { previewJobSchemas } from './api';
+
+const JOB_TYPES: Array<{ value: 'batch' | 'service-triggered' | 'manual'; label: string }> = [
+  { value: 'batch', label: 'Batch' },
+  { value: 'service-triggered', label: 'Service-triggered' },
+  { value: 'manual', label: 'Manual' }
+];
+
+const EMPTY_JSON_TEXT = '{\n}\n';
+
+function slugify(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9-_]+/g, '-')
+    .replace(/-{2,}/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 100);
+}
+
+function parseJsonObject(
+  value: string,
+  onError: (message: string) => void
+): Record<string, unknown> | null {
+  if (!value.trim()) {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      onError('Value must be a JSON object');
+      return null;
+    }
+    return parsed as Record<string, unknown>;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Invalid JSON';
+    onError(`Invalid JSON: ${message}`);
+    return null;
+  }
+}
+
+function formatSchema(schema: Record<string, unknown> | null): string {
+  if (!schema) {
+    return EMPTY_JSON_TEXT;
+  }
+  try {
+    return `${JSON.stringify(schema, null, 2)}\n`;
+  } catch {
+    return EMPTY_JSON_TEXT;
+  }
+}
+
+type JobCreateDialogProps = {
+  open: boolean;
+  onClose: () => void;
+  authorizedFetch: AuthorizedFetch;
+  defaultRuntime: 'node' | 'python';
+  runtimeStatuses: JobRuntimeStatus[];
+  onCreated: (job: JobDefinitionSummary) => void;
+};
+
+export default function JobCreateDialog({
+  open,
+  onClose,
+  authorizedFetch,
+  defaultRuntime,
+  runtimeStatuses,
+  onCreated
+}: JobCreateDialogProps) {
+  const runtimeStatusMap = useMemo(() => {
+    const map = new Map<'node' | 'python', JobRuntimeStatus>();
+    for (const status of runtimeStatuses) {
+      map.set(status.runtime, status);
+    }
+    return map;
+  }, [runtimeStatuses]);
+
+  const [name, setName] = useState('');
+  const [slug, setSlug] = useState('');
+  const [slugTouched, setSlugTouched] = useState(false);
+  const [jobType, setJobType] = useState<'batch' | 'service-triggered' | 'manual'>('batch');
+  const [runtime, setRuntime] = useState<'node' | 'python'>(defaultRuntime);
+  const [entryPoint, setEntryPoint] = useState('');
+  const [version, setVersion] = useState('');
+  const [timeoutMs, setTimeoutMs] = useState('');
+  const [parametersSchemaText, setParametersSchemaText] = useState(EMPTY_JSON_TEXT);
+  const [defaultParametersText, setDefaultParametersText] = useState(EMPTY_JSON_TEXT);
+  const [outputSchemaText, setOutputSchemaText] = useState(EMPTY_JSON_TEXT);
+  const [parametersSchemaError, setParametersSchemaError] = useState<string | null>(null);
+  const [defaultParametersError, setDefaultParametersError] = useState<string | null>(null);
+  const [outputSchemaError, setOutputSchemaError] = useState<string | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [autoDetectPending, setAutoDetectPending] = useState(false);
+  const [autoDetectError, setAutoDetectError] = useState<string | null>(null);
+  const [schemaSources, setSchemaSources] = useState<{ parameters?: string | null; output?: string | null }>({});
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    setName('');
+    setSlug('');
+    setSlugTouched(false);
+    setJobType('batch');
+    setRuntime(defaultRuntime);
+    setEntryPoint('');
+    setVersion('');
+    setTimeoutMs('');
+    setParametersSchemaText(EMPTY_JSON_TEXT);
+    setDefaultParametersText(EMPTY_JSON_TEXT);
+    setOutputSchemaText(EMPTY_JSON_TEXT);
+    setParametersSchemaError(null);
+    setDefaultParametersError(null);
+    setOutputSchemaError(null);
+    setFormError(null);
+    setAutoDetectError(null);
+    setAutoDetectPending(false);
+    setSchemaSources({});
+  }, [open, defaultRuntime]);
+
+  useEffect(() => {
+    if (!slugTouched) {
+      setSlug(slugify(name));
+    }
+  }, [name, slugTouched]);
+
+  const handleSlugChange = useCallback((value: string) => {
+    setSlugTouched(true);
+    setSlug(value);
+  }, []);
+
+  const handleRuntimeChange = useCallback((value: 'node' | 'python') => {
+    setRuntime(value);
+  }, []);
+
+  const handleAutoDetect = useCallback(async () => {
+    setAutoDetectError(null);
+    if (!entryPoint.trim()) {
+      setAutoDetectError('Provide an entry point to inspect schemas.');
+      return;
+    }
+    setAutoDetectPending(true);
+    try {
+      const preview: SchemaPreview = await previewJobSchemas(authorizedFetch, {
+        entryPoint: entryPoint.trim(),
+        runtime
+      });
+      setParametersSchemaText(formatSchema(preview.parametersSchema));
+      setDefaultParametersText((current) => current || EMPTY_JSON_TEXT);
+      setOutputSchemaText(formatSchema(preview.outputSchema));
+      setParametersSchemaError(null);
+      setOutputSchemaError(null);
+      setSchemaSources({
+        parameters: preview.parametersSource ?? null,
+        output: preview.outputSource ?? null
+      });
+      if (!preview.parametersSchema && !preview.outputSchema) {
+        setAutoDetectError('No schemas were discovered in the referenced bundle.');
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to inspect entry point';
+      setAutoDetectError(message);
+    } finally {
+      setAutoDetectPending(false);
+    }
+  }, [authorizedFetch, entryPoint, runtime]);
+
+  const handleSubmit = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (submitting) {
+        return;
+      }
+      setFormError(null);
+      setParametersSchemaError(null);
+      setDefaultParametersError(null);
+      setOutputSchemaError(null);
+
+      const trimmedName = name.trim();
+      const trimmedSlug = slug.trim();
+      const trimmedEntryPoint = entryPoint.trim();
+      const trimmedVersion = version.trim();
+      const trimmedTimeout = timeoutMs.trim();
+
+      if (!trimmedName) {
+        setFormError('Name is required.');
+        return;
+      }
+      if (!trimmedSlug) {
+        setFormError('Slug is required.');
+        return;
+      }
+      if (!/^[a-z0-9][a-z0-9-_]*$/i.test(trimmedSlug)) {
+        setFormError('Slug must contain only alphanumeric characters, dashes, or underscores.');
+        return;
+      }
+      if (!trimmedEntryPoint) {
+        setFormError('Entry point is required.');
+        return;
+      }
+
+      const parametersSchema = parseJsonObject(parametersSchemaText, setParametersSchemaError);
+      if (!parametersSchema) {
+        return;
+      }
+      const defaultParameters = parseJsonObject(defaultParametersText, setDefaultParametersError);
+      if (!defaultParameters) {
+        return;
+      }
+      const outputSchema = parseJsonObject(outputSchemaText, setOutputSchemaError);
+      if (!outputSchema) {
+        return;
+      }
+
+      let versionValue: number | undefined;
+      if (trimmedVersion) {
+        const parsed = Number(trimmedVersion);
+        if (!Number.isInteger(parsed) || parsed < 1) {
+          setFormError('Version must be a positive integer if provided.');
+          return;
+        }
+        versionValue = parsed;
+      }
+
+      let timeoutValue: number | null | undefined;
+      if (trimmedTimeout) {
+        const parsed = Number(trimmedTimeout);
+        if (!Number.isFinite(parsed) || parsed <= 0) {
+          setFormError('Timeout must be a positive number of milliseconds.');
+          return;
+        }
+        timeoutValue = Math.floor(parsed);
+      }
+
+      setSubmitting(true);
+      try {
+        const job = await createJobDefinition(authorizedFetch, {
+          slug: trimmedSlug,
+          name: trimmedName,
+          type: jobType,
+          runtime,
+          entryPoint: trimmedEntryPoint,
+          version: versionValue,
+          timeoutMs: timeoutValue,
+          parametersSchema,
+          defaultParameters,
+          outputSchema
+        });
+        onCreated(job);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Failed to create job';
+        setFormError(message);
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [
+      submitting,
+      name,
+      slug,
+      entryPoint,
+      version,
+      timeoutMs,
+      jobType,
+      runtime,
+      parametersSchemaText,
+      defaultParametersText,
+      outputSchemaText,
+      authorizedFetch,
+      onCreated
+    ]
+  );
+
+  if (!open) {
+    return null;
+  }
+
+  const nodeStatus = runtimeStatusMap.get('node');
+  const pythonStatus = runtimeStatusMap.get('python');
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/60 p-4 backdrop-blur-sm"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="job-create-title"
+      onClick={onClose}
+    >
+      <div
+        className="relative flex w-full max-w-3xl flex-col overflow-hidden rounded-3xl border border-slate-200/70 bg-white shadow-2xl dark:border-slate-700/70 dark:bg-slate-900"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <header className="flex items-start justify-between gap-4 border-b border-slate-200/60 bg-slate-50/60 px-6 py-4 dark:border-slate-700/60 dark:bg-slate-900/60">
+          <div>
+            <h2 id="job-create-title" className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+              Create job definition
+            </h2>
+            <p className="text-sm text-slate-600 dark:text-slate-400">
+              Provide the entry point and default metadata for a new job.
+            </p>
+          </div>
+          <button
+            type="button"
+            className="rounded-full border border-slate-300 px-3 py-1 text-xs font-semibold text-slate-600 hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-500 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-800"
+            onClick={onClose}
+          >
+            Close
+          </button>
+        </header>
+
+        <form className="flex flex-col gap-5 px-6 py-5" onSubmit={handleSubmit}>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <label className="flex flex-col gap-1 text-sm font-semibold text-slate-700 dark:text-slate-200">
+              Name
+              <input
+                type="text"
+                className="rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-800 shadow-sm focus:border-violet-500 focus:outline-none focus:ring-2 focus:ring-violet-200 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                required
+              />
+            </label>
+            <label className="flex flex-col gap-1 text-sm font-semibold text-slate-700 dark:text-slate-200">
+              Slug
+              <input
+                type="text"
+                className="rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-800 shadow-sm focus:border-violet-500 focus:outline-none focus:ring-2 focus:ring-violet-200 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
+                value={slug}
+                onChange={(event) => handleSlugChange(event.target.value)}
+                required
+              />
+            </label>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <label className="flex flex-col gap-2 text-sm font-semibold text-slate-700 dark:text-slate-200">
+              Type
+              <div className="flex flex-wrap gap-2">
+                {JOB_TYPES.map((option) => {
+                  const isActive = jobType === option.value;
+                  return (
+                    <button
+                      key={option.value}
+                      type="button"
+                      className={`rounded-full border px-3 py-1 text-xs font-semibold transition-colors ${
+                        isActive
+                          ? 'border-violet-500 bg-violet-600 text-white shadow'
+                          : 'border-slate-300 text-slate-600 hover:bg-slate-100 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-800'
+                      }`}
+                      onClick={() => setJobType(option.value)}
+                    >
+                      {option.label}
+                    </button>
+                  );
+                })}
+              </div>
+            </label>
+            <label className="flex flex-col gap-2 text-sm font-semibold text-slate-700 dark:text-slate-200">
+              Runtime
+              <div className="flex flex-wrap gap-2">
+                {(['node', 'python'] as const).map((option) => {
+                  const status = runtimeStatusMap.get(option);
+                  const ready = status ? status.ready : true;
+                  const disabled = option === 'python' && status ? !status.ready : false;
+                  const isActive = runtime === option;
+                  const badgeClass = ready
+                    ? 'text-emerald-600 dark:text-emerald-300'
+                    : 'text-rose-600 dark:text-rose-300';
+                  return (
+                    <div key={option} className="flex flex-col gap-1">
+                      <button
+                        type="button"
+                        className={`rounded-full border px-3 py-1 text-xs font-semibold transition-colors ${
+                          isActive
+                            ? 'border-violet-500 bg-violet-600 text-white shadow'
+                            : 'border-slate-300 text-slate-600 hover:bg-slate-100 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-800'
+                        } ${disabled ? 'cursor-not-allowed opacity-60' : ''}`}
+                        onClick={() => !disabled && handleRuntimeChange(option)}
+                        disabled={disabled}
+                      >
+                        {option === 'python' ? 'Python' : 'Node'}
+                      </button>
+                      {status && (
+                        <span className={`text-[11px] font-medium ${badgeClass}`}>
+                          {status.ready ? 'Ready' : status.reason ? status.reason : 'Unavailable'}
+                        </span>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </label>
+          </div>
+
+          <label className="flex flex-col gap-1 text-sm font-semibold text-slate-700 dark:text-slate-200">
+            Entry point
+            <input
+              type="text"
+              className="rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-800 shadow-sm focus:border-violet-500 focus:outline-none focus:ring-2 focus:ring-violet-200 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
+              value={entryPoint}
+              onChange={(event) => setEntryPoint(event.target.value)}
+              required
+              placeholder="bundle:slug@version"
+            />
+          </label>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <label className="flex flex-col gap-1 text-sm font-semibold text-slate-700 dark:text-slate-200">
+              Version (optional)
+              <input
+                type="number"
+                min={1}
+                className="rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-800 shadow-sm focus:border-violet-500 focus:outline-none focus:ring-2 focus:ring-violet-200 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
+                value={version}
+                onChange={(event) => setVersion(event.target.value)}
+              />
+            </label>
+            <label className="flex flex-col gap-1 text-sm font-semibold text-slate-700 dark:text-slate-200">
+              Timeout (ms, optional)
+              <input
+                type="number"
+                min={1000}
+                className="rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-800 shadow-sm focus:border-violet-500 focus:outline-none focus:ring-2 focus:ring-violet-200 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
+                value={timeoutMs}
+                onChange={(event) => setTimeoutMs(event.target.value)}
+              />
+            </label>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <div className="flex flex-wrap items-center gap-3">
+              <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-200">Schemas</h3>
+              <button
+                type="button"
+                className="rounded-full border border-slate-300 px-3 py-1 text-xs font-semibold text-slate-600 transition-colors hover:bg-slate-100 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-800"
+                onClick={handleAutoDetect}
+                disabled={autoDetectPending}
+              >
+                {autoDetectPending ? 'Detecting…' : 'Auto-detect from entry point'}
+              </button>
+            </div>
+            {autoDetectError && (
+              <p className="text-xs text-rose-600 dark:text-rose-300">{autoDetectError}</p>
+            )}
+            <div className="grid gap-4 md:grid-cols-2">
+              <label className="flex flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                Parameters schema
+                <textarea
+                  className="min-h-[140px] rounded-xl border border-slate-300 px-3 py-2 font-mono text-xs text-slate-800 shadow-sm focus:border-violet-500 focus:outline-none focus:ring-2 focus:ring-violet-200 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
+                  value={parametersSchemaText}
+                  onChange={(event) => setParametersSchemaText(event.target.value)}
+                  spellCheck={false}
+                />
+                {schemaSources.parameters && (
+                  <span className="text-[11px] text-slate-500 dark:text-slate-400">
+                    Detected from {schemaSources.parameters}
+                  </span>
+                )}
+                {parametersSchemaError && (
+                  <span className="text-[11px] font-semibold text-rose-600 dark:text-rose-300">
+                    {parametersSchemaError}
+                  </span>
+                )}
+              </label>
+              <label className="flex flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                Default parameters
+                <textarea
+                  className="min-h-[140px] rounded-xl border border-slate-300 px-3 py-2 font-mono text-xs text-slate-800 shadow-sm focus:border-violet-500 focus:outline-none focus:ring-2 focus:ring-violet-200 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
+                  value={defaultParametersText}
+                  onChange={(event) => setDefaultParametersText(event.target.value)}
+                  spellCheck={false}
+                />
+                {defaultParametersError && (
+                  <span className="text-[11px] font-semibold text-rose-600 dark:text-rose-300">
+                    {defaultParametersError}
+                  </span>
+                )}
+              </label>
+              <label className="flex flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400 md:col-span-2">
+                Output schema
+                <textarea
+                  className="min-h-[140px] rounded-xl border border-slate-300 px-3 py-2 font-mono text-xs text-slate-800 shadow-sm focus:border-violet-500 focus:outline-none focus:ring-2 focus:ring-violet-200 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
+                  value={outputSchemaText}
+                  onChange={(event) => setOutputSchemaText(event.target.value)}
+                  spellCheck={false}
+                />
+                {schemaSources.output && (
+                  <span className="text-[11px] text-slate-500 dark:text-slate-400">
+                    Detected from {schemaSources.output}
+                  </span>
+                )}
+                {outputSchemaError && (
+                  <span className="text-[11px] font-semibold text-rose-600 dark:text-rose-300">
+                    {outputSchemaError}
+                  </span>
+                )}
+              </label>
+            </div>
+          </div>
+
+          {formError && (
+            <p className="text-sm font-semibold text-rose-600 dark:text-rose-300">{formError}</p>
+          )}
+
+          <div className="flex items-center justify-end gap-3">
+            <button
+              type="button"
+              className="rounded-full border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-600 hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-500 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-800"
+              onClick={onClose}
+              disabled={submitting}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="rounded-full bg-violet-600 px-5 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-violet-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-500 disabled:cursor-not-allowed disabled:opacity-60"
+              disabled={submitting}
+            >
+              {submitting ? 'Creating…' : 'Create job'}
+            </button>
+          </div>
+
+          <div className="grid gap-2 border-t border-slate-200/70 pt-4 text-[11px] text-slate-500 dark:border-slate-700/60 dark:text-slate-400 sm:grid-cols-2">
+            <div>
+              <strong className="font-semibold text-slate-600 dark:text-slate-300">Node runtime</strong>
+              <p>
+                {nodeStatus?.ready
+                  ? 'Sandbox ready.'
+                  : nodeStatus?.reason ?? 'Runtime status unavailable.'}
+              </p>
+            </div>
+            <div>
+              <strong className="font-semibold text-slate-600 dark:text-slate-300">Python runtime</strong>
+              <p>
+                {pythonStatus?.ready
+                  ? pythonStatus.details?.version ?? 'Sandbox ready.'
+                  : pythonStatus?.reason ?? 'Runtime status unavailable.'}
+              </p>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/jobs/api.ts
+++ b/apps/frontend/src/jobs/api.ts
@@ -28,6 +28,14 @@ export type JobDetailResponse = {
   runs: JobRunSummary[];
 };
 
+export type JobRuntimeStatus = {
+  runtime: 'node' | 'python';
+  ready: boolean;
+  reason: string | null;
+  checkedAt: string;
+  details: Record<string, unknown> | null;
+};
+
 export type BundleEditorFile = {
   path: string;
   contents: string;
@@ -76,11 +84,47 @@ export type BundleEditorData = {
   availableVersions: BundleVersionSummary[];
 };
 
+export type SchemaPreview = {
+  parametersSchema: Record<string, unknown> | null;
+  outputSchema: Record<string, unknown> | null;
+  parametersSource: string | null;
+  outputSource: string | null;
+};
+
+function toRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
 export async function fetchJobs(fetcher: AuthorizedFetch): Promise<JobDefinitionSummary[]> {
   const response = await fetcher(`${API_BASE_URL}/jobs`);
   await ensureOk(response, 'Failed to load job definitions');
   const payload = await parseJson<{ data?: JobDefinitionSummary[] }>(response);
   return Array.isArray(payload.data) ? payload.data : [];
+}
+
+export async function fetchJobRuntimeStatuses(fetcher: AuthorizedFetch): Promise<JobRuntimeStatus[]> {
+  const response = await fetcher(`${API_BASE_URL}/jobs/runtimes`);
+  await ensureOk(response, 'Failed to load job runtime readiness');
+  const payload = await parseJson<{ data?: unknown }>(response);
+  const rawData = payload.data;
+  const raw = Array.isArray(rawData) ? rawData : [];
+  const statuses: JobRuntimeStatus[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== 'object') {
+      continue;
+    }
+    const record = entry as Record<string, unknown>;
+    const runtime = record.runtime === 'python' ? 'python' : 'node';
+    const ready = Boolean(record.ready);
+    const reason = typeof record.reason === 'string' ? record.reason : null;
+    const checkedAt = typeof record.checkedAt === 'string' ? record.checkedAt : new Date().toISOString();
+    const details = toRecord(record.details ?? null);
+    statuses.push({ runtime, ready, reason, checkedAt, details });
+  }
+  return statuses;
 }
 
 export async function fetchJobDetail(
@@ -142,4 +186,31 @@ export async function regenerateJobBundle(
     throw new Error('Bundle regeneration response missing data');
   }
   return payload.data;
+}
+
+export async function previewJobSchemas(
+  fetcher: AuthorizedFetch,
+  input: { entryPoint: string; runtime?: 'node' | 'python' }
+): Promise<SchemaPreview> {
+  const response = await fetcher(`${API_BASE_URL}/jobs/schema-preview`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ entryPoint: input.entryPoint, runtime: input.runtime })
+  });
+  await ensureOk(response, 'Failed to inspect entry point schemas');
+  const payload = await parseJson<{
+    data?: {
+      parametersSchema?: unknown;
+      outputSchema?: unknown;
+      parametersSource?: unknown;
+      outputSource?: unknown;
+    };
+  }>(response);
+  const data = payload.data ?? {};
+  return {
+    parametersSchema: toRecord(data.parametersSchema ?? null),
+    outputSchema: toRecord(data.outputSchema ?? null),
+    parametersSource: typeof data.parametersSource === 'string' ? data.parametersSource : null,
+    outputSource: typeof data.outputSource === 'string' ? data.outputSource : null
+  } satisfies SchemaPreview;
 }

--- a/apps/frontend/src/workflows/WorkflowsPage.tsx
+++ b/apps/frontend/src/workflows/WorkflowsPage.tsx
@@ -44,7 +44,6 @@ export default function WorkflowsPage() {
     workflowAnalytics,
     setWorkflowAnalyticsRange,
     setWorkflowAnalyticsOutcomes,
-    loadWorkflowAnalytics,
     manualRunPending,
     manualRunError,
     lastTriggeredRun,

--- a/apps/frontend/src/workflows/api.ts
+++ b/apps/frontend/src/workflows/api.ts
@@ -105,6 +105,7 @@ export type JobDefinitionCreateInput = {
   name: string;
   version?: number;
   type: 'batch' | 'service-triggered' | 'manual';
+  runtime?: 'node' | 'python';
   entryPoint: string;
   timeoutMs?: number | null;
   retryPolicy?: unknown;
@@ -120,6 +121,7 @@ export type JobDefinitionSummary = {
   name: string;
   version: number;
   type: string;
+  runtime: 'node' | 'python';
   entryPoint: string;
   registryRef: string | null;
   parametersSchema: unknown;

--- a/services/catalog/src/jobs/runtimeReadiness.ts
+++ b/services/catalog/src/jobs/runtimeReadiness.ts
@@ -1,0 +1,177 @@
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import process from 'node:process';
+
+import type { JobRuntime } from '../db/types';
+import { logger } from '../observability/logger';
+import { resolveNodeSandboxEntrypoint } from './sandbox/runner';
+import { resolvePythonHarnessPath } from './sandbox/pythonRunner';
+
+export type RuntimeReadiness = {
+  runtime: JobRuntime;
+  ready: boolean;
+  reason: string | null;
+  checkedAt: string;
+  details: Record<string, unknown> | null;
+};
+
+const READINESS_CACHE_TTL_MS = 60_000;
+
+let readinessCache: { expiresAt: number; result: RuntimeReadiness[] } | null = null;
+let readinessInflight: Promise<RuntimeReadiness[]> | null = null;
+
+function cloneStatus(status: RuntimeReadiness): RuntimeReadiness {
+  return {
+    runtime: status.runtime,
+    ready: status.ready,
+    reason: status.reason,
+    checkedAt: status.checkedAt,
+    details: status.details ? { ...status.details } : null
+  } satisfies RuntimeReadiness;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+async function probePythonVersion(): Promise<{ version: string }> {
+  return await new Promise<{ version: string }>((resolve, reject) => {
+    const child = spawn('python3', ['--version'], { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    const cleanup = () => {
+      try {
+        child.removeAllListeners();
+      } catch {
+        // ignore listener cleanup errors
+      }
+    };
+    const timeout = setTimeout(() => {
+      cleanup();
+      try {
+        child.kill('SIGKILL');
+      } catch {
+        // ignore forced kill errors
+      }
+      reject(new Error('python3 readiness check timed out after 5s'));
+    }, 5_000);
+
+    const clear = () => {
+      clearTimeout(timeout);
+      cleanup();
+    };
+
+    if (child.stdout) {
+      child.stdout.setEncoding('utf8');
+      child.stdout.on('data', (chunk: string) => {
+        stdout += chunk;
+      });
+    }
+    if (child.stderr) {
+      child.stderr.setEncoding('utf8');
+      child.stderr.on('data', (chunk: string) => {
+        stderr += chunk;
+      });
+    }
+
+    child.once('error', (err) => {
+      clear();
+      reject(new Error(`Failed to spawn python3: ${err.message}`));
+    });
+
+    child.once('exit', (code, signal) => {
+      clear();
+      if (code === 0) {
+        const text = `${stdout}${stderr}`.trim();
+        resolve({ version: text || 'python3' });
+        return;
+      }
+      const reason = signal
+        ? `python3 --version terminated with signal ${signal}`
+        : `python3 --version exited with code ${code}`;
+      const message = stderr.trim() || stdout.trim();
+      reject(new Error(message ? `${reason}: ${message}` : reason));
+    });
+  });
+}
+
+async function checkNodeRuntime(): Promise<RuntimeReadiness> {
+  const entryPoint = resolveNodeSandboxEntrypoint();
+  const exists = existsSync(entryPoint);
+  return {
+    runtime: 'node',
+    ready: exists,
+    reason: exists ? null : `Node sandbox entrypoint missing at ${entryPoint}`,
+    checkedAt: nowIso(),
+    details: { version: process.version }
+  } satisfies RuntimeReadiness;
+}
+
+async function checkPythonRuntime(): Promise<RuntimeReadiness> {
+  const harnessPath = resolvePythonHarnessPath();
+  if (!existsSync(harnessPath)) {
+    const message = `Python harness not found at ${harnessPath}`;
+    logger.warn(message);
+    return {
+      runtime: 'python',
+      ready: false,
+      reason: message,
+      checkedAt: nowIso(),
+      details: null
+    } satisfies RuntimeReadiness;
+  }
+
+  try {
+    const probe = await probePythonVersion();
+    return {
+      runtime: 'python',
+      ready: true,
+      reason: null,
+      checkedAt: nowIso(),
+      details: { executable: 'python3', version: probe.version }
+    } satisfies RuntimeReadiness;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.warn('Python runtime readiness check failed', { message });
+    return {
+      runtime: 'python',
+      ready: false,
+      reason: message,
+      checkedAt: nowIso(),
+      details: null
+    } satisfies RuntimeReadiness;
+  }
+}
+
+async function computeRuntimeReadiness(): Promise<RuntimeReadiness[]> {
+  const [nodeStatus, pythonStatus] = await Promise.all([checkNodeRuntime(), checkPythonRuntime()]);
+  return [nodeStatus, pythonStatus];
+}
+
+export async function getRuntimeReadiness(forceRefresh = false): Promise<RuntimeReadiness[]> {
+  const now = Date.now();
+  if (!forceRefresh && readinessCache && readinessCache.expiresAt > now) {
+    return readinessCache.result.map(cloneStatus);
+  }
+  if (!forceRefresh && readinessInflight) {
+    return readinessInflight.then((result) => result.map(cloneStatus));
+  }
+
+  readinessInflight = computeRuntimeReadiness()
+    .then((result) => {
+      readinessCache = {
+        expiresAt: Date.now() + READINESS_CACHE_TTL_MS,
+        result: result.map(cloneStatus)
+      };
+      return readinessCache.result.map(cloneStatus);
+    })
+    .finally(() => {
+      readinessInflight = null;
+    });
+
+  return readinessInflight;
+}
+
+export function clearRuntimeReadinessCache(): void {
+  readinessCache = null;
+}

--- a/services/catalog/src/jobs/sandbox/pythonRunner.ts
+++ b/services/catalog/src/jobs/sandbox/pythonRunner.ts
@@ -24,7 +24,7 @@ function sanitizeForIpc<T>(value: T): T {
   }
 }
 
-function buildPythonHarnessPath(): string {
+export function resolvePythonHarnessPath(): string {
   const local = path.resolve(__dirname, 'pythonChild.py');
   if (existsSync(local)) {
     return local;
@@ -103,7 +103,7 @@ export class PythonSandboxRunner {
       childEnv.APPHUB_SANDBOX_HOST_ROOT_PREFIX = hostRootPrefix;
     }
 
-    const harness = buildPythonHarnessPath();
+    const harness = resolvePythonHarnessPath();
     const child = spawn('python3', [harness], {
       stdio: ['pipe', 'pipe', 'pipe'],
       env: childEnv

--- a/services/catalog/src/jobs/sandbox/runner.ts
+++ b/services/catalog/src/jobs/sandbox/runner.ts
@@ -78,7 +78,7 @@ function sanitizeForIpc<T>(value: T): T {
   }
 }
 
-function buildChildScriptPath(): string {
+export function resolveNodeSandboxEntrypoint(): string {
   const compiled = path.resolve(__dirname, 'childRunner.js');
   if (existsSync(compiled)) {
     return compiled;
@@ -133,7 +133,7 @@ export class SandboxRunner {
     if (shouldPrefixHostPaths && hostRootPrefix) {
       childEnv.APPHUB_SANDBOX_HOST_ROOT_PREFIX = hostRootPrefix;
     }
-    const child = fork(buildChildScriptPath(), [], {
+    const child = fork(resolveNodeSandboxEntrypoint(), [], {
       stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
       env: childEnv,
       execArgv: process.execArgv

--- a/services/catalog/src/jobs/schemaIntrospector.ts
+++ b/services/catalog/src/jobs/schemaIntrospector.ts
@@ -1,0 +1,168 @@
+import type { JsonValue } from '../db/types';
+const BUNDLE_ENTRY_REGEX = /^bundle:([a-z0-9][a-z0-9._-]*)@([^#]+?)(?:#([a-zA-Z_$][\w$]*))?$/i;
+
+type BundleBinding = {
+  slug: string;
+  version: string;
+  exportName: string | null;
+};
+
+function parseBundleEntryPoint(entryPoint: string | null | undefined): BundleBinding | null {
+  if (!entryPoint || typeof entryPoint !== 'string') {
+    return null;
+  }
+  const trimmed = entryPoint.trim();
+  const matches = BUNDLE_ENTRY_REGEX.exec(trimmed);
+  if (!matches) {
+    return null;
+  }
+  const [, rawSlug, rawVersion, rawExport] = matches;
+  const slug = rawSlug.toLowerCase();
+  const version = rawVersion.trim();
+  if (!version) {
+    return null;
+  }
+  return {
+    slug,
+    version,
+    exportName: rawExport ?? null
+  } satisfies BundleBinding;
+}
+
+export type SchemaPreview = {
+  parametersSchema: JsonValue | null;
+  outputSchema: JsonValue | null;
+  parametersSource: string | null;
+  outputSource: string | null;
+};
+
+function toJsonObject(value: JsonValue | null | undefined): Record<string, JsonValue> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, JsonValue>;
+}
+
+function cloneJson<T extends JsonValue>(value: T): T {
+  return JSON.parse(JSON.stringify(value ?? null)) as T;
+}
+
+type ExtractionTarget = {
+  parametersSchema: JsonValue | null;
+  outputSchema: JsonValue | null;
+  parametersSource: string | null;
+  outputSource: string | null;
+};
+
+type SchemaCandidate = {
+  value: JsonValue;
+  source: string;
+};
+
+function pickSchema(
+  record: Record<string, JsonValue>,
+  keys: string[],
+  prefix: string
+): SchemaCandidate | null {
+  for (const key of keys) {
+    if (!Object.prototype.hasOwnProperty.call(record, key)) {
+      continue;
+    }
+    const candidate = record[key];
+    if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) {
+      continue;
+    }
+    return { value: candidate, source: `${prefix}.${key}` } satisfies SchemaCandidate;
+  }
+  return null;
+}
+
+function assignIfMissing(
+  target: ExtractionTarget,
+  kind: 'parametersSchema' | 'outputSchema',
+  candidate: SchemaCandidate | null
+): void {
+  if (!candidate) {
+    return;
+  }
+  if (kind === 'parametersSchema') {
+    if (!target.parametersSchema) {
+      target.parametersSchema = cloneJson(candidate.value);
+      target.parametersSource = candidate.source;
+    }
+    return;
+  }
+  if (!target.outputSchema) {
+    target.outputSchema = cloneJson(candidate.value);
+    target.outputSource = candidate.source;
+  }
+}
+
+function inspectRecord(record: Record<string, JsonValue>, prefix: string, target: ExtractionTarget): void {
+  assignIfMissing(target, 'parametersSchema', pickSchema(record, ['parametersSchema', 'inputSchema', 'parameters', 'inputs'], prefix));
+  assignIfMissing(target, 'outputSchema', pickSchema(record, ['outputSchema', 'resultSchema', 'output', 'outputs'], prefix));
+
+  const schemas = toJsonObject(record.schemas);
+  if (schemas) {
+    inspectRecord(schemas, `${prefix}.schemas`, target);
+  }
+
+  const metadata = toJsonObject(record.metadata);
+  if (metadata) {
+    inspectRecord(metadata, `${prefix}.metadata`, target);
+  }
+}
+
+type BundleSchemaSource = {
+  metadata?: JsonValue | null;
+  manifest?: JsonValue | null;
+};
+
+export function extractSchemasFromBundleVersion(source: BundleSchemaSource): SchemaPreview {
+  const result: ExtractionTarget = {
+    parametersSchema: null,
+    outputSchema: null,
+    parametersSource: null,
+    outputSource: null
+  } satisfies ExtractionTarget;
+
+  const inspect = (value: JsonValue | null | undefined, origin: string) => {
+    const record = toJsonObject(value);
+    if (!record) {
+      return;
+    }
+    inspectRecord(record, origin, result);
+  };
+
+  inspect(source.metadata ?? null, 'bundleVersion.metadata');
+  inspect(source.manifest ?? null, 'bundleVersion.manifest');
+
+  const manifestRecord = toJsonObject(source.manifest);
+  if (manifestRecord?.metadata !== undefined) {
+    inspect(manifestRecord.metadata ?? null, 'bundleVersion.manifest.metadata');
+  }
+
+  return {
+    parametersSchema: result.parametersSchema,
+    outputSchema: result.outputSchema,
+    parametersSource: result.parametersSource,
+    outputSource: result.outputSource
+  } satisfies SchemaPreview;
+}
+
+export async function introspectEntryPointSchemas(entryPoint: string): Promise<SchemaPreview | null> {
+  const binding = parseBundleEntryPoint(entryPoint);
+  if (!binding) {
+    return null;
+  }
+  const { getJobBundleVersion } = await import('../db/jobBundles');
+  const version = await getJobBundleVersion(binding.slug, binding.version);
+  if (!version) {
+    return null;
+  }
+
+  return extractSchemasFromBundleVersion({
+    metadata: version.metadata ?? null,
+    manifest: version.manifest ?? null
+  });
+}

--- a/services/catalog/tests/jobs.e2e.ts
+++ b/services/catalog/tests/jobs.e2e.ts
@@ -162,6 +162,32 @@ async function testJobEndpoints(): Promise<void> {
     });
     assert.equal(conflictResponse.statusCode, 409);
 
+    const schemaPreviewResponse = await app.inject({
+      method: 'POST',
+      url: '/jobs/schema-preview',
+      headers: {
+        Authorization: `Bearer ${OPERATOR_TOKEN}`
+      },
+      payload: {
+        entryPoint: 'tests.jobs.nonbundle',
+        runtime: 'python'
+      }
+    });
+    assert.equal(schemaPreviewResponse.statusCode, 200);
+    const schemaPreviewBody = JSON.parse(schemaPreviewResponse.payload) as {
+      data: {
+        parametersSchema: unknown;
+        outputSchema: unknown;
+        parametersSource: unknown;
+        outputSource: unknown;
+      };
+    };
+    assert(schemaPreviewBody.data);
+    assert.equal(schemaPreviewBody.data.parametersSchema, null);
+    assert.equal(schemaPreviewBody.data.outputSchema, null);
+    assert.equal(schemaPreviewBody.data.parametersSource, null);
+    assert.equal(schemaPreviewBody.data.outputSource, null);
+
     const fetchJobResponse = await app.inject({ method: 'GET', url: '/jobs/jobs-test-basic' });
     assert.equal(fetchJobResponse.statusCode, 200);
     const fetchJobBody = JSON.parse(fetchJobResponse.payload) as {

--- a/services/catalog/tests/schemaIntrospector.test.ts
+++ b/services/catalog/tests/schemaIntrospector.test.ts
@@ -1,0 +1,98 @@
+process.env.APPHUB_EVENTS_MODE = 'inline';
+process.env.REDIS_URL = 'inline';
+process.env.APPHUB_ANALYTICS_INTERVAL_MS = '0';
+
+import assert from 'node:assert/strict';
+import type { JsonValue } from '../src/db/types';
+
+const { extractSchemasFromBundleVersion } = require('../src/jobs/schemaIntrospector') as typeof import('../src/jobs/schemaIntrospector');
+
+type SchemaPreview = ReturnType<typeof extractSchemasFromBundleVersion>;
+
+function extract(metadata: JsonValue | null, manifest: JsonValue | null): SchemaPreview {
+  return extractSchemasFromBundleVersion({ metadata, manifest });
+}
+
+const basicMetadata = {
+  parametersSchema: {
+    type: 'object',
+    properties: {
+      path: { type: 'string' }
+    },
+    required: ['path']
+  },
+  outputSchema: {
+    type: 'object',
+    properties: {
+      contents: { type: 'string' }
+    }
+  }
+} satisfies JsonValue;
+
+(() => {
+  const preview = extract(basicMetadata, null);
+  assert.deepEqual(preview.parametersSchema, basicMetadata.parametersSchema);
+  assert.equal(preview.parametersSource, 'bundleVersion.metadata.parametersSchema');
+  assert.deepEqual(preview.outputSchema, basicMetadata.outputSchema);
+  assert.equal(preview.outputSource, 'bundleVersion.metadata.outputSchema');
+})();
+
+(() => {
+  const metadata = {
+    schemas: {
+      parameters: {
+        type: 'object',
+        properties: {
+          url: { type: 'string', format: 'uri' }
+        }
+      }
+    }
+  } satisfies JsonValue;
+  const manifest = {
+    metadata: {
+      output: {
+        type: 'array',
+        items: { type: 'string' }
+      }
+    }
+  } satisfies JsonValue;
+
+  const preview = extract(metadata, manifest);
+  assert.deepEqual(preview.parametersSchema, metadata.schemas.parameters);
+  assert.equal(preview.parametersSource, 'bundleVersion.metadata.schemas.parameters');
+  assert.deepEqual(preview.outputSchema, manifest.metadata.output);
+  assert.equal(preview.outputSource, 'bundleVersion.manifest.metadata.output');
+})();
+
+(() => {
+  const manifest = {
+    schemas: {
+      inputSchema: {
+        type: 'object',
+        properties: {
+          query: { type: 'string' }
+        }
+      },
+      resultSchema: {
+        type: 'object',
+        properties: {
+          status: { type: 'string', enum: ['ok', 'error'] }
+        }
+      }
+    }
+  } satisfies JsonValue;
+
+  const preview = extract(null, manifest);
+  assert.deepEqual(preview.parametersSchema, manifest.schemas.inputSchema);
+  assert.equal(preview.parametersSource, 'bundleVersion.manifest.schemas.inputSchema');
+  assert.deepEqual(preview.outputSchema, manifest.schemas.resultSchema);
+  assert.equal(preview.outputSource, 'bundleVersion.manifest.schemas.resultSchema');
+})();
+
+(() => {
+  const preview = extract('not-json-object' as JsonValue, 123 as JsonValue);
+  assert.equal(preview.parametersSchema, null);
+  assert.equal(preview.parametersSource, null);
+  assert.equal(preview.outputSchema, null);
+  assert.equal(preview.outputSource, null);
+})();


### PR DESCRIPTION
## Summary
- expose a lightweight schema extraction helper to avoid requiring bundle metadata during import
- ensure schema preview endpoint tolerates non-bundle entry points via an e2e assertion
- cover schema discovery with targeted unit tests against representative metadata layouts

## Testing
- `npm run lint`
- `npx tsx tests/schemaIntrospector.test.ts`
- `npm run test:e2e` *(fails: Embedded Postgres refuses to start when running as root)*

------
https://chatgpt.com/codex/tasks/task_e_68d11b3e66748333b9db14a46589d344