### PR TITLE
feat: refresh marketing site status messaging

### DIFF
--- a/apps/website/src/components/navigation/navLinks.ts
+++ b/apps/website/src/components/navigation/navLinks.ts
@@ -1,0 +1,33 @@
+export type NavLink = {
+  href: string;
+  label: string;
+  description: string;
+};
+
+export const navLinks: NavLink[] = [
+  {
+    href: '/',
+    label: 'Platform',
+    description: 'Overview of the Osiris AppHub control plane.'
+  },
+  {
+    href: '/business',
+    label: 'For Business Leaders',
+    description: 'Business value pillars and ROI hypotheses.'
+  },
+  {
+    href: '/technical',
+    label: 'For Engineering Teams',
+    description: 'Technical architecture, integration surfaces, and security posture.'
+  },
+  {
+    href: '/adoption',
+    label: 'Adoption Services',
+    description: 'Rollout playbooks, enablement support, and engagement tiers.'
+  },
+  {
+    href: '/module-sdk',
+    label: 'Module SDK',
+    description: 'Code snippets and cookbook for module authors.'
+  }
+];

--- a/apps/website/src/data/moduleSdkSnippets.ts
+++ b/apps/website/src/data/moduleSdkSnippets.ts
@@ -1,0 +1,594 @@
+export type ModuleSdkSnippet = {
+  id: string;
+  title: string;
+  description: string;
+  language?: string;
+  highlightLines?: number[];
+  code: string;
+  tags: string[];
+  category: 'module' | 'jobs' | 'services' | 'capabilities' | 'workflows' | 'assets';
+};
+
+export const moduleSdkSnippets: ModuleSdkSnippet[] = [
+  {
+    id: 'module-definition',
+    title: 'Define a module with imported targets',
+    description:
+      'Keep module metadata, capability wiring, and target registration in one place while jobs and workflows live beside each other.',
+    language: 'typescript',
+    highlightLines: [1, 13, 28, 48],
+    tags: ['module', 'definition', 'targets'],
+    category: 'module',
+    code: String.raw`import { defineModule } from '@apphub/module-sdk';
+import {
+  ingestMinuteJob,
+  aggregateHourJob,
+  publishDashboardJob
+} from './targets/jobs';
+import {
+  ingestToTimestoreWorkflow,
+  hourlyAggregationWorkflow,
+  dashboardPublishingWorkflow
+} from './targets/workflows';
+
+export default defineModule({
+  metadata: {
+    name: 'environmental-observatory',
+    version: '0.7.0',
+    displayName: 'Environmental Observatory'
+  },
+  settings: {
+    defaults: {
+      ingestPrefix: 'observatory/minute',
+      dashboardSlug: 'observatory-dashboard'
+    }
+  },
+  secrets: {
+    defaults: {}
+  },
+  capabilities: {
+    filestore: {
+      baseUrl: { $ref: 'settings.filestore.baseUrl' },
+      backendMountId: { $ref: 'settings.filestore.mountId', fallback: 1 }
+    },
+    timestore: {
+      baseUrl: { $ref: 'settings.timestore.baseUrl' },
+      token: { $ref: 'secrets.timestoreToken' }
+    },
+    metastore: {
+      baseUrl: { $ref: 'settings.metastore.baseUrl' },
+      namespace: { $ref: 'settings.metastore.namespace' },
+      token: { $ref: 'secrets.metastoreToken', optional: true }
+    },
+    events: {
+      baseUrl: { $ref: 'settings.core.baseUrl' },
+      defaultSource: { $ref: 'settings.events.source', fallback: 'observatory.module' },
+      token: { $ref: 'secrets.eventsToken', optional: true }
+    }
+  },
+  targets: [
+    ingestMinuteJob,
+    aggregateHourJob,
+    publishDashboardJob,
+    ingestToTimestoreWorkflow,
+    hourlyAggregationWorkflow,
+    dashboardPublishingWorkflow
+  ]
+});`
+  },
+  {
+    id: 'filestore-ensure-directory',
+    title: 'Create directories in Filestore',
+    description: 'Use the filestore capability to create a namespaced directory before uploading artefacts.',
+    language: 'typescript',
+    highlightLines: [7, 10],
+    tags: ['filestore'],
+    category: 'jobs',
+    code: String.raw`import { createJobHandler } from '@apphub/module-sdk';
+
+export const ensureIngestDirectory = createJobHandler({
+  name: 'ensure-filestore-directory',
+  handler: async (ctx) => {
+    const mount = ctx.parameters.mount ?? 'observatory-data';
+    const path = \`datasets/\${ctx.parameters.dataset}/\${ctx.parameters.minute}\`;
+
+    await ctx.capabilities.filestore?.ensureDirectory({
+      mount,
+      path
+    });
+  }
+});`
+  },
+  {
+    id: 'event-bus-publish',
+    title: 'Emit custom events',
+    description: 'Publish domain-specific events back into the AppHub event bus from module code.',
+    language: 'typescript',
+    highlightLines: [11],
+    tags: ['event-bus'],
+    category: 'jobs',
+    code: String.raw`import { createJobHandler } from '@apphub/module-sdk';
+
+export const alertOnAnomaly = createJobHandler({
+  name: 'observatory-anomaly-alert',
+  handler: async (ctx) => {
+    const payload = {
+      siteId: ctx.parameters.siteId,
+      minute: ctx.parameters.minute,
+      score: ctx.parameters.score
+    };
+
+    await ctx.capabilities.eventBus?.publish({
+      type: 'observatory.anomaly.detected',
+      source: 'observatory.analytics',
+      payload,
+      correlationId: ctx.runId
+    });
+  }
+});`
+  },
+  {
+    id: 'job-with-secrets',
+    title: 'Guard secrets with a resolver',
+    description: 'Coerce raw secrets into typed values and block execution until mandatory keys are present.',
+    language: 'typescript',
+    highlightLines: [9, 13, 19],
+    tags: ['jobs', 'secrets'],
+    category: 'jobs',
+    code: String.raw`import { createJobHandler } from '@apphub/module-sdk';
+
+type ForwarderSettings = {
+  partnerEndpoint: string;
+};
+
+type ForwarderSecrets = {
+  ingestToken: string;
+  grafanaApiKey?: string;
+};
+
+export const pushToPartner = createJobHandler<ForwarderSettings, ForwarderSecrets>({
+  name: 'observatory-partner-forwarder',
+  secrets: {
+    resolve(raw) {
+      const input = (raw ?? {}) as Partial<ForwarderSecrets>;
+      if (!input.ingestToken) {
+        throw new Error('Missing ingestToken secret for partner forwarding.');
+      }
+      return {
+        ingestToken: String(input.ingestToken),
+        grafanaApiKey: input.grafanaApiKey ? String(input.grafanaApiKey) : undefined
+      };
+    }
+  },
+  handler: async (ctx) => {
+    const endpoint = ctx.settings.partnerEndpoint.replace(/\/$/, '') + '/events';
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer ' + ctx.secrets.ingestToken,
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify(ctx.parameters.eventPayload)
+    });
+
+    if (!response.ok) {
+      throw new Error('Forwarding failed with status ' + response.status);
+    }
+  }
+});`
+  },
+  {
+    id: 'timestore-sql-query',
+    title: 'Query timestore partitions via SQL',
+    description: 'Call the timestore capability from a job or service to run ANSI SQL against Parquet partitions.',
+    language: 'typescript',
+    highlightLines: [9, 16],
+    tags: ['timestore', 'sql'],
+    category: 'capabilities',
+    code: String.raw`import { createJobHandler } from '@apphub/module-sdk';
+
+export const summarizeReadings = createJobHandler({
+  name: 'observatory-summary-query',
+  handler: async (ctx) => {
+    const sql = \`SELECT
+      minute,
+      avg(temperature) AS avg_temperature,
+      max(temperature) AS max_temperature
+    FROM observatory_minute
+    WHERE site_id = @siteId
+    GROUP BY minute
+    ORDER BY minute DESC
+    LIMIT 120\`;
+
+    const rows = await ctx.capabilities.timestore?.query({
+      sql,
+      parameters: { siteId: ctx.parameters.siteId }
+    });
+
+    return { status: 'succeeded', result: { rows } };
+  }
+});`
+  },
+  {
+    id: 'dashboard-service',
+    title: 'Register a dashboard service',
+    description: 'Expose a Fastify-powered UI with health checks and filestore-backed report streaming.',
+    language: 'typescript',
+    highlightLines: [1, 12, 26, 42],
+    tags: ['services', 'fastify', 'filestore'],
+    category: 'services',
+    code: String.raw`import { createService, type ServiceLifecycle } from '@apphub/module-sdk';
+import Fastify from 'fastify';
+
+type ObservatorySettings = {
+  filestore: { backendMountId: number };
+  dashboard: { port: number };
+  principals: { dashboardAggregator: string };
+};
+
+export const dashboardService = createService<
+  ObservatorySettings,
+  Record<string, never>,
+  ServiceLifecycle
+>({
+  name: 'observatory-dashboard-service',
+  registration: {
+    slug: 'observatory-dashboard',
+    kind: 'dashboard',
+    healthEndpoint: '/healthz',
+    defaultPort: 4311,
+    basePath: '/',
+    tags: ['dashboard', 'ui'],
+    ui: { previewPath: '/', spa: true }
+  },
+  handler: (ctx) => {
+    const app = Fastify({ logger: false });
+
+    app.get('/healthz', async () => ({
+      status: 'ok',
+      moduleVersion: ctx.module.version
+    }));
+
+    app.get('/reports/:partition', async (request, reply) => {
+      const filestore = ctx.capabilities.filestore;
+      if (!filestore) {
+        reply.code(503).send({ error: 'Filestore unavailable' });
+        return;
+      }
+
+      const params = request.params as { partition: string };
+      const node = await filestore.getNodeByPath({
+        backendMountId: ctx.settings.filestore.backendMountId,
+        path: 'reports/' + params.partition + '.json',
+        principal: ctx.settings.principals.dashboardAggregator
+      });
+
+      const download = await filestore.downloadFile({
+        nodeId: node.id,
+        principal: ctx.settings.principals.dashboardAggregator
+      });
+
+      reply.header('content-type', download.mediaType ?? 'application/json');
+      reply.send(download.stream);
+    });
+
+    return {
+      async start() {
+        const port = Number(process.env.PORT ?? ctx.settings.dashboard.port ?? 4311);
+        await app.listen({ host: '0.0.0.0', port });
+      },
+      async stop() {
+        await app.close();
+      }
+    } satisfies ServiceLifecycle;
+  }
+});`
+  },
+  {
+    id: 'metastore-upsert',
+    title: 'Persist configuration with Metastore',
+    description: 'Upsert a configuration document with optimistic concurrency guarantees.',
+    language: 'typescript',
+    highlightLines: [14],
+    tags: ['metastore', 'configuration'],
+    category: 'capabilities',
+    code: String.raw`import { createJobHandler } from '@apphub/module-sdk';
+
+export const upsertThresholds = createJobHandler({
+  name: 'observatory-threshold-upsert',
+  handler: async (ctx) => {
+    const namespace = 'observatory.thresholds';
+    const key = ctx.parameters.siteId;
+
+    await ctx.capabilities.metastore?.upsertRecord({
+      namespace,
+      key,
+      record: {
+        ...ctx.parameters.thresholds,
+        updatedAt: new Date().toISOString()
+      }
+    });
+  }
+});`
+  },
+  {
+    id: 'capability-overrides',
+    title: 'Instrument capability overrides',
+    description: 'Wrap built-in capabilities to add metrics or feature flags without forking the SDK.',
+    language: 'typescript',
+    highlightLines: [1, 14, 18, 29],
+    tags: ['capabilities', 'overrides', 'observability'],
+    category: 'capabilities',
+    code: String.raw`import { createJobHandler } from '@apphub/module-sdk';
+
+type IngestSettings = {
+  timestore: { dataset: string };
+};
+
+type IngestSecrets = {
+  timestoreToken?: string;
+};
+
+export const ingestMinuteWithMetrics = createJobHandler<
+  IngestSettings,
+  IngestSecrets,
+  unknown,
+  { records: unknown[] }
+>({
+  name: 'observatory-minute-ingest',
+  capabilityOverrides: {
+    timestore: (config, createDefault) => {
+      const base = createDefault();
+      if (!base) {
+        return undefined;
+      }
+      return {
+        ...base,
+        async ingestRecords(input) {
+          const started = Date.now();
+          const result = await base.ingestRecords(input);
+          const elapsed = Date.now() - started;
+          console.log('Ingested ' + (input.records?.length ?? 0) + ' rows in ' + elapsed + 'ms');
+          return result;
+        }
+      };
+    }
+  },
+  handler: async (ctx) => {
+    await ctx.capabilities.timestore?.ingestRecords({
+      dataset: ctx.settings.timestore.dataset,
+      records: ctx.parameters.records
+    });
+  }
+});`
+  },
+  {
+    id: 'workflow-with-triggers',
+    title: 'Respond to events with workflow triggers',
+    description: 'Declare a workflow that reacts whenever a new timestore partition is ready.',
+    language: 'typescript',
+    highlightLines: [1, 12, 16],
+    tags: ['workflows', 'triggers'],
+    category: 'workflows',
+    code: String.raw`import { createWorkflow, createWorkflowTrigger } from '@apphub/module-sdk';
+
+export const materializeWorkflow = createWorkflow({
+  name: 'observatory-materialize',
+  definition: {
+    slug: 'observatory-materialize',
+    steps: [
+      {
+        id: 'refresh-dataset',
+        jobSlug: 'observatory-minute-ingest'
+      }
+    ]
+  },
+  triggers: [
+    createWorkflowTrigger({
+      name: 'minute-ready',
+      eventType: 'observatory.ingest.completed',
+      predicates: [
+        { path: 'payload.minute', operator: 'exists' }
+      ]
+    })
+  ]
+});`
+  },
+  {
+    id: 'workflow-with-schedule',
+    title: 'Schedule recurring workflows',
+    description: 'Run nightly maintenance workflows using `createWorkflowSchedule`.',
+    language: 'typescript',
+    highlightLines: [1, 13, 19],
+    tags: ['workflows', 'schedules'],
+    category: 'workflows',
+    code: String.raw`import { createWorkflow, createWorkflowSchedule } from '@apphub/module-sdk';
+
+export const nightlyReconciliation = createWorkflow({
+  name: 'observatory-nightly-reconciliation',
+  definition: {
+    slug: 'observatory-nightly-reconciliation',
+    steps: [
+      {
+        id: 'reconcile-hashes',
+        jobSlug: 'observatory-hash-reconciliation'
+      }
+    ]
+  },
+  schedules: [
+    createWorkflowSchedule({
+      name: 'nightly',
+      cron: '0 3 * * *',
+      timezone: 'UTC',
+      enabled: true
+    })
+  ]
+});`
+  },
+  {
+    id: 'workflow-triggers-and-schedules',
+    title: 'Blend triggers and schedules',
+    description: 'Combine event triggers with cron schedules for resilient workflows.',
+    language: 'typescript',
+    highlightLines: [12, 24],
+    tags: ['workflows', 'triggers', 'schedules'],
+    category: 'workflows',
+    code: String.raw`import {
+  createWorkflow,
+  createWorkflowTrigger,
+  createWorkflowSchedule
+} from '@apphub/module-sdk';
+
+export const aggregateMetrics = createWorkflow({
+  name: 'observatory-dashboard-aggregate',
+  definition: {
+    slug: 'observatory-dashboard-aggregate',
+    steps: [{ id: 'aggregate', jobSlug: 'observatory-dashboard-aggregate' }]
+  },
+  triggers: [
+    createWorkflowTrigger({
+      name: 'partition-ready',
+      eventType: 'observatory.minute.partition-ready',
+      predicates: [
+        {
+          path: 'payload.datasetSlug',
+          operator: 'equals',
+          value: 'observatory-timeseries'
+        }
+      ]
+    })
+  ],
+  schedules: [
+    createWorkflowSchedule({
+      name: 'hourly-backfill',
+      cron: '0 * * * *',
+      timezone: 'UTC'
+    })
+  ]
+});`
+  },
+  {
+    id: 'workflow-completion-callback',
+    title: 'Chain workflows on completion',
+    description: 'Wait for an upstream workflow to succeed, then enqueue a follow-up run with recorded metadata.',
+    language: 'typescript',
+    highlightLines: [1, 18, 36, 52],
+    tags: ['workflows', 'callbacks', 'core-workflows'],
+    category: 'workflows',
+    code: String.raw`import { createJobHandler, createWorkflow, createWorkflowTrigger } from '@apphub/module-sdk';
+
+type WorkflowSettings = {
+  principals: { observability: string };
+};
+
+type WorkflowSecrets = Record<string, never>;
+
+export const awaitIngestCompletion = createJobHandler<
+  WorkflowSettings,
+  WorkflowSecrets,
+  unknown,
+  { runId: string; partitionKey: string }
+>({
+  name: 'observatory-await-ingest',
+  handler: async (ctx) => {
+    const coreWorkflows = ctx.capabilities.coreWorkflows;
+    if (!coreWorkflows) {
+      throw new Error('coreWorkflows capability required');
+    }
+
+    const response = await coreWorkflows.getWorkflowRun({
+      runId: ctx.parameters.runId,
+      principal: ctx.settings.principals.observability
+    });
+
+    const envelope = response && typeof response === 'object' ? response : {};
+    const data = 'data' in envelope && envelope.data && typeof envelope.data === 'object'
+      ? (envelope.data as Record<string, unknown>)
+      : (envelope as Record<string, unknown>);
+    const status = typeof data.status === 'string' ? data.status : 'pending';
+
+    if (status !== 'succeeded') {
+      throw new Error('Upstream workflow is still ' + status);
+    }
+
+    await coreWorkflows.enqueueWorkflowRun({
+      workflowSlug: 'observatory-dashboard-refresh',
+      partitionKey: ctx.parameters.partitionKey,
+      triggeredBy: 'workflow:' + ctx.parameters.runId,
+      metadata: {
+        sourceRunId: ctx.parameters.runId
+      }
+    });
+  }
+});
+
+export const dashboardRefreshWorkflow = createWorkflow<WorkflowSettings, WorkflowSecrets>({
+  name: 'observatory-dashboard-refresh',
+  definition: {
+    slug: 'observatory-dashboard-refresh',
+    steps: [
+      {
+        id: 'await-ingest',
+        jobSlug: 'observatory-await-ingest'
+      },
+      {
+        id: 'publish-dashboard',
+        jobSlug: 'observatory-dashboard-publish'
+      }
+    ]
+  },
+  triggers: [
+    createWorkflowTrigger({
+      name: 'minute-ingest-complete',
+      eventType: 'observatory.workflow.completed',
+      predicates: [
+        { path: 'payload.workflowSlug', operator: 'equals', value: 'observatory-minute-ingest' },
+        { path: 'payload.status', operator: 'equals', value: 'succeeded' }
+      ],
+      parameterTemplate: {
+        runId: '{{ event.payload.runId }}',
+        partitionKey: '{{ event.payload.partitionKey }}'
+      }
+    })
+  ]
+});`
+  },
+  {
+    id: 'asset-auto-materialize',
+    title: 'Emit assets with auto-materialisation hints',
+    description: 'Return assets from a job so downstream workflows refresh automatically when data changes.',
+    language: 'typescript',
+    highlightLines: [5, 9, 19],
+    tags: ['assets', 'jobs'],
+    category: 'assets',
+    code: String.raw`import { createJobHandler } from '@apphub/module-sdk';
+
+export const publishVisualizations = createJobHandler({
+  name: 'observatory-visualizations',
+  produces: [
+    {
+      assetId: 'observatory.visualizations.minute',
+      autoMaterialize: { onUpstreamUpdate: true },
+      freshness: { ttlMs: 15 * 60 * 1000 }
+    }
+  ],
+  handler: async (ctx) => {
+    const asset = {
+      assetId: 'observatory.visualizations.minute',
+      partitionKey: ctx.parameters.minute,
+      payload: {
+        plots: ctx.parameters.plots,
+        generatedAt: new Date().toISOString()
+      }
+    };
+
+    return {
+      status: 'succeeded',
+      result: {
+        assets: [asset]
+      }
+    };
+  }
+});`
+  }
+];

