### PR TITLE
fix: lock demo nuke endpoints behind new scope

### DIFF
--- a/services/core/src/auth/tokens.ts
+++ b/services/core/src/auth/tokens.ts
@@ -29,7 +29,8 @@ type OperatorScope =
   | 'filestore:admin'
   | 'runtime:write'
   | 'timestore:sql:read'
-  | 'timestore:sql:exec';
+  | 'timestore:sql:exec'
+  | 'admin:danger-zone';
 
 const ALL_SCOPES: OperatorScope[] = [
   'jobs:read',
@@ -46,7 +47,8 @@ const ALL_SCOPES: OperatorScope[] = [
   'filestore:admin',
   'runtime:write',
   'timestore:sql:read',
-  'timestore:sql:exec'
+  'timestore:sql:exec',
+  'admin:danger-zone'
 ];
 
 export const OPERATOR_SCOPES: readonly OperatorScope[] = [...ALL_SCOPES];
@@ -66,7 +68,8 @@ const SCOPE_ALIASES: Record<OperatorScope, OperatorScope[]> = {
   'filestore:admin': ['filestore:write', 'filestore:read'],
   'runtime:write': [],
   'timestore:sql:read': [],
-  'timestore:sql:exec': ['timestore:sql:read']
+  'timestore:sql:exec': ['timestore:sql:read'],
+  'admin:danger-zone': []
 };
 
 type OperatorKind = 'user' | 'service';
@@ -288,6 +291,10 @@ function getTokenCache(): Map<string, TokenCacheEntry> {
     tokenCache = buildTokenCache();
   }
   return tokenCache;
+}
+
+export function resetOperatorTokenCache(): void {
+  tokenCache = null;
 }
 
 function extractBearerToken(input: unknown): string | null {

--- a/services/core/src/routes/shared/scopes.ts
+++ b/services/core/src/routes/shared/scopes.ts
@@ -12,3 +12,4 @@ export const RUNTIME_SCALING_WRITE_SCOPES: OperatorScope[] = ['runtime:write'];
 export const OBSERVATORY_READ_SCOPES: OperatorScope[] = ['filestore:read'];
 export const OBSERVATORY_WRITE_SCOPES: OperatorScope[] = ['filestore:write'];
 export const OBSERVATORY_REPROCESS_SCOPES: OperatorScope[] = ['filestore:write', 'workflows:run'];
+export const ADMIN_DANGER_SCOPES: OperatorScope[] = ['admin:danger-zone'];

--- a/services/core/tests/adminNukeAuth.test.ts
+++ b/services/core/tests/adminNukeAuth.test.ts
@@ -1,0 +1,69 @@
+import { ensureEmbeddedPostgres } from './setupTestEnv';
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import Fastify from 'fastify';
+import cookie from '@fastify/cookie';
+import { registerAdminRoutes } from '../src/routes/admin';
+import { ensureDatabase } from '../src/db';
+import { resetOperatorTokenCache } from '../src/auth/tokens';
+
+test('admin nuke routes require the admin danger scope', async (t) => {
+  const viewerToken = 'admin-nuke-auth-viewer';
+  const adminToken = 'admin-nuke-auth-admin';
+  const originalTokensEnv = process.env.APPHUB_OPERATOR_TOKENS;
+
+  process.env.APPHUB_OPERATOR_TOKENS = JSON.stringify([
+    {
+      subject: 'viewer',
+      token: viewerToken,
+      scopes: ['jobs:read', 'workflows:read', 'job-bundles:read', 'filestore:read']
+    },
+    {
+      subject: 'admin',
+      token: adminToken,
+      scopes: ['admin:danger-zone']
+    }
+  ]);
+  resetOperatorTokenCache();
+
+  await ensureEmbeddedPostgres();
+  await ensureDatabase();
+
+  const app = Fastify();
+  await app.register(cookie);
+  await registerAdminRoutes(app);
+
+  t.after(async () => {
+    await app.close();
+    process.env.APPHUB_OPERATOR_TOKENS = originalTokensEnv;
+    resetOperatorTokenCache();
+  });
+
+  const unauthorizedResponse = await app.inject({
+    method: 'POST',
+    url: '/admin/core/nuke',
+    headers: { authorization: `Bearer ${viewerToken}` }
+  });
+  assert.equal(unauthorizedResponse.statusCode, 403, unauthorizedResponse.body);
+
+  const runDataResponse = await app.inject({
+    method: 'POST',
+    url: '/admin/core/nuke/run-data',
+    headers: { authorization: `Bearer ${adminToken}` }
+  });
+  assert.equal(runDataResponse.statusCode, 200, runDataResponse.body);
+
+  const coreResponse = await app.inject({
+    method: 'POST',
+    url: '/admin/core/nuke',
+    headers: { authorization: `Bearer ${adminToken}` }
+  });
+  assert.equal(coreResponse.statusCode, 200, coreResponse.body);
+
+  const everythingResponse = await app.inject({
+    method: 'POST',
+    url: '/admin/core/nuke/everything',
+    headers: { authorization: `Bearer ${adminToken}` }
+  });
+  assert.equal(everythingResponse.statusCode, 200, everythingResponse.body);
+});


### PR DESCRIPTION
## Summary
- guard core nuke endpoints behind a dedicated `admin:danger-zone` scope and audit the outcome
- gate the frontend danger zone controls on the same scope so demo tokens stay read-only
- add regression coverage ensuring only scoped tokens can hit the destructive routes

## Testing
- npx tsx services/core/tests/adminNukeAuth.test.ts
- npm run lint --workspace @apphub/core
