### PR TITLE
Refactor UI advanced controls

### DIFF
--- a/apps/frontend/src/components/CollapsibleSection.tsx
+++ b/apps/frontend/src/components/CollapsibleSection.tsx
@@ -1,0 +1,53 @@
+import { useState, type ReactNode } from 'react';
+import classNames from 'classnames';
+
+interface CollapsibleSectionProps {
+  title: string;
+  children: ReactNode;
+  description?: string;
+  defaultOpen?: boolean;
+  className?: string;
+  contentClassName?: string;
+  onToggle?: (open: boolean) => void;
+}
+
+const WRAPPER_CLASS = 'overflow-hidden rounded-3xl border border-subtle bg-surface-glass shadow-elevation-lg';
+const SUMMARY_CLASS =
+  'flex cursor-pointer items-center justify-between gap-3 px-5 py-4 text-left outline-none transition-colors hover:bg-surface-glass-soft focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent';
+const SUMMARY_TEXT_CLASS = 'flex flex-col gap-1';
+const DESCRIPTION_CLASS = 'text-scale-xs text-secondary';
+const TOGGLE_HINT_CLASS = 'text-scale-xs font-weight-medium text-muted';
+const CONTENT_CLASS = 'border-t border-subtle bg-surface-glass-soft px-5 py-4';
+
+export function CollapsibleSection({
+  title,
+  description,
+  children,
+  defaultOpen = false,
+  className,
+  contentClassName,
+  onToggle
+}: CollapsibleSectionProps) {
+  const [open, setOpen] = useState(defaultOpen);
+
+  return (
+    <details
+      className={classNames('group', WRAPPER_CLASS, className)}
+      open={open}
+      onToggle={(event) => {
+        const next = event.currentTarget.open;
+        setOpen(next);
+        onToggle?.(next);
+      }}
+    >
+      <summary className={SUMMARY_CLASS}>
+        <span className={SUMMARY_TEXT_CLASS}>
+          <span className="text-scale-sm font-weight-semibold text-primary">{title}</span>
+          {description ? <span className={DESCRIPTION_CLASS}>{description}</span> : null}
+        </span>
+        <span className={TOGGLE_HINT_CLASS}>{open ? 'Hide' : 'Show'}</span>
+      </summary>
+      <div className={classNames(CONTENT_CLASS, contentClassName)}>{children}</div>
+    </details>
+  );
+}

--- a/apps/frontend/src/components/index.ts
+++ b/apps/frontend/src/components/index.ts
@@ -5,3 +5,4 @@ export type { SpinnerProps } from './Spinner';
 export { Modal } from './Modal';
 export { ScrollableListContainer } from './ScrollableListContainer';
 export { CopyButton } from './CopyButton';
+export { CollapsibleSection } from './CollapsibleSection';

--- a/apps/frontend/src/filestore/FilestoreExplorerPage.tsx
+++ b/apps/frontend/src/filestore/FilestoreExplorerPage.tsx
@@ -12,6 +12,7 @@ import type { AuthIdentity } from '../auth/useAuth';
 import { useAuthorizedFetch } from '../auth/useAuthorizedFetch';
 import { usePollingResource } from '../hooks/usePollingResource';
 import { useDebouncedValue } from '../hooks/useDebouncedValue';
+import { CollapsibleSection } from '../components/CollapsibleSection';
 import { useToastHelpers } from '../components/toast';
 import {
   copyNode,
@@ -2866,13 +2867,15 @@ export default function FilestoreExplorerPage({ identity }: FilestoreExplorerPag
               <div>
                 <div className="flex items-center justify-between">
                   <span className="text-scale-xs font-weight-medium text-muted">Advanced filters</span>
-                  <button
-                    type="button"
-                    onClick={handleResetFilters}
-                    className="text-scale-xs text-muted underline decoration-dotted underline-offset-2 hover:text-accent"
-                  >
-                    Reset all
-                  </button>
+                  {hasAdvancedFilters ? (
+                    <button
+                      type="button"
+                      onClick={handleResetFilters}
+                      className="text-scale-xs text-muted underline decoration-dotted underline-offset-2 hover:text-accent"
+                    >
+                      Reset all
+                    </button>
+                  ) : null}
                 </div>
                 {hasAdvancedFilters ? (
                   <div className="mt-2 flex flex-wrap gap-2">
@@ -2893,12 +2896,19 @@ export default function FilestoreExplorerPage({ identity }: FilestoreExplorerPag
                 )}
               </div>
 
-              <form
-                className="space-y-2"
-                onSubmit={(event) => {
-                  event.preventDefault();
-                  handleApplyQuery(queryDraft);
-                }}
+              <CollapsibleSection
+                title="Configure advanced filters"
+                description="Add metadata, size, time, and rollup constraints to refine the node list."
+                defaultOpen={hasAdvancedFilters}
+                contentClassName="space-y-4"
+              >
+
+                <form
+                  className="space-y-2"
+                  onSubmit={(event) => {
+                    event.preventDefault();
+                    handleApplyQuery(queryDraft);
+                  }}
               >
                 <label htmlFor="filestore-query" className="text-scale-xs font-weight-medium text-muted">
                   Search query
@@ -3130,6 +3140,8 @@ export default function FilestoreExplorerPage({ identity }: FilestoreExplorerPag
                   </button>
                 </div>
               </form>
+
+              </CollapsibleSection>
             </div>
 
             <div className="space-y-3">


### PR DESCRIPTION
## Summary
- hide timestore advanced controls behind collapsible sections and remove duplicate SQL entry point
- add reusable collapsible section component and adopt it across filestore/metastore
- collapse metastore DSL and patch tooling so default view focuses on basics

## Testing
- npm run lint --workspace @apphub/frontend