--- a/apps/website/src/pages/adoption/index.astro
+++ b/apps/website/src/pages/adoption/index.astro
@@ -1,0 +1,322 @@
+---
+import BaseLayout from '@layouts/BaseLayout.astro';
+import { AdoptionJourneyDiagram } from '@components/diagrams';
+
+const title = 'Adoption services | Osiris AppHub';
+const description = 'Partner with the AppHub team to learn the platform, model your module, and launch in weeks.';
+
+const sessions = [
+  {
+    name: 'Architecture deep dive',
+    detail: 'Understand the core orchestrator, timestore, filestore, and metastore. We map your systems onto the AppHub fabric.'
+  },
+  {
+    name: 'Module SDK lab',
+    detail: 'Hands-on labs show how to declare jobs, assets, and services with the SDK so your team can extend modules confidently.'
+  },
+  {
+    name: 'Operations rehearsal',
+    detail: 'Simulate workflow runs, asset materialisation, and UI monitoring before production. Capture runbooks as part of the module.'
+  }
+];
+
+const phases = [
+  {
+    title: 'Frame the module',
+    copy: 'Clarify outcomes, inputs, assets, and governance. Draft the module descriptor and integration checklist.'
+  },
+  {
+    title: 'Co-build & test',
+    copy: 'Pair with our engineers to wire the workflows, timestore datasets, filestore mounts, and UI surfaces.'
+  },
+  {
+    title: 'Launch & handoff',
+    copy: 'Run rehearsals, document change management, and hand back a module that your team can version without us.'
+  }
+];
+
+const crew = [
+  { role: 'Module strategist', focus: 'Keeps the charter aligned with business outcomes and governance requirements.' },
+  { role: 'Platform engineer', focus: 'Pairs on integrations, module code, and observability hooks.' },
+  { role: 'Operator coach', focus: 'Designs rehearsals, trains end users, and documents operational playbooks.' }
+];
+
+const signals = [
+  'Module charter approved with clear success metrics and dependencies.',
+  'First workflow run rehearsed end-to-end with simulated telemetry.',
+  'Team members comfortable publishing module updates and monitoring assets.'
+];
+---
+<BaseLayout title={title} description={description}>
+  <section class="page-hero">
+    <div class="container page-hero__inner">
+      <div>
+        <p class="page-hero__eyebrow">Adoption programme</p>
+        <h1>Co-build your first AppHub module with us.</h1>
+        <p class="page-hero__intro">
+          AppHub is open source. We teach your team the platform, model the module with you, and launch together—so you can run and extend it with confidence.
+        </p>
+        <div class="page-hero__actions">
+          <a class="button button--primary" href="mailto:osirisapphub@gmail.com">Plan an onboarding sprint</a>
+          <a class="button button--secondary" href="https://github.com/benediktbwimmer/apphub" target="_blank" rel="noreferrer">View on GitHub</a>
+          <a class="button button--ghost" href="/module-sdk">Explore the Module SDK</a>
+        </div>
+        <div class="page-hero__notice">
+          <strong>Help build the Service Adoption team.</strong>
+          <span>
+            We are recruiting contributors, facilitators, and designers to co-create the onboarding experience. If you love shaping playbooks and polishing the UI,
+            reach out at <a href="mailto:osirisapphub@gmail.com">osirisapphub@gmail.com</a>.
+          </span>
+        </div>
+      </div>
+      <figure>
+        <div class="diagram">
+          <AdoptionJourneyDiagram />
+        </div>
+        <figcaption>Learn, co-design, build, and launch in weeks.</figcaption>
+      </figure>
+    </div>
+  </section>
+
+  <section class="sessions" aria-labelledby="sessions-heading">
+    <div class="container sessions__inner">
+      <h2 id="sessions-heading" class="section-heading">What the teaching sessions cover</h2>
+      <div class="sessions__grid">
+        {sessions.map((item) => (
+          <article>
+            <h3>{item.name}</h3>
+            <p>{item.detail}</p>
+          </article>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <section class="phases" aria-labelledby="phases-heading">
+    <div class="container phases__inner">
+      <h2 id="phases-heading" class="section-heading">Three-phase adoption path</h2>
+      <ol>
+        {phases.map((phase) => (
+          <li>
+            <h3>{phase.title}</h3>
+            <p>{phase.copy}</p>
+          </li>
+        ))}
+      </ol>
+      <div class="diagram">
+        <AdoptionJourneyDiagram />
+      </div>
+    </div>
+  </section>
+
+  <section class="crew" aria-labelledby="crew-heading">
+    <div class="container crew__inner">
+      <h2 id="crew-heading" class="section-heading">Your embedded crew</h2>
+      <div class="crew__grid">
+        {crew.map((member) => (
+          <article>
+            <p class="crew__role">{member.role}</p>
+            <p>{member.focus}</p>
+          </article>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <section class="signals" aria-labelledby="signals-heading">
+    <div class="container signals__inner">
+      <h2 id="signals-heading" class="section-heading">Signals we look for before launch</h2>
+      <ul>
+        {signals.map((signal) => (
+          <li>{signal}</li>
+        ))}
+      </ul>
+    </div>
+  </section>
+
+  <section class="cta" aria-labelledby="cta-heading">
+    <div class="container cta__inner">
+      <div>
+        <h2 id="cta-heading" class="section-heading">Ready to build?</h2>
+        <p>
+          Share your module idea and we will assemble the right crew—strategist, engineer, coach—to help you deploy faster while contributing back to the open-source platform.
+        </p>
+      </div>
+      <div class="cta__actions">
+        <a class="button button--primary" href="mailto:osirisapphub@gmail.com">Start the conversation</a>
+        <a class="button button--ghost" href="https://github.com/benediktbwimmer/apphub" target="_blank" rel="noreferrer">Explore on GitHub</a>
+      </div>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .page-hero {
+    padding: var(--apphub-spacing-3xl) 0;
+    background: linear-gradient(150deg, rgba(13, 148, 136, 0.18), rgba(34, 211, 238, 0.12));
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .page-hero {
+      background: linear-gradient(150deg, rgba(20, 184, 166, 0.22), rgba(2, 19, 18, 0.88));
+    }
+  }
+
+  .page-hero__inner {
+    display: grid;
+    gap: var(--apphub-spacing-xl);
+    align-items: center;
+  }
+
+  .page-hero__eyebrow {
+    margin: 0;
+    font-size: var(--apphub-typography-font-size-xs);
+    letter-spacing: var(--apphub-typography-letter-spacing-wide);
+    text-transform: uppercase;
+    color: var(--apphub-color-text-soft);
+  }
+
+  .page-hero__intro {
+    margin: 0 0 var(--apphub-spacing-lg);
+    color: var(--apphub-color-text-muted);
+    max-width: 70ch;
+  }
+
+  .page-hero__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--apphub-spacing-sm);
+  }
+
+  .page-hero__notice {
+    margin-top: var(--apphub-spacing-md);
+    display: flex;
+    flex-direction: column;
+    gap: var(--apphub-spacing-xxs);
+    padding: var(--apphub-spacing-sm);
+    border: 1px solid var(--apphub-color-border);
+    border-radius: var(--apphub-radius-lg);
+    background: var(--apphub-color-surface-muted);
+    color: var(--apphub-color-text);
+    font-size: var(--apphub-typography-font-size-sm);
+  }
+
+  .page-hero__notice a {
+    color: var(--apphub-color-accent-strong);
+  }
+
+  .page-hero figure {
+    margin: 0;
+    display: grid;
+    gap: var(--apphub-spacing-xxs);
+    text-align: center;
+  }
+
+  .page-hero .diagram svg {
+    width: 100%;
+    border-radius: var(--apphub-radius-xl);
+    border: 1px solid var(--apphub-color-border);
+    box-shadow: var(--apphub-shadow-soft);
+    background: var(--apphub-color-surface);
+  }
+
+  .page-hero figcaption {
+    font-size: var(--apphub-typography-font-size-xs);
+    color: var(--apphub-color-text-soft);
+  }
+
+  .sessions,
+  .phases,
+  .crew,
+  .signals,
+  .cta {
+    padding: var(--apphub-spacing-3xl) 0;
+  }
+
+  .sessions__grid,
+  .crew__grid {
+    display: grid;
+    gap: var(--apphub-spacing-lg);
+  }
+
+  .sessions__grid article,
+  .crew__grid article {
+    background: var(--apphub-color-surface);
+    border-radius: var(--apphub-radius-xl);
+    padding: var(--apphub-spacing-lg);
+    border: 1px solid var(--apphub-color-border);
+  }
+
+  .crew__role {
+    margin: 0 0 var(--apphub-spacing-xxs);
+    font-size: var(--apphub-typography-font-size-sm);
+    letter-spacing: var(--apphub-typography-letter-spacing-wide);
+    text-transform: uppercase;
+    color: var(--apphub-color-text-soft);
+    font-weight: var(--apphub-typography-font-weight-semibold);
+  }
+
+  .phases__inner {
+    display: grid;
+    gap: var(--apphub-spacing-lg);
+  }
+
+  .phases ol {
+    margin: 0;
+    padding-left: var(--apphub-spacing-lg);
+    display: grid;
+    gap: var(--apphub-spacing-lg);
+  }
+
+  .phases li {
+    background: var(--apphub-color-surface);
+    border-radius: var(--apphub-radius-xl);
+    padding: var(--apphub-spacing-lg);
+    border: 1px solid var(--apphub-color-border);
+  }
+
+  .signals__inner ul {
+    margin: 0;
+    padding-left: var(--apphub-spacing-lg);
+    display: grid;
+    gap: var(--apphub-spacing-sm);
+    color: var(--apphub-color-text-muted);
+    background: var(--apphub-color-surface);
+    border-radius: var(--apphub-radius-xl);
+    padding: var(--apphub-spacing-lg);
+    border: 1px solid var(--apphub-color-border);
+  }
+
+  .cta {
+    background: linear-gradient(160deg, rgba(13, 148, 136, 0.2), rgba(15, 118, 110, 0.16));
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .cta {
+      background: linear-gradient(160deg, rgba(20, 184, 166, 0.22), rgba(2, 19, 18, 0.88));
+    }
+  }
+
+  .cta__inner {
+    display: grid;
+    gap: var(--apphub-spacing-lg);
+    align-items: center;
+  }
+
+  .cta__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--apphub-spacing-sm);
+  }
+
+  @media (min-width: 768px) {
+    .page-hero__inner {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .sessions__grid,
+    .crew__grid {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+</style>

--- a/apps/website/src/pages/business/index.astro
+++ b/apps/website/src/pages/business/index.astro
@@ -1,0 +1,426 @@
+---
+import BaseLayout from '@layouts/BaseLayout.astro';
+import { BusinessConstellationDiagram, BusinessObservatoryDiagram } from '@components/diagrams';
+
+const title = 'Business value | Osiris AppHub';
+const description =
+  'Understand how AppHub modules accelerate operations programmes and how we partner with leadership teams to model use cases in weeks.';
+
+const reasons = [
+  {
+    heading: 'Everything becomes a module',
+    detail:
+      'Use cases live as versioned modules with jobs, assets, UI surfaces, and runbooks. Governance, rollout, and measurement stay consistent across teams.'
+  },
+  {
+    heading: 'Shared control plane',
+    detail:
+      'Executives, engineers, and operators work from the same data and workflow fabric—no fragmented stacks or duplicate tooling.'
+  },
+  {
+    heading: 'Weeks, not quarters',
+    detail:
+      'We model the first module alongside you and hand over a repeatable blueprint so every follow-on use case arrives faster.'
+  }
+];
+
+const offerings = [
+  {
+    title: 'Strategy & module framing',
+    detail: 'Translate goals into module boundaries, assets, and KPIs that leadership can track from day one.'
+  },
+  {
+    title: 'Enablement intensives',
+    detail: 'Teach your product, operations, and data teams how the AppHub stack works and how to extend it safely.'
+  },
+  {
+    title: 'Co-built delivery',
+    detail: 'Our engineers build the first module with you, packaging workflows, dashboards, and operator experiences as turnkey assets.'
+  }
+];
+
+const modulePatterns = [
+  {
+    name: 'Observatory networks',
+    body: 'Coordinate instrument telemetry, enrich data, and publish live dashboards without stitching multiple vendors together.'
+  },
+  {
+    name: 'Asset lifecycle programmes',
+    body: 'Standardise inspections, maintenance, and compliance evidence across sites while retaining local flexibility.'
+  },
+  {
+    name: 'Field response playbooks',
+    body: 'Blend logistics, comms, and policy to orchestrate crews and partners in real time.'
+  }
+];
+
+const valueSignals = [
+  'Shared source of truth for telemetry, workflows, and reports.',
+  'Faster time-to-market because modules reuse the same infrastructure footprint.',
+  'Lower integration risk: Redis queues, timestore partitions, and module governance are already battle tested in the platform.',
+  'Operators stay in the loop through the AppHub UI—no context lost in spreadsheets or slide decks.'
+];
+
+const engagementTimeline = [
+  {
+    phase: 'Discover',
+    description: 'Clarify the use case, data sources, and success metrics. Align stakeholders on a shared module scope and governance model.'
+  },
+  {
+    phase: 'Design',
+    description: 'Mock the module experience, define assets, and plan integrations. Hands-on workshops with the module SDK accelerate alignment.'
+  },
+  {
+    phase: 'Deliver',
+    description: 'Co-build the module, hook into timestore/filestore, and rehearse workflows. Document change management and handoff playbooks.'
+  }
+];
+
+const observatoryHighlights = [
+  {
+    title: 'Telemetry to action',
+    detail: 'Instrument data arrives via the observatory gateway, lands in Filestore with rich metadata, and kicks off workflow runs when assets refresh.'
+  },
+  {
+    title: 'Audience-aligned visuals',
+    detail: 'Module services render dashboards directly inside the AppHub UI, so site leads and executives read the same view.'
+  },
+  {
+    title: 'Auditable outcomes',
+    detail: 'Every workflow run, file change, and timestore partition is logged. Leadership reviews readiness in minutes, not days.'
+  }
+];
+---
+<BaseLayout title={title} description={description}>
+  <section class="page-hero">
+    <div class="container page-hero__inner">
+      <div>
+        <p class="page-hero__eyebrow">For leadership teams</p>
+        <h1>Model any operations programme as an AppHub module.</h1>
+        <p class="page-hero__intro">
+          AppHub is open source. We collaborate with business leaders to turn critical initiatives into modules that deploy in weeks—self-hosted or with our guidance.
+        </p>
+        <div class="page-hero__actions">
+          <a class="button button--primary" href="mailto:osirisapphub@gmail.com">Schedule a strategy workshop</a>
+          <a class="button button--secondary" href="https://github.com/benediktbwimmer/apphub" target="_blank" rel="noreferrer">View on GitHub</a>
+          <a class="button button--ghost" href="/adoption">Explore adoption services</a>
+        </div>
+      </div>
+      <figure>
+        <div class="diagram">
+          <BusinessConstellationDiagram />
+        </div>
+        <figcaption>Modules keep telemetry, workflows, and reporting aligned across teams.</figcaption>
+      </figure>
+    </div>
+  </section>
+
+  <section class="reasons" aria-labelledby="reasons-heading">
+    <div class="container">
+      <h2 id="reasons-heading" class="section-heading">Why organisations are choosing modules</h2>
+      <div class="cards-grid">
+        {reasons.map((item) => (
+          <article>
+            <h3>{item.heading}</h3>
+            <p>{item.detail}</p>
+          </article>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <section class="offerings" aria-labelledby="offerings-heading">
+    <div class="container offerings__inner">
+      <h2 id="offerings-heading" class="section-heading">How we partner with you</h2>
+      <div class="cards-grid cards-grid--three">
+        {offerings.map((item) => (
+          <article>
+            <h3>{item.title}</h3>
+            <p>{item.detail}</p>
+          </article>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <section class="patterns" aria-labelledby="patterns-heading">
+    <div class="container patterns__inner">
+      <h2 id="patterns-heading" class="section-heading">Module patterns ready to adapt</h2>
+      <div class="cards-grid cards-grid--three">
+        {modulePatterns.map((item) => (
+          <article>
+            <h3>{item.name}</h3>
+            <p>{item.body}</p>
+          </article>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <section class="value" aria-labelledby="value-heading">
+    <div class="container value__inner">
+      <h2 id="value-heading" class="section-heading">The value lens</h2>
+      <ul>
+        {valueSignals.map((signal) => (
+          <li>{signal}</li>
+        ))}
+      </ul>
+    </div>
+  </section>
+
+  <section class="timeline" aria-labelledby="timeline-heading">
+    <div class="container timeline__inner">
+      <h2 id="timeline-heading" class="section-heading">What the first six weeks look like</h2>
+      <ol>
+        {engagementTimeline.map((item) => (
+          <li>
+            <h3>{item.phase}</h3>
+            <p>{item.description}</p>
+          </li>
+        ))}
+      </ol>
+      <p class="timeline__note">
+        Combine internal teams with our strategists, solution engineers, and operator coaches—we meet you where you are on the open-source journey.
+      </p>
+    </div>
+  </section>
+
+  <section class="observatory" aria-labelledby="observatory-heading">
+    <div class="container observatory__inner">
+      <div>
+        <h2 id="observatory-heading" class="section-heading">In focus: The Observatory module</h2>
+        <p>
+          Our flagship module demonstrates the full control plane: ingestion, storage, workflow automation, and operator surfaces orchestrated in one place.
+        </p>
+        <div class="observatory__grid">
+          {observatoryHighlights.map((item) => (
+            <article>
+              <h3>{item.title}</h3>
+              <p>{item.detail}</p>
+            </article>
+          ))}
+        </div>
+      </div>
+      <figure>
+        <div class="diagram">
+          <BusinessObservatoryDiagram />
+        </div>
+        <figcaption>Telemetry → module automations → dashboards, all powered by AppHub components.</figcaption>
+      </figure>
+    </div>
+  </section>
+
+  <section class="cta" aria-labelledby="cta-heading">
+    <div class="container cta__inner">
+      <div>
+        <h2 id="cta-heading" class="section-heading">Accelerate with open source AppHub</h2>
+        <p>
+          Use the repository as your foundation or partner with us for a guided rollout. We align strategy, data, and operations on the same control plane.
+        </p>
+      </div>
+      <div class="cta__actions">
+        <a class="button button--primary" href="mailto:osirisapphub@gmail.com">Start the conversation</a>
+        <a class="button button--ghost" href="https://github.com/benediktbwimmer/apphub" target="_blank" rel="noreferrer">Explore on GitHub</a>
+      </div>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .page-hero {
+    padding: var(--apphub-spacing-3xl) 0;
+    background: linear-gradient(150deg, rgba(13, 148, 136, 0.18), rgba(34, 211, 238, 0.12));
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .page-hero {
+      background: linear-gradient(150deg, rgba(20, 184, 166, 0.24), rgba(2, 19, 18, 0.9));
+    }
+  }
+
+  .page-hero__inner {
+    display: grid;
+    gap: var(--apphub-spacing-xl);
+    align-items: center;
+  }
+
+  .page-hero__eyebrow {
+    margin: 0;
+    font-size: var(--apphub-typography-font-size-xs);
+    letter-spacing: var(--apphub-typography-letter-spacing-wide);
+    text-transform: uppercase;
+    color: var(--apphub-color-text-soft);
+  }
+
+  .page-hero__intro {
+    margin: 0 0 var(--apphub-spacing-lg);
+    color: var(--apphub-color-text-muted);
+    max-width: 70ch;
+  }
+
+  .page-hero__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--apphub-spacing-sm);
+  }
+
+  .page-hero figure {
+    margin: 0;
+    display: grid;
+    gap: var(--apphub-spacing-xxs);
+    text-align: center;
+  }
+
+  .page-hero .diagram svg {
+    width: 100%;
+    border-radius: var(--apphub-radius-xl);
+    border: 1px solid var(--apphub-color-border);
+    box-shadow: var(--apphub-shadow-soft);
+    background: var(--apphub-color-surface);
+  }
+
+  .page-hero figcaption {
+    font-size: var(--apphub-typography-font-size-xs);
+    color: var(--apphub-color-text-soft);
+  }
+
+  .cards-grid {
+    display: grid;
+    gap: var(--apphub-spacing-lg);
+  }
+
+  .cards-grid article {
+    background: var(--apphub-color-surface);
+    border-radius: var(--apphub-radius-xl);
+    padding: var(--apphub-spacing-lg);
+    border: 1px solid var(--apphub-color-border);
+  }
+
+  .reasons,
+  .offerings,
+  .patterns,
+  .value,
+  .timeline,
+  .observatory {
+    padding: var(--apphub-spacing-3xl) 0;
+  }
+
+  .value__inner ul {
+    margin: 0;
+    padding-left: var(--apphub-spacing-lg);
+    display: grid;
+    gap: var(--apphub-spacing-sm);
+    color: var(--apphub-color-text-muted);
+    background: var(--apphub-color-surface);
+    border-radius: var(--apphub-radius-xl);
+    padding: var(--apphub-spacing-lg);
+    border: 1px solid var(--apphub-color-border);
+  }
+
+  .timeline__inner {
+    display: grid;
+    gap: var(--apphub-spacing-lg);
+  }
+
+  .timeline ol {
+    margin: 0;
+    padding-left: var(--apphub-spacing-lg);
+    display: grid;
+    gap: var(--apphub-spacing-lg);
+  }
+
+  .timeline li {
+    background: var(--apphub-color-surface);
+    border-radius: var(--apphub-radius-xl);
+    padding: var(--apphub-spacing-lg);
+    border: 1px solid var(--apphub-color-border);
+  }
+
+  .timeline__note {
+    margin: 0;
+    color: var(--apphub-color-text-soft);
+  }
+
+  .observatory__inner {
+    display: grid;
+    gap: var(--apphub-spacing-xl);
+    align-items: center;
+  }
+
+  .observatory__grid {
+    display: grid;
+    gap: var(--apphub-spacing-md);
+  }
+
+  .observatory__grid article {
+    background: var(--apphub-color-surface);
+    border-radius: var(--apphub-radius-lg);
+    padding: var(--apphub-spacing-md);
+    border: 1px solid var(--apphub-color-border);
+  }
+
+  .observatory figure {
+    margin: 0;
+    display: grid;
+    gap: var(--apphub-spacing-xxs);
+    text-align: center;
+  }
+
+  .observatory .diagram svg {
+    width: 100%;
+    border-radius: var(--apphub-radius-xl);
+    border: 1px solid var(--apphub-color-border);
+    box-shadow: var(--apphub-shadow-soft);
+    background: var(--apphub-color-surface);
+  }
+
+  .observatory figcaption {
+    font-size: var(--apphub-typography-font-size-xs);
+    color: var(--apphub-color-text-soft);
+  }
+
+  .cta {
+    padding: var(--apphub-spacing-4xl) 0;
+    background: linear-gradient(160deg, rgba(13, 148, 136, 0.2), rgba(15, 118, 110, 0.16));
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .cta {
+      background: linear-gradient(160deg, rgba(20, 184, 166, 0.22), rgba(2, 19, 18, 0.88));
+    }
+  }
+
+  .cta__inner {
+    display: grid;
+    gap: var(--apphub-spacing-lg);
+    align-items: center;
+  }
+
+  .diagram {
+    width: 100%;
+    max-width: 540px;
+    margin: 0 auto;
+  }
+
+  .cta__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--apphub-spacing-sm);
+  }
+
+  .cards-grid--three {
+    display: grid;
+    gap: var(--apphub-spacing-lg);
+  }
+
+  @media (min-width: 768px) {
+    .page-hero__inner,
+    .observatory__inner {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .cards-grid--three {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+</style>

--- a/apps/website/src/pages/index.astro
+++ b/apps/website/src/pages/index.astro
@@ -1,0 +1,781 @@
+---
+import BaseLayout from '@layouts/BaseLayout.astro';
+import {
+  DataPlaneDiagram,
+  DeploymentOptionsDiagram,
+  EventBusDiagram,
+  ModuleLifecycleDiagram,
+  ObservatoryFlowDiagram,
+  SystemArchitectureDiagram,
+  UiGraphDiagram
+} from '@components/diagrams';
+
+const title = 'Osiris AppHub | Unified operations platform built on modules';
+const description =
+  'AppHub pairs an event-driven core, timestore, filestore, metastore, and unified UI so teams can ship modules that orchestrate data and automation in weeks.';
+
+const heroStats = [
+  { label: 'Platform status', value: 'Open-source control plane' },
+  { label: 'Module rollout time', value: 'Weeks from sketch to live operations' },
+  { label: 'Engagement focus', value: 'Teaching + turnkey module creation' }
+];
+
+const components = [
+  {
+    name: 'Core orchestrator',
+    copy:
+      'Fastify API and Redis-backed BullMQ workers coordinate jobs, assets, and events. Asset auto-materialisation keeps modules fresh without manual triggers.'
+  },
+  {
+    name: 'Timestore',
+    copy:
+      'DuckDB-powered SQL API backed by partitioned Parquet in object storage. Predicate pushdown and distributed execution keep costs low and queries fast.'
+  },
+  {
+    name: 'Filestore',
+    copy:
+      'Deterministic storage control plane that tracks directory sizes, hashes, and change events across S3, MinIO, and local mounts.'
+  },
+  {
+    name: 'Metastore',
+    copy:
+      'Namespace-scoped document store with optimistic concurrency and rich querying for module settings, topology, and governance metadata.'
+  },
+  {
+    name: 'Unified UI',
+    copy:
+      'React console renders live workflow graphs, asset lineage, service health, and SQL workspaces without leaving the browser.'
+  }
+];
+
+const modulePrinciples = [
+  {
+    title: 'Modules everywhere',
+    detail:
+      'Every use case becomes a module bundle built with the TypeScript SDK. Jobs, workflows, services, and UI surfaces ship together, versioned, and ready to import.'
+  },
+  {
+    title: 'First-class ergonomics',
+    detail:
+      'Capability shims for filestore, metastore, timestore, and the event bus mean module authors write clear domain logic instead of plumbing.'
+  },
+  {
+    title: 'Real-time evolution',
+    detail:
+      'Publish new module versions with compatibility checks, migrations, and promotion pipelines so operations stay ahead of changing requirements.'
+  }
+];
+
+const useCases = [
+  {
+    name: 'Environmental observatory',
+    summary:
+      'Ingest instrument telemetry every minute, reconcile files with Filestore, materialise partitions in Timestore, and publish dashboards automatically.'
+  },
+  {
+    name: 'Industrial asset uptime',
+    summary:
+      'Fuse PLC readings, operator inspections, and maintenance orders into a module that predicts equipment drift and schedules remediation flows.'
+  },
+  {
+    name: 'Field logistics co-ordination',
+    summary:
+      'Blend inventory snapshots, routing constraints, and crew updates with custom events so dispatchers and sites stay in lockstep.'
+  }
+];
+
+const dataHighlights = [
+  'SQL you already know. Timestore accepts ANSI SQL while translating queries into DuckDB plans executed over Parquet shards in object storage.',
+  'Partitioned manifests. Manifest sharding keeps ingestion fast even as datasets span months of history.',
+  'Hybrid storage. Pair cloud buckets with MinIO or on-prem disks; Filestore keeps metadata consistent and reconciles drift automatically.'
+];
+
+const orchestrationPoints = [
+  'Redis-backed event bus. BullMQ queues move events, workflow runs, and triggers with millisecond latency.',
+  'Asset-based automation and event triggers. Choose freshness-based runs or explicit domain events to launch workflows instantly.',
+  'Observable workers. Queue metrics, Prometheus exports, and OpenTelemetry traces come baked in for every background role.'
+];
+
+const uiHighlights = [
+  'Live workflow topology. Graphs show each run, dependency, and asset freshness in real time—no separate tracing tool needed.',
+  'Faster than stand-alone orchestrators. AppHub skips heavyweight RPC layers so modules move quicker than Temporal while inheriting Dagster-style assets.',
+  'In-app SQL lab. Query timestores, preview files, and link every result back to the producing module without leaving the console.'
+];
+
+const deploymentOptions = [
+  {
+    heading: 'Dedicated servers',
+    detail: 'Bring your own hardware with Docker Compose or Minikube. MinIO supplies object storage when S3 is not available.'
+  },
+  {
+    heading: 'Cloud-native',
+    detail: 'Deploy on Kubernetes with autoscaling workers, or run the stack on a VM plus managed S3/GCS buckets for effortless durability.'
+  },
+  {
+    heading: 'Hybrid topologies',
+    detail: 'Mix local ingestion workers with cloud control planes. Redis queues and service discovery keep modules coordinated across sites.'
+  }
+];
+
+const services = [
+  {
+    title: 'Immersive teaching sessions',
+    detail:
+      'Hands-on workshops cover AppHub architecture, the module SDK, and how to wire timestore/filestore integrations. Teams leave ready to build.'
+  },
+  {
+    title: 'Module modelling sprints',
+    detail:
+      'We translate your use case into a module blueprint—jobs, assets, services, and governance artifacts included.'
+  },
+  {
+    title: 'Turnkey module builds',
+    detail:
+      'Partner with our engineers to deliver a production-ready module, complete with observability dashboards and runbooks.'
+  }
+];
+
+const observatoryTakeaways = [
+  'Gateway normalises sensor events and pushes them through the Redis event bus into the Core.',
+  'Filestore journals every instrument upload, tracking directory sizes and hashing payloads for provenance.',
+  'Timestore compacts minute partitions into Parquet shards while exposing a SQL API for analysts and dashboards.',
+  'Event triggers fire downstream workflows the moment new telemetry arrives, complementing asset auto-materialisation.',
+  'Module services render the Observatory graph and status boards inside the unified UI using the module SDK capabilities.'
+];
+---
+<BaseLayout title={title} description={description}>
+  <section class="hero" aria-labelledby="hero-heading">
+    <div class="container hero__inner">
+      <div class="hero__content">
+        <p class="hero__eyebrow">Modules over monoliths</p>
+        <h1 id="hero-heading">Build an operations control plane that evolves faster than your roadmap.</h1>
+        <p class="hero__summary">
+          Osiris AppHub unifies the orchestrator, timestore, filestore, metastore, and UI into one event-driven platform. It is fully open
+          source—self-host it, fork it, or collaborate with our team to build modules faster.
+        </p>
+        <div class="hero__status">
+          <p>
+            <strong>Heads-up:</strong> the unified UI is mid-polish and will keep changing rapidly—expect frequent visual and UX updates as we harden the experience.
+          </p>
+          <p>
+            <strong>Early access:</strong> AppHub is not production ready yet. We are in the final hardening sprint and expect to flip the production-ready switch within the next couple of weeks.
+          </p>
+        </div>
+        <div class="hero__actions">
+          <a class="button button--primary" href="mailto:osirisapphub@gmail.com">Book a module workshop</a>
+          <a class="button button--secondary" href="/technical">Review the technical brief</a>
+          <a class="button button--ghost" href="https://github.com/benediktbwimmer/apphub" target="_blank" rel="noreferrer">View on GitHub</a>
+        </div>
+        <div class="hero__contributor">
+          <strong>Join the crew:</strong>
+          <span>
+            We are actively looking for open-source contributors and teammates for the Service Adoption team. If you want to shape onboarding playbooks or ship UI polish, email
+            <a href="mailto:osirisapphub@gmail.com">osirisapphub@gmail.com</a>.
+          </span>
+        </div>
+        <dl class="hero__stats" aria-label="Current commitments">
+          {heroStats.map((item) => (
+            <div>
+              <dt>{item.label}</dt>
+              <dd>{item.value}</dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+      <figure class="hero__visual">
+        <div class="diagram">
+          <SystemArchitectureDiagram />
+        </div>
+        <figcaption>Event bus at the centre: modules speak through shared services instead of bespoke glue code.</figcaption>
+      </figure>
+    </div>
+  </section>
+
+  <section class="components" aria-labelledby="components-heading">
+    <div class="container components__inner">
+      <div class="section-header">
+        <h2 id="components-heading" class="section-heading">Five services, one platform</h2>
+        <p>
+          Each AppHub workspace ships the same building blocks, so modules rely on proven infrastructure instead of reinventing data pipes
+          and orchestration.
+        </p>
+      </div>
+      <div class="components__grid">
+        {components.map((item) => (
+          <article>
+            <h3>{item.name}</h3>
+            <p>{item.copy}</p>
+          </article>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <section class="modules" aria-labelledby="modules-heading">
+    <div class="container modules__inner">
+      <figure>
+        <div class="diagram">
+          <ModuleLifecycleDiagram />
+        </div>
+      </figure>
+      <div>
+        <h2 id="modules-heading" class="section-heading">Modules are how you ship use cases</h2>
+        <div class="modules__grid">
+          {modulePrinciples.map((item) => (
+            <article>
+              <h3>{item.title}</h3>
+              <p>{item.detail}</p>
+            </article>
+          ))}
+        </div>
+        <p class="modules__footnote">
+          The module SDK lives in <code>packages/module-sdk</code> and gives authors typed access to filestore, metastore, timestore, and the event bus in just a
+          few lines.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="use-cases" aria-labelledby="use-cases-heading">
+    <div class="container use-cases__inner">
+      <h2 id="use-cases-heading" class="section-heading">Example modules we are delivering</h2>
+      <div class="use-cases__grid">
+        {useCases.map((item) => (
+          <article>
+            <h3>{item.name}</h3>
+            <p>{item.summary}</p>
+          </article>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <section class="data-plane" aria-labelledby="data-plane-heading">
+    <div class="container data-plane__inner">
+      <div>
+        <h2 id="data-plane-heading" class="section-heading">Data plane built on object storage</h2>
+        <ul>
+          {dataHighlights.map((point) => (
+            <li>{point}</li>
+          ))}
+        </ul>
+      </div>
+      <figure>
+        <div class="diagram">
+          <DataPlaneDiagram />
+        </div>
+      </figure>
+    </div>
+  </section>
+
+  <section class="orchestration" aria-labelledby="orchestration-heading">
+    <div class="container orchestration__inner">
+      <figure>
+        <div class="diagram">
+          <EventBusDiagram />
+        </div>
+      </figure>
+      <div>
+        <h2 id="orchestration-heading" class="section-heading">Event-driven orchestration without the overhead</h2>
+        <ul>
+          {orchestrationPoints.map((point) => (
+            <li>{point}</li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <section class="ui" aria-labelledby="ui-heading">
+    <div class="container ui__inner">
+      <div>
+        <h2 id="ui-heading" class="section-heading">A unified UI operators actually enjoy using</h2>
+        <ul>
+          {uiHighlights.map((point) => (
+            <li>{point}</li>
+          ))}
+        </ul>
+      </div>
+      <figure>
+        <div class="diagram">
+          <UiGraphDiagram />
+        </div>
+      </figure>
+    </div>
+  </section>
+
+  <section class="deploy" aria-labelledby="deploy-heading">
+    <div class="container deploy__inner">
+      <h2 id="deploy-heading" class="section-heading">Deploy it your way</h2>
+      <div class="diagram">
+        <DeploymentOptionsDiagram />
+      </div>
+      <div class="deploy__grid">
+        {deploymentOptions.map((option) => (
+          <article>
+            <h3>{option.heading}</h3>
+            <p>{option.detail}</p>
+          </article>
+        ))}
+      </div>
+      <p class="deploy__note">
+        Redis queues, Postgres, and object storage scale independently, so hybrid footprints—edge ingestion, cloud analytics, dedicated failover—stay in sync.
+      </p>
+    </div>
+  </section>
+
+  <section class="services" aria-labelledby="services-heading">
+    <div class="container services__inner">
+      <h2 id="services-heading" class="section-heading">What we offer today</h2>
+      <div class="services__grid">
+        {services.map((item) => (
+          <article>
+            <h3>{item.title}</h3>
+            <p>{item.detail}</p>
+          </article>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <section class="observatory" aria-labelledby="observatory-heading">
+    <div class="container observatory__inner">
+      <div>
+        <h2 id="observatory-heading" class="section-heading">Case study · Observatory module</h2>
+        <p class="observatory__intro">
+          The environmental observatory module is built entirely with the module SDK. It ingests instrument data, reconciles files, materialises parquet, and renders dashboards without leaving AppHub.
+        </p>
+        <ul>
+          {observatoryTakeaways.map((item) => (
+            <li>{item}</li>
+          ))}
+        </ul>
+      </div>
+      <figure>
+        <div class="diagram">
+          <ObservatoryFlowDiagram />
+        </div>
+      </figure>
+    </div>
+  </section>
+
+  <section class="cta" aria-labelledby="cta-heading">
+    <div class="container cta__inner">
+      <div>
+        <h2 id="cta-heading" class="section-heading">Start building with the community</h2>
+        <p>
+          Clone the repo, explore existing modules, and ship your own workflows. We collaborate in the open—file issues, open pull requests, or team up with us for turnkey delivery.
+        </p>
+      </div>
+      <div class="cta__actions">
+        <a class="button button--primary" href="https://github.com/benediktbwimmer/apphub" target="_blank" rel="noreferrer">Explore on GitHub</a>
+        <a class="button button--ghost" href="mailto:osirisapphub@gmail.com">Plan a discovery session</a>
+      </div>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .hero {
+    padding: var(--apphub-spacing-3xl) 0;
+    background: linear-gradient(140deg, rgba(13, 148, 136, 0.16), rgba(34, 211, 238, 0.12));
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .hero {
+      background: linear-gradient(140deg, rgba(20, 184, 166, 0.24), rgba(94, 234, 212, 0.14));
+    }
+  }
+
+  .hero__inner {
+    display: grid;
+    gap: var(--apphub-spacing-xl);
+    align-items: center;
+  }
+
+  .hero__eyebrow {
+    margin: 0;
+    font-size: var(--apphub-typography-font-size-xs);
+    letter-spacing: var(--apphub-typography-letter-spacing-wide);
+    text-transform: uppercase;
+    color: var(--apphub-color-text-soft);
+    font-weight: var(--apphub-typography-font-weight-semibold);
+  }
+
+  .hero__summary {
+    margin: 0;
+    font-size: var(--apphub-typography-font-size-lg);
+    color: var(--apphub-color-text-muted);
+    max-width: 68ch;
+  }
+
+  .hero__status {
+    margin-top: var(--apphub-spacing-md);
+    display: grid;
+    gap: var(--apphub-spacing-xxs);
+    padding: var(--apphub-spacing-sm);
+    border: 1px solid var(--apphub-color-border);
+    border-radius: var(--apphub-radius-lg);
+    background: var(--apphub-color-surface-muted);
+    color: var(--apphub-color-text);
+  }
+
+  .hero__status p {
+    margin: 0;
+    font-size: var(--apphub-typography-font-size-sm);
+  }
+
+  .hero__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--apphub-spacing-sm);
+  }
+
+  .hero__contributor {
+    margin-top: var(--apphub-spacing-md);
+    display: flex;
+    flex-direction: column;
+    gap: var(--apphub-spacing-xxs);
+    font-size: var(--apphub-typography-font-size-sm);
+    color: var(--apphub-color-text);
+  }
+
+  .hero__contributor a {
+    color: var(--apphub-color-accent-strong);
+  }
+
+  .hero__stats {
+    display: grid;
+    gap: var(--apphub-spacing-sm);
+    margin: var(--apphub-spacing-lg) 0 0;
+  }
+
+  .hero__stats dt {
+    font-size: var(--apphub-typography-font-size-xs);
+    letter-spacing: var(--apphub-typography-letter-spacing-wide);
+    text-transform: uppercase;
+    color: var(--apphub-color-text-soft);
+  }
+
+  .hero__stats dd {
+    margin: 0;
+    font-weight: var(--apphub-typography-font-weight-medium);
+  }
+
+  .hero__visual {
+    margin: 0;
+    display: grid;
+    gap: var(--apphub-spacing-xxs);
+    text-align: center;
+  }
+
+  .hero__visual .diagram svg {
+    width: 100%;
+    border-radius: var(--apphub-radius-xl);
+    border: 1px solid var(--apphub-color-border);
+    box-shadow: var(--apphub-shadow-soft);
+    background: var(--apphub-color-surface);
+  }
+
+  .hero__visual figcaption {
+    font-size: var(--apphub-typography-font-size-xs);
+    color: var(--apphub-color-text-soft);
+  }
+
+  .section-header {
+    display: grid;
+    gap: var(--apphub-spacing-sm);
+    margin-bottom: var(--apphub-spacing-xl);
+    max-width: 72ch;
+  }
+
+  .components {
+    padding: var(--apphub-spacing-3xl) 0;
+  }
+
+  .components__grid {
+    display: grid;
+    gap: var(--apphub-spacing-lg);
+  }
+
+  .components__grid article {
+    background: var(--apphub-color-surface);
+    border-radius: var(--apphub-radius-xl);
+    padding: var(--apphub-spacing-lg);
+    border: 1px solid var(--apphub-color-border);
+    box-shadow: var(--apphub-shadow-soft);
+  }
+
+  .components__grid h3 {
+    margin: 0 0 var(--apphub-spacing-xxs);
+  }
+
+  .modules {
+    padding: var(--apphub-spacing-3xl) 0;
+    background: var(--apphub-color-surface-muted);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .modules {
+      background: rgba(8, 49, 47, 0.6);
+    }
+  }
+
+  .modules__inner {
+    display: grid;
+    gap: var(--apphub-spacing-xl);
+    align-items: center;
+  }
+
+  .modules__grid {
+    display: grid;
+    gap: var(--apphub-spacing-md);
+  }
+
+  .modules__grid article {
+    background: var(--apphub-color-surface);
+    border-radius: var(--apphub-radius-lg);
+    padding: var(--apphub-spacing-md);
+    border: 1px solid var(--apphub-color-border);
+  }
+
+  .modules__footnote {
+    margin: var(--apphub-spacing-md) 0 0;
+    font-size: var(--apphub-typography-font-size-sm);
+    color: var(--apphub-color-text-soft);
+  }
+
+  .modules__footnote code {
+    background: rgba(15, 118, 110, 0.1);
+    padding: 0 var(--apphub-spacing-xxs);
+    border-radius: var(--apphub-radius-sm);
+  }
+
+  .use-cases {
+    padding: var(--apphub-spacing-3xl) 0;
+  }
+
+  .use-cases__grid {
+    display: grid;
+    gap: var(--apphub-spacing-lg);
+  }
+
+  .use-cases__grid article {
+    padding: var(--apphub-spacing-lg);
+    border-radius: var(--apphub-radius-xl);
+    border: 1px solid var(--apphub-color-border);
+    background: var(--apphub-color-surface);
+  }
+
+  .data-plane {
+    padding: var(--apphub-spacing-3xl) 0;
+    background: linear-gradient(145deg, rgba(13, 148, 136, 0.12), rgba(15, 118, 110, 0.08));
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .data-plane {
+      background: linear-gradient(145deg, rgba(20, 184, 166, 0.16), rgba(4, 47, 46, 0.9));
+    }
+  }
+
+  .data-plane__inner {
+    display: grid;
+    gap: var(--apphub-spacing-xl);
+    align-items: center;
+  }
+
+  .data-plane ul,
+  .orchestration ul,
+  .ui ul,
+  .observatory ul {
+    margin: 0;
+    padding-left: var(--apphub-spacing-lg);
+    display: grid;
+    gap: var(--apphub-spacing-sm);
+    color: var(--apphub-color-text-muted);
+  }
+
+  .data-plane figure,
+  .orchestration figure,
+  .ui figure,
+  .observatory figure {
+    margin: 0;
+    display: grid;
+    gap: var(--apphub-spacing-xxs);
+    text-align: center;
+  }
+
+  .data-plane .diagram svg,
+  .orchestration .diagram svg,
+  .ui .diagram svg,
+  .observatory .diagram svg {
+    width: 100%;
+    border-radius: var(--apphub-radius-xl);
+    border: 1px solid var(--apphub-color-border);
+    box-shadow: var(--apphub-shadow-soft);
+    background: var(--apphub-color-surface);
+  }
+
+  .diagram {
+    width: 100%;
+    max-width: 640px;
+    margin: 0 auto;
+  }
+
+  .data-plane figcaption,
+  .orchestration figcaption,
+  .ui figcaption,
+  .observatory figcaption {
+    font-size: var(--apphub-typography-font-size-xs);
+    color: var(--apphub-color-text-soft);
+  }
+
+  .orchestration {
+    padding: var(--apphub-spacing-3xl) 0;
+  }
+
+  .orchestration__inner {
+    display: grid;
+    gap: var(--apphub-spacing-xl);
+    align-items: center;
+  }
+
+  .ui {
+    padding: var(--apphub-spacing-3xl) 0;
+    background: var(--apphub-color-surface-muted);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .ui {
+      background: rgba(2, 19, 18, 0.78);
+    }
+  }
+
+  .ui__inner {
+    display: grid;
+    gap: var(--apphub-spacing-xl);
+    align-items: center;
+  }
+
+  .deploy {
+    padding: var(--apphub-spacing-3xl) 0;
+  }
+
+  .deploy__grid {
+    display: grid;
+    gap: var(--apphub-spacing-lg);
+  }
+
+  .deploy__grid article {
+    background: var(--apphub-color-surface);
+    border-radius: var(--apphub-radius-xl);
+    padding: var(--apphub-spacing-lg);
+    border: 1px solid var(--apphub-color-border);
+  }
+
+  .deploy__note {
+    margin: var(--apphub-spacing-lg) 0 0;
+    color: var(--apphub-color-text-soft);
+  }
+
+  .services {
+    padding: var(--apphub-spacing-3xl) 0;
+    background: linear-gradient(135deg, rgba(34, 211, 238, 0.12), rgba(13, 148, 136, 0.08));
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .services {
+      background: linear-gradient(135deg, rgba(20, 184, 166, 0.18), rgba(2, 19, 18, 0.92));
+    }
+  }
+
+  .services__inner {
+    display: grid;
+    gap: var(--apphub-spacing-xl);
+  }
+
+  .services__grid {
+    display: grid;
+    gap: var(--apphub-spacing-lg);
+  }
+
+  .services__grid article {
+    background: var(--apphub-color-surface);
+    border-radius: var(--apphub-radius-xl);
+    padding: var(--apphub-spacing-lg);
+    border: 1px solid var(--apphub-color-border);
+  }
+
+  .observatory {
+    padding: var(--apphub-spacing-3xl) 0;
+  }
+
+  .observatory__inner {
+    display: grid;
+    gap: var(--apphub-spacing-xl);
+    align-items: center;
+  }
+
+  .observatory__intro {
+    margin: 0 0 var(--apphub-spacing-md);
+    color: var(--apphub-color-text-muted);
+  }
+
+  .cta {
+    padding: var(--apphub-spacing-4xl) 0 var(--apphub-spacing-5xl);
+    background: linear-gradient(160deg, rgba(13, 148, 136, 0.2), rgba(15, 118, 110, 0.16));
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .cta {
+      background: linear-gradient(160deg, rgba(20, 184, 166, 0.24), rgba(2, 19, 18, 0.88));
+    }
+  }
+
+  .cta__inner {
+    display: grid;
+    gap: var(--apphub-spacing-xl);
+    align-items: center;
+  }
+
+  .cta__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--apphub-spacing-sm);
+  }
+
+  @media (min-width: 768px) {
+    .hero__inner {
+      grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+    }
+
+    .hero__stats {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .components__grid {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .modules__inner,
+    .data-plane__inner,
+    .orchestration__inner,
+    .ui__inner,
+    .observatory__inner {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .modules__grid {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .use-cases__grid {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .deploy__grid,
+    .services__grid {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+</style>

--- a/apps/website/src/pages/module-sdk/index.astro
+++ b/apps/website/src/pages/module-sdk/index.astro
@@ -1,0 +1,409 @@
+---
+import BaseLayout from '@layouts/BaseLayout.astro';
+import { CodeSnippet } from '@components/code';
+import { moduleSdkSnippets } from '@data/moduleSdkSnippets';
+
+const title = 'Module SDK cookbook';
+const description = 'Explore ready-to-run snippets for the AppHub Module SDK—jobs, capabilities, and event patterns.';
+
+const categoryOrder: Array<'module' | 'jobs' | 'services' | 'workflows' | 'assets' | 'capabilities'> = [
+  'module',
+  'jobs',
+  'services',
+  'workflows',
+  'assets',
+  'capabilities'
+];
+
+const categoryLabels: Record<string, string> = {
+  module: 'Module definitions',
+  jobs: 'Jobs & handlers',
+  services: 'Services & UIs',
+  assets: 'Assets & materialisation',
+  workflows: 'Workflows, triggers & schedules',
+  capabilities: 'Service capabilities'
+};
+
+const categoryDescriptions: Record<string, string> = {
+  module: 'Start with the module shell—metadata, settings, and the targets you want to expose.',
+  jobs: 'Implement job handlers that interact with the control plane and emit events.',
+  services: 'Serve dashboards or control panes with lifecycle hooks and rich registrations.',
+  assets: 'Return assets with freshness hints so downstream workflows auto-materialise.',
+  workflows: 'Compose jobs into workflows, react to events, and schedule recurring automation.',
+  capabilities: 'Reach out to filestore, metastore, timestore, and other services from module code.'
+};
+
+const sections = categoryOrder
+  .map((category) => ({
+    category,
+    label: categoryLabels[category] ?? category,
+    description: categoryDescriptions[category] ?? '',
+    snippets: moduleSdkSnippets.filter((snippet) => snippet.category === category)
+  }))
+  .filter((section) => section.snippets.length > 0);
+
+const allTags = Array.from(
+  new Set(moduleSdkSnippets.flatMap((snippet) => snippet.tags))
+).sort((a, b) => a.localeCompare(b));
+
+const totalSnippets = moduleSdkSnippets.length;
+---
+<BaseLayout title={title} description={description}>
+  <section class="page-hero">
+    <div class="container page-hero__inner">
+      <div>
+        <p class="page-hero__eyebrow">Module SDK</p>
+        <h1>Build modules faster with reusable snippets.</h1>
+        <p class="page-hero__intro">
+          Every snippet is grounded in production usage—copy, adapt, and compose them to speed up your module development. Contributions are
+          welcome on GitHub.
+        </p>
+        <div class="page-hero__actions">
+          <a class="button button--primary" href="https://github.com/benediktbwimmer/apphub" target="_blank" rel="noreferrer">Browse the SDK on GitHub</a>
+          <a class="button button--ghost" href="mailto:osirisapphub@gmail.com">Request a walkthrough</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="snippets" aria-labelledby="snippets-heading">
+    <div class="container snippets__inner">
+      <h2 id="snippets-heading" class="section-heading">Cookbook</h2>
+      <div class="snippet-filters" data-snippet-filters>
+        <div class="snippet-filters__search">
+          <label class="visually-hidden" for="snippet-filter-search">Search snippets</label>
+          <input
+            id="snippet-filter-search"
+            type="search"
+            placeholder="Search snippets by name, description, or tag"
+            autocomplete="off"
+            data-filter-search
+          />
+        </div>
+        <div class="snippet-filters__tags" role="group" aria-label="Filter by tag">
+          {allTags.map((tag) => (
+            <button type="button" class="snippet-tag" data-filter-tag data-tag={tag} aria-pressed="false">
+              {tag}
+            </button>
+          ))}
+        </div>
+        <div class="snippet-filters__row">
+          <button type="button" class="snippet-filters__clear" data-filter-clear>Clear filters</button>
+          <span class="snippet-filters__summary" data-filter-summary>{totalSnippets} snippets</span>
+        </div>
+      </div>
+      {sections.map((section) => (
+        <section class="snippet-group" id={section.category} data-snippet-group>
+          <header class="snippet-group__header">
+            <div>
+              <h3>{section.label}</h3>
+              {section.description ? <p>{section.description}</p> : null}
+            </div>
+            <span class="snippet-group__count">{section.snippets.length} snippet{section.snippets.length === 1 ? '' : 's'}</span>
+          </header>
+          <div class="snippet-group__grid">
+            {section.snippets.map((snippet) => {
+              const tags = snippet.tags.join('|');
+              const search = `${snippet.title} ${snippet.description} ${snippet.tags.join(' ')}`.toLowerCase();
+              return (
+                <article
+                  class="snippet-card"
+                  id={snippet.id}
+                  data-snippet
+                  data-category={section.category}
+                  data-tags={tags}
+                  data-search={search}
+                >
+                  <h4>{snippet.title}</h4>
+                  <p>{snippet.description}</p>
+                  <CodeSnippet
+                    code={snippet.code}
+                    language={snippet.language}
+                    highlightLines={snippet.highlightLines}
+                    caption={`Tags: ${snippet.tags.join(', ')}`}
+                  />
+                </article>
+              );
+            })}
+          </div>
+        </section>
+      ))}
+    </div>
+  </section>
+</BaseLayout>
+
+<script type="module">
+  const filters = document.querySelector('[data-snippet-filters]');
+  if (filters) {
+    const searchInput = filters.querySelector('[data-filter-search]');
+    const tagButtons = Array.from(filters.querySelectorAll('[data-filter-tag]'));
+    const clearButton = filters.querySelector('[data-filter-clear]');
+    const summary = filters.querySelector('[data-filter-summary]');
+    const cards = Array.from(document.querySelectorAll('[data-snippet]'));
+    const groups = Array.from(document.querySelectorAll('[data-snippet-group]'));
+    const activeTags = new Set();
+
+    const updateSummary = (visible) => {
+      if (!summary) return;
+      if (visible === cards.length) {
+        summary.textContent = `${cards.length} snippets`;
+      } else {
+        summary.textContent = `${visible} of ${cards.length} snippets`;
+      }
+    };
+
+    const applyFilters = () => {
+      const query = (searchInput?.value ?? '').trim().toLowerCase();
+      let visibleCount = 0;
+
+      cards.forEach((card) => {
+        const tags = (card.dataset.tags ?? '').split('|').filter(Boolean);
+        const matchesTags = activeTags.size === 0 || Array.from(activeTags).every((tag) => tags.includes(tag));
+        const searchHaystack = card.dataset.search ?? '';
+        const matchesQuery = query.length === 0 || searchHaystack.includes(query);
+        const isVisible = matchesTags && matchesQuery;
+        card.style.display = isVisible ? '' : 'none';
+        if (isVisible) {
+          visibleCount += 1;
+        }
+      });
+
+      groups.forEach((group) => {
+        const groupCards = Array.from(group.querySelectorAll('[data-snippet]'));
+        const hasVisible = groupCards.some((card) => card instanceof HTMLElement && card.style.display !== 'none');
+        (group instanceof HTMLElement) && (group.style.display = hasVisible ? '' : 'none');
+      });
+
+      updateSummary(visibleCount);
+    };
+
+    tagButtons.forEach((button) => {
+      button.addEventListener('click', () => {
+        const tag = button.getAttribute('data-tag');
+        if (!tag) return;
+        if (activeTags.has(tag)) {
+          activeTags.delete(tag);
+          button.classList.remove('is-active');
+          button.setAttribute('aria-pressed', 'false');
+        } else {
+          activeTags.add(tag);
+          button.classList.add('is-active');
+          button.setAttribute('aria-pressed', 'true');
+        }
+        applyFilters();
+      });
+    });
+
+    searchInput?.addEventListener('input', () => {
+      window.requestAnimationFrame(applyFilters);
+    });
+
+    clearButton?.addEventListener('click', () => {
+      activeTags.clear();
+      tagButtons.forEach((button) => {
+        button.classList.remove('is-active');
+        button.setAttribute('aria-pressed', 'false');
+      });
+      if (searchInput) {
+        searchInput.value = '';
+        searchInput.focus();
+      }
+      applyFilters();
+    });
+
+    applyFilters();
+  }
+</script>
+
+<style>
+  .page-hero {
+    padding: var(--apphub-spacing-3xl) 0;
+    background: linear-gradient(140deg, rgba(13, 148, 136, 0.18), rgba(34, 211, 238, 0.12));
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .page-hero {
+      background: linear-gradient(140deg, rgba(20, 184, 166, 0.24), rgba(2, 19, 18, 0.88));
+    }
+  }
+
+  .page-hero__inner {
+    display: grid;
+    gap: var(--apphub-spacing-xl);
+  }
+
+  .page-hero__eyebrow {
+    margin: 0;
+    font-size: var(--apphub-typography-font-size-xs);
+    letter-spacing: var(--apphub-typography-letter-spacing-wide);
+    text-transform: uppercase;
+    color: var(--apphub-color-text-soft);
+  }
+
+  .page-hero__intro {
+    margin: 0 0 var(--apphub-spacing-lg);
+    color: var(--apphub-color-text-muted);
+    max-width: 70ch;
+  }
+
+  .page-hero__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--apphub-spacing-sm);
+  }
+
+  .snippets {
+    padding: var(--apphub-spacing-3xl) 0;
+  }
+
+  .snippets__inner {
+    display: grid;
+    gap: var(--apphub-spacing-2xl);
+  }
+
+  .snippet-filters {
+    display: grid;
+    gap: var(--apphub-spacing-md);
+    background: var(--apphub-color-surface);
+    border: 1px solid var(--apphub-color-border);
+    border-radius: var(--apphub-radius-xl);
+    padding: var(--apphub-spacing-lg);
+    box-shadow: var(--apphub-shadow-soft);
+  }
+
+  .snippet-filters__search input {
+    width: 100%;
+    padding: var(--apphub-spacing-sm) var(--apphub-spacing-md);
+    border: 1px solid var(--apphub-color-border);
+    border-radius: var(--apphub-radius-lg);
+    background: var(--apphub-color-surface-muted);
+    color: var(--apphub-color-text);
+  }
+
+  .snippet-filters__tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--apphub-spacing-xs);
+  }
+
+  .snippet-tag {
+    padding: var(--apphub-spacing-xxs) var(--apphub-spacing-sm);
+    border-radius: 999px;
+    border: 1px solid var(--apphub-color-border);
+    background: var(--apphub-color-surface-muted);
+    color: var(--apphub-color-text-soft);
+    font-size: var(--apphub-typography-font-size-sm);
+    cursor: pointer;
+    transition: background-color 160ms ease, color 160ms ease, border-color 160ms ease;
+  }
+
+  .snippet-tag:hover {
+    border-color: var(--apphub-color-border);
+    color: var(--apphub-color-text);
+  }
+
+  .snippet-tag.is-active {
+    background: rgba(20, 184, 166, 0.16);
+    border-color: rgba(13, 148, 136, 0.6);
+    color: var(--apphub-color-text);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .snippet-tag.is-active {
+      background: rgba(45, 212, 191, 0.24);
+      border-color: rgba(20, 184, 166, 0.6);
+    }
+  }
+
+  .snippet-filters__row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--apphub-spacing-sm);
+  }
+
+  .snippet-filters__clear {
+    padding: var(--apphub-spacing-xxs) var(--apphub-spacing-sm);
+    border-radius: var(--apphub-radius-lg);
+    border: 1px solid transparent;
+    background: transparent;
+    color: var(--apphub-color-text-soft);
+    font-size: var(--apphub-typography-font-size-sm);
+    cursor: pointer;
+    transition: color 160ms ease, border-color 160ms ease;
+  }
+
+  .snippet-filters__clear:hover {
+    color: var(--apphub-color-text);
+    border-color: var(--apphub-color-border);
+  }
+
+  .snippet-filters__summary {
+    font-size: var(--apphub-typography-font-size-sm);
+    color: var(--apphub-color-text-soft);
+  }
+
+  .snippet-group {
+    display: grid;
+    gap: var(--apphub-spacing-xl);
+  }
+
+  .snippet-group__header {
+    display: flex;
+    flex-direction: column;
+    gap: var(--apphub-spacing-xxs);
+  }
+
+  @media (min-width: 768px) {
+    .snippet-group__header {
+      flex-direction: row;
+      justify-content: space-between;
+      align-items: baseline;
+    }
+  }
+
+  .snippet-group__header h3 {
+    margin: 0;
+    font-size: var(--apphub-typography-font-size-xl);
+  }
+
+  .snippet-group__header p {
+    margin: 0;
+    color: var(--apphub-color-text-soft);
+  }
+
+  .snippet-group__count {
+    font-size: var(--apphub-typography-font-size-sm);
+    color: var(--apphub-color-text-soft);
+  }
+
+  .snippet-group__grid {
+    display: grid;
+    gap: var(--apphub-spacing-xl);
+    grid-template-columns: minmax(0, 1fr);
+    max-width: 960px;
+    margin: 0 auto;
+  }
+
+  .snippet-card {
+    display: grid;
+    gap: var(--apphub-spacing-sm);
+    background: var(--apphub-color-surface);
+    padding: var(--apphub-spacing-lg);
+    border-radius: var(--apphub-radius-xl);
+    border: 1px solid var(--apphub-color-border);
+    box-shadow: var(--apphub-shadow-soft);
+  }
+
+  .snippet-card h4 {
+    margin: 0;
+    font-size: var(--apphub-typography-font-size-lg);
+  }
+
+  .snippet-card p {
+    margin: 0;
+    color: var(--apphub-color-text-muted);
+  }
+
+</style>

--- a/apps/website/src/pages/technical/index.astro
+++ b/apps/website/src/pages/technical/index.astro
@@ -1,0 +1,472 @@
+---
+import BaseLayout from '@layouts/BaseLayout.astro';
+import { CodeSnippet } from '@components/code';
+import {
+  EventFlowDiagram,
+  FilestoreStackDiagram,
+  ObservabilityDiagram,
+  TechnicalArchitectureDiagram,
+  TimestoreStackDiagram
+} from '@components/diagrams';
+
+const title = 'Technical overview | Osiris AppHub';
+const description = 'Dive into the architecture of the AppHub control plane: orchestrator, data plane, event bus, and module ergonomics.';
+
+const coreStack = [
+  {
+    heading: 'Core orchestrator',
+    detail:
+      'Fastify gateway with typed OpenAPI surface. Redis + BullMQ drive ingest, workflow, build, and materializer queues. Asset materialisation keeps data fresh automatically.'
+  },
+  {
+    heading: 'Timestore',
+    detail:
+      'DuckDB runtime generates Parquet partitions in object storage, exposes ANSI SQL, and uses predicate pushdown to keep IO costs low.'
+  },
+  {
+    heading: 'Filestore',
+    detail:
+      'Transactional filesystem API that journals mutations, tracks hashes, and reconciles drift across MinIO, S3, GCS, or local disks.'
+  },
+  {
+    heading: 'Metastore',
+    detail: 'PostgreSQL-backed document store with optimistic concurrency and JSON-path querying for module settings and topology.'
+  },
+  {
+    heading: 'Unified UI',
+    detail: 'Vite + React console streaming WebSocket events, rendering workflow graphs, SQL editor, and service health from the core.'
+  }
+];
+
+const eventHighlights = [
+  'BullMQ queues with Redis deliver sub-50ms event fan-out for workflow runs, asset updates, and service health frames.',
+  'Inline mode keeps local development simple, while HTTP proxies let sandboxed jobs publish events without bundling BullMQ.',
+  'Asset materialisation and explicit event triggers both kick off workflows—choose freshness-based or domain-driven execution patterns.'
+];
+
+const timestoreDetails = [
+  'Partitioned Parquet manifests sharded by day keep ingestion free of row-level contention.',
+  'DuckDB query plans exploit predicate pushdown and column pruning, so scanning months of data remains affordable.',
+  'Lifecycle workers manage compaction, retention, and exports. Metrics such as `timestore_ingest_job_duration_seconds` ship out of the box.',
+  'SQL editor in the UI reuses the same API surface exposed to modules; no parallel warehouse required.'
+];
+
+const filestoreDetails = [
+  'Journaled mutations guarantee metadata accuracy—size, checksums, lifecycles—across every node.',
+  'Watchers and reconciliation workers detect drift introduced outside the API and self-heal using BullMQ jobs.',
+  'Backends span local volumes, MinIO, S3, or GCS. Metadata stays central in Postgres while payloads live in object storage.',
+  'Event feeds push change notifications into modules and timestore so downstream consumers react instantly.'
+];
+
+const moduleErgonomics = [
+  'TypeScript SDK supplies capability shims for filestore, metastore, timestore, and the event bus. Authors focus on domain logic.',
+  'Targets (jobs, workflows, services) declare semantic versions and assets, enabling precise rollouts and auto-materialisation.',
+  'Services ship with registrations so module-defined UIs appear automatically in the AppHub console.'
+];
+
+const moduleSnippet = String.raw`import { defineModule, createJobHandler } from '@apphub/module-sdk';
+
+const ingest = createJobHandler({
+  name: 'observatory-minute-ingest',
+  produces: [{ assetId: 'observatory.timeseries.raw' }],
+  handler: async (ctx) => {
+    const files = await ctx.capabilities.filestore?.list({ prefix: ctx.parameters.prefix });
+    await ctx.capabilities.timestore?.ingestRecords({
+      dataset: 'observatory-minute',
+      records: files.map((file) => buildRow(file))
+    });
+    await ctx.capabilities.eventBus?.publish({
+      type: 'observatory.ingest.completed',
+      source: 'observatory.module',
+      payload: { minute: ctx.parameters.minute }
+    });
+  }
+});
+
+export default defineModule({
+  metadata: { name: 'environmental-observatory', version: '0.5.0' },
+  targets: [ingest]
+});`;
+
+const deployment = [
+  {
+    title: 'Single-node prototyping',
+    copy: 'Docker Compose or Minikube packages Redis, Postgres, object storage (MinIO), and the AppHub services for quick demos.'
+  },
+  {
+    title: 'Kubernetes-first',
+    copy: 'Helm manifests and workers scale horizontally. Object storage can be S3, GCS, or in-cluster MinIO; Redis and Postgres scale independently.'
+  },
+  {
+    title: 'Hybrid footprints',
+    copy: 'Run ingestion workers next to data sources while keeping the control plane in the cloud. Event bus routing and service registry keep everything in sync.'
+  }
+];
+
+const observability = [
+  'Prometheus metrics across services (queue depth, ingest latency, reconciliation backlog) with configurable scopes.',
+  'OpenTelemetry spans for timestore queries, ingestion, and workflow execution.',
+  'Admin APIs expose queue health, event explorers, dataset audit trails, and asset histories.'
+];
+---
+<BaseLayout title={title} description={description}>
+  <section class="page-hero">
+    <div class="container page-hero__inner">
+      <div>
+        <p class="page-hero__eyebrow">For engineering and platform teams</p>
+        <h1>The event-driven control plane behind AppHub modules.</h1>
+        <p class="page-hero__intro">
+          AppHub is open source. It pairs an opinionated orchestrator with a scalable data plane so modules can blend automation, telemetry, and operator experiences without reinventing the stack.
+        </p>
+        <div class="page-hero__actions">
+          <a class="button button--primary" href="mailto:osirisapphub@gmail.com">Book an architecture review</a>
+          <a class="button button--secondary" href="https://github.com/benediktbwimmer/apphub" target="_blank" rel="noreferrer">View on GitHub</a>
+          <a class="button button--ghost" href="/module-sdk">Explore the Module SDK</a>
+        </div>
+        <div class="page-hero__notice">
+          <strong>Current status:</strong>
+          <span>
+            UI polish is ongoing and the control plane is still in early access. We expect production readiness within the next couple of weeks—contributors are welcome to help us reach the finish line.
+          </span>
+        </div>
+      </div>
+      <figure>
+        <div class="diagram">
+          <TechnicalArchitectureDiagram />
+        </div>
+        <figcaption>Core workers, data services, and UI share the same event bus and object storage fabric.</figcaption>
+      </figure>
+    </div>
+  </section>
+
+  <section class="stack" aria-labelledby="stack-heading">
+    <div class="container stack__inner">
+      <h2 id="stack-heading" class="section-heading">Stack components</h2>
+      <div class="stack__grid">
+        {coreStack.map((item) => (
+          <article>
+            <h3>{item.heading}</h3>
+            <p>{item.detail}</p>
+          </article>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <section class="events" aria-labelledby="events-heading">
+    <div class="container events__inner">
+      <figure>
+        <div class="diagram">
+          <EventFlowDiagram />
+        </div>
+      </figure>
+      <div>
+        <h2 id="events-heading" class="section-heading">Event bus & asset materialisation</h2>
+        <ul>
+          {eventHighlights.map((item) => (
+            <li>{item}</li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <section class="timestore" aria-labelledby="timestore-heading">
+    <div class="container timestore__inner">
+      <div>
+        <h2 id="timestore-heading" class="section-heading">Timestore at scale</h2>
+        <ul>
+          {timestoreDetails.map((item) => (
+            <li>{item}</li>
+          ))}
+        </ul>
+      </div>
+      <figure>
+        <div class="diagram">
+          <TimestoreStackDiagram />
+        </div>
+      </figure>
+    </div>
+  </section>
+
+  <section class="filestore" aria-labelledby="filestore-heading">
+    <div class="container filestore__inner">
+      <figure>
+        <div class="diagram">
+          <FilestoreStackDiagram />
+        </div>
+      </figure>
+      <div>
+        <h2 id="filestore-heading" class="section-heading">Filestore metadata engine</h2>
+        <ul>
+          {filestoreDetails.map((item) => (
+            <li>{item}</li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <section class="modules" aria-labelledby="modules-heading">
+    <div class="container modules__inner">
+      <h2 id="modules-heading" class="section-heading">Module ergonomics</h2>
+      <div class="modules__grid">
+        {moduleErgonomics.map((item) => (
+          <article>
+            <h3>{item}</h3>
+          </article>
+        ))}
+      </div>
+      <CodeSnippet
+        code={moduleSnippet}
+        language="typescript"
+        highlightLines={[1, 5, 15]}
+        caption="Module definition using Filestore, Timestore, and Event bus capabilities"
+      />
+    </div>
+  </section>
+
+  <section class="deployment" aria-labelledby="deployment-heading">
+    <div class="container deployment__inner">
+      <h2 id="deployment-heading" class="section-heading">Deployment options</h2>
+      <div class="deployment__grid">
+        {deployment.map((item) => (
+          <article>
+            <h3>{item.title}</h3>
+            <p>{item.copy}</p>
+          </article>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <section class="observability" aria-labelledby="observability-heading">
+    <div class="container observability__inner">
+      <div>
+        <h2 id="observability-heading" class="section-heading">Observability & operations</h2>
+        <ul>
+          {observability.map((item) => (
+            <li>{item}</li>
+          ))}
+        </ul>
+      </div>
+      <figure>
+        <div class="diagram">
+          <ObservabilityDiagram />
+        </div>
+      </figure>
+    </div>
+  </section>
+
+  <section class="cta" aria-labelledby="cta-heading">
+    <div class="container cta__inner">
+      <div>
+        <h2 id="cta-heading" class="section-heading">Need a deeper walkthrough?</h2>
+        <p>We’ll step through the queues, sharding strategies, and SDK internals with your engineering leads.</p>
+      </div>
+      <a class="button button--primary" href="mailto:osirisapphub@gmail.com">Book a technical session</a>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .page-hero {
+    padding: var(--apphub-spacing-3xl) 0;
+    background: linear-gradient(140deg, rgba(13, 148, 136, 0.2), rgba(34, 211, 238, 0.14));
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .page-hero {
+      background: linear-gradient(140deg, rgba(20, 184, 166, 0.24), rgba(2, 19, 18, 0.88));
+    }
+  }
+
+  .page-hero__inner {
+    display: grid;
+    gap: var(--apphub-spacing-xl);
+    align-items: center;
+  }
+
+  .page-hero__eyebrow {
+    margin: 0;
+    font-size: var(--apphub-typography-font-size-xs);
+    letter-spacing: var(--apphub-typography-letter-spacing-wide);
+    text-transform: uppercase;
+    color: var(--apphub-color-text-soft);
+  }
+
+  .page-hero__intro {
+    margin: 0 0 var(--apphub-spacing-lg);
+    color: var(--apphub-color-text-muted);
+    max-width: 72ch;
+  }
+
+  .page-hero__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--apphub-spacing-sm);
+  }
+
+  .page-hero__notice {
+    margin-top: var(--apphub-spacing-md);
+    display: flex;
+    flex-direction: column;
+    gap: var(--apphub-spacing-xxs);
+    padding: var(--apphub-spacing-sm);
+    border: 1px solid var(--apphub-color-border);
+    border-radius: var(--apphub-radius-lg);
+    background: var(--apphub-color-surface-muted);
+    color: var(--apphub-color-text);
+    font-size: var(--apphub-typography-font-size-sm);
+  }
+
+  .page-hero figure {
+    margin: 0;
+    display: grid;
+    gap: var(--apphub-spacing-xxs);
+    text-align: center;
+  }
+
+  .page-hero .diagram svg {
+    width: 100%;
+    border-radius: var(--apphub-radius-xl);
+    border: 1px solid var(--apphub-color-border);
+    box-shadow: var(--apphub-shadow-soft);
+    background: var(--apphub-color-surface);
+  }
+
+  .page-hero figcaption {
+    font-size: var(--apphub-typography-font-size-xs);
+    color: var(--apphub-color-text-soft);
+  }
+
+  .stack,
+  .events,
+  .timestore,
+  .filestore,
+  .modules,
+  .deployment,
+  .observability,
+  .cta {
+    padding: var(--apphub-spacing-3xl) 0;
+  }
+
+  .stack__grid,
+  .deployment__grid {
+    display: grid;
+    gap: var(--apphub-spacing-lg);
+  }
+
+  .stack__grid article,
+  .deployment__grid article {
+    background: var(--apphub-color-surface);
+    border-radius: var(--apphub-radius-xl);
+    padding: var(--apphub-spacing-lg);
+    border: 1px solid var(--apphub-color-border);
+  }
+
+  .events__inner,
+  .timestore__inner,
+  .filestore__inner,
+  .observability__inner {
+    display: grid;
+    gap: var(--apphub-spacing-xl);
+    align-items: center;
+  }
+
+  .events figure,
+  .timestore figure,
+  .filestore figure,
+  .observability figure {
+    margin: 0;
+    display: grid;
+    gap: var(--apphub-spacing-xxs);
+    text-align: center;
+  }
+
+  .events .diagram svg,
+  .timestore .diagram svg,
+  .filestore .diagram svg,
+  .observability .diagram svg {
+    width: 100%;
+    border-radius: var(--apphub-radius-xl);
+    border: 1px solid var(--apphub-color-border);
+    box-shadow: var(--apphub-shadow-soft);
+    background: var(--apphub-color-surface);
+  }
+
+  .events ul,
+  .timestore ul,
+  .filestore ul,
+  .observability ul {
+    margin: 0;
+    padding-left: var(--apphub-spacing-lg);
+    display: grid;
+    gap: var(--apphub-spacing-sm);
+    color: var(--apphub-color-text-muted);
+  }
+
+  .modules {
+    background: var(--apphub-color-surface-muted);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .modules {
+      background: rgba(2, 19, 18, 0.82);
+    }
+  }
+
+  .modules__inner {
+    display: grid;
+    gap: var(--apphub-spacing-xl);
+  }
+
+  .modules__grid {
+    display: grid;
+    gap: var(--apphub-spacing-md);
+  }
+
+  .modules__grid article {
+    background: var(--apphub-color-surface);
+    border-radius: var(--apphub-radius-lg);
+    padding: var(--apphub-spacing-md);
+    border: 1px solid var(--apphub-color-border);
+  }
+
+  .cta {
+    background: linear-gradient(160deg, rgba(13, 148, 136, 0.2), rgba(15, 118, 110, 0.16));
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .cta {
+      background: linear-gradient(160deg, rgba(20, 184, 166, 0.22), rgba(2, 19, 18, 0.88));
+    }
+  }
+
+  .cta__inner {
+    display: grid;
+    gap: var(--apphub-spacing-lg);
+    align-items: center;
+  }
+
+  .diagram {
+    width: 100%;
+    max-width: 560px;
+    margin: 0 auto;
+  }
+
+  @media (min-width: 768px) {
+    .page-hero__inner,
+    .events__inner,
+    .timestore__inner,
+    .filestore__inner,
+    .observability__inner {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .stack__grid,
+    .deployment__grid {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+</style>


### PR DESCRIPTION
## Summary
- expand the Module SDK cookbook with new snippets and a filterable layout
- surface early access notices, contributor callouts, and adoption-team recruitment across the site
- streamline navigation while promoting open-source involvement

## Testing
- npm run build --workspace @apphub/website