### PR TITLE
feat: add metastore full-text search UI

### DIFF
--- a/apps/frontend/src/filestore/hooks/useFilestorePreferences.ts
+++ b/apps/frontend/src/filestore/hooks/useFilestorePreferences.ts
@@ -1,0 +1,160 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { FilestoreNodeKind } from '../api';
+
+export type ViewMode = 'browse' | 'search';
+
+export type StoredNodeReference = {
+  backendMountId: number;
+  path: string;
+  kind: FilestoreNodeKind;
+  displayName: string;
+  lastAccessed: number;
+};
+
+type FilestorePreferences = {
+  viewMode: ViewMode;
+  setViewMode: (next: ViewMode) => void;
+  recents: StoredNodeReference[];
+  pushRecent: (node: Omit<StoredNodeReference, 'lastAccessed'>) => void;
+  starred: StoredNodeReference[];
+  toggleStar: (node: Omit<StoredNodeReference, 'lastAccessed'>) => void;
+  removeStar: (backendMountId: number, path: string) => void;
+  isStarred: (backendMountId: number, path: string) => boolean;
+};
+
+const VIEW_MODE_STORAGE_KEY = 'apphub.filestore.viewMode';
+const RECENTS_STORAGE_KEY = 'apphub.filestore.recentNodes';
+const STARRED_STORAGE_KEY = 'apphub.filestore.starredNodes';
+const MAX_RECENTS = 12;
+
+function readFromStorage<T>(key: string): T | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) {
+      return null;
+    }
+    return JSON.parse(raw) as T;
+  } catch (error) {
+    console.warn(`[filestore:preferences] Failed to read ${key} from storage`, error);
+    return null;
+  }
+}
+
+function writeToStorage<T>(key: string, value: T): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    window.localStorage.setItem(key, JSON.stringify(value));
+  } catch (error) {
+    console.warn(`[filestore:preferences] Failed to persist ${key} to storage`, error);
+  }
+}
+
+export function useFilestorePreferences(): FilestorePreferences {
+  const [viewMode, setViewModeState] = useState<ViewMode>(() => {
+    const stored = readFromStorage<ViewMode>(VIEW_MODE_STORAGE_KEY);
+    return stored === 'search' ? 'search' : 'browse';
+  });
+
+  const [recents, setRecents] = useState<StoredNodeReference[]>(() => {
+    const stored = readFromStorage<StoredNodeReference[]>(RECENTS_STORAGE_KEY);
+    if (!stored) {
+      return [];
+    }
+    return stored
+      .filter((entry) => entry.backendMountId && entry.path)
+      .map((entry) => ({
+        ...entry,
+        kind: entry.kind ?? 'file',
+        displayName: entry.displayName ?? entry.path.split('/').pop() ?? entry.path,
+        lastAccessed: entry.lastAccessed ?? Date.now()
+      }));
+  });
+
+  const [starred, setStarred] = useState<StoredNodeReference[]>(() => {
+    const stored = readFromStorage<StoredNodeReference[]>(STARRED_STORAGE_KEY);
+    if (!stored) {
+      return [];
+    }
+    return stored
+      .filter((entry) => entry.backendMountId && entry.path)
+      .map((entry) => ({
+        ...entry,
+        kind: entry.kind ?? 'file',
+        displayName: entry.displayName ?? entry.path.split('/').pop() ?? entry.path,
+        lastAccessed: entry.lastAccessed ?? Date.now()
+      }));
+  });
+
+  useEffect(() => {
+    writeToStorage(VIEW_MODE_STORAGE_KEY, viewMode);
+  }, [viewMode]);
+
+  useEffect(() => {
+    writeToStorage(RECENTS_STORAGE_KEY, recents);
+  }, [recents]);
+
+  useEffect(() => {
+    writeToStorage(STARRED_STORAGE_KEY, starred);
+  }, [starred]);
+
+  const pushRecent = useCallback(
+    (input: Omit<StoredNodeReference, 'lastAccessed'>) => {
+      setRecents((prev) => {
+        const withoutDupes = prev.filter(
+          (entry) => !(entry.backendMountId === input.backendMountId && entry.path === input.path)
+        );
+        const next: StoredNodeReference[] = [
+          { ...input, lastAccessed: Date.now() },
+          ...withoutDupes
+        ];
+        return next.slice(0, MAX_RECENTS);
+      });
+    },
+    []
+  );
+
+  const toggleStar = useCallback(
+    (input: Omit<StoredNodeReference, 'lastAccessed'>) => {
+      setStarred((prev) => {
+        const existing = prev.find(
+          (entry) => entry.backendMountId === input.backendMountId && entry.path === input.path
+        );
+        if (existing) {
+          return prev.filter(
+            (entry) => !(entry.backendMountId === input.backendMountId && entry.path === input.path)
+          );
+        }
+        const next: StoredNodeReference[] = [
+          { ...input, lastAccessed: Date.now() },
+          ...prev
+        ];
+        return next;
+      });
+    },
+    []
+  );
+
+  const removeStar = useCallback((backendMountId: number, path: string) => {
+    setStarred((prev) =>
+      prev.filter((entry) => !(entry.backendMountId === backendMountId && entry.path === path))
+    );
+  }, []);
+
+  const isStarred = useCallback(
+    (backendMountId: number, path: string) =>
+      starred.some((entry) => entry.backendMountId === backendMountId && entry.path === path),
+    [starred]
+  );
+
+  const value = useMemo<FilestorePreferences>(
+    () => ({ viewMode, setViewMode: setViewModeState, recents, pushRecent, starred, toggleStar, removeStar, isStarred }),
+    [viewMode, recents, pushRecent, starred, toggleStar, removeStar, isStarred]
+  );
+
+  return value;
+}

--- a/services/metastore/openapi.json
+++ b/services/metastore/openapi.json
@@ -1043,6 +1043,10 @@
                     "type": "string",
                     "description": "Lightweight query-string syntax (e.g. `key:foo owner=ops status:\"in progress\"`). Combined with other filters using AND semantics."
                   },
+                  "search": {
+                    "type": "string",
+                    "description": "Full-text search across record keys and serialized metadata."
+                  },
                   "preset": {
                     "type": "string",
                     "description": "Named server-defined filter preset. Requires appropriate scopes to use."

--- a/services/metastore/src/db/migrations.ts
+++ b/services/metastore/src/db/migrations.ts
@@ -98,6 +98,13 @@ const migrations: Migration[] = [
       `CREATE INDEX IF NOT EXISTS idx_metastore_record_idempotency_created
          ON metastore_record_idempotency(created_at);`
     ]
+  },
+  {
+    id: '005_metastore_full_text_search',
+    statements: [
+      `CREATE INDEX IF NOT EXISTS idx_metastore_records_search
+         ON metastore_records USING GIN (to_tsvector('simple', record_key || ' ' || COALESCE(metadata::text, '')));`
+    ]
   }
 ];
 

--- a/services/metastore/src/openapi/document.ts
+++ b/services/metastore/src/openapi/document.ts
@@ -665,6 +665,10 @@ export const openApiDocument: OpenAPIV3.Document = {
                     description:
                       'Lightweight query-string syntax (e.g. `key:foo owner=ops status:"in progress"`). Combined with other filters using AND semantics.'
                   },
+                  search: {
+                    type: 'string',
+                    description: 'Full-text search across record keys and serialized metadata.'
+                  },
                   preset: {
                     type: 'string',
                     description: 'Named server-defined filter preset. Requires appropriate scopes to use.'

--- a/services/metastore/src/routes/records.ts
+++ b/services/metastore/src/routes/records.ts
@@ -352,7 +352,8 @@ export async function registerRecordRoutes(app: FastifyInstance, config: Service
       limit: payload.limit,
       offset: payload.offset,
       sort: payload.sort,
-      projection: payload.projection
+      projection: payload.projection,
+      search: payload.search
     });
 
     const mode = payload.projection

--- a/services/metastore/src/schemas/records.ts
+++ b/services/metastore/src/schemas/records.ts
@@ -102,6 +102,7 @@ const searchSchema = z.object({
   namespace: namespaceSchema,
   filter: z.unknown().optional(),
   q: z.string().trim().min(1).max(512).optional(),
+  search: z.string().trim().min(2).max(512).optional(),
   preset: z.string().trim().min(1).max(64).optional(),
   includeDeleted: z.boolean().optional(),
   limit: z.number().int().min(1).max(200).optional(),
@@ -237,6 +238,7 @@ export type ParsedSearchPayload = {
   sort?: SortField[];
   projection?: string[];
   summary?: boolean;
+  search?: string;
 };
 
 export function parseSearchPayload(payload: unknown): ParsedSearchPayload {
@@ -264,7 +266,8 @@ export function parseSearchPayload(payload: unknown): ParsedSearchPayload {
     preset: parsed.preset,
     sort,
     projection,
-    summary: summary ? true : undefined
+    summary: summary ? true : undefined,
+    search: parsed.search
   } satisfies ParsedSearchPayload;
 }
 

--- a/services/metastore/src/search/queryBuilder.ts
+++ b/services/metastore/src/search/queryBuilder.ts
@@ -431,6 +431,16 @@ export function buildSearchQuery(options: SearchOptions): {
     predicates.push(`(${buildFilter(builder, options.filter)})`);
   }
 
+  if (options.search) {
+    const searchTerm = options.search.trim();
+    if (searchTerm.length > 0) {
+      const placeholder = builder.add(searchTerm);
+      predicates.push(
+        `to_tsvector('simple', ${TABLE_NAME}.record_key || ' ' || COALESCE(${TABLE_NAME}.metadata::text, '')) @@ plainto_tsquery('simple', ${placeholder})`
+      );
+    }
+  }
+
   const whereClause = predicates.length > 0 ? `WHERE ${predicates.join(' AND ')}` : '';
   const orderClause = buildOrderBy(options.sort);
 

--- a/services/metastore/src/search/types.ts
+++ b/services/metastore/src/search/types.ts
@@ -40,6 +40,7 @@ export type SearchOptions = {
   offset?: number;
   sort?: SortField[];
   projection?: string[];
+  search?: string;
 };
 
 export type SearchResult<T> = {

--- a/services/metastore/src/services/recordService.ts
+++ b/services/metastore/src/services/recordService.ts
@@ -46,6 +46,7 @@ export type SearchParams = {
   offset?: number;
   sort?: SortField[];
   projection?: string[];
+  search?: string;
 };
 
 export type BulkOperationResult =
@@ -528,7 +529,8 @@ export function createRecordService(deps: RecordServiceDependencies = {}) {
         limit: params.limit,
         offset: params.offset,
         sort: params.sort,
-        projection: params.projection
+        projection: params.projection,
+        search: params.search
       })
     );
   }

--- a/services/metastore/tests/unit/queryBuilder.test.ts
+++ b/services/metastore/tests/unit/queryBuilder.test.ts
@@ -33,3 +33,12 @@ test('omits metadata column for summary projections', () => {
   assert.match(selectClause, /metastore_records\.record_key/);
   assert.match(selectClause, /metastore_records\.updated_at/);
 });
+
+test('adds full-text predicate when search term is provided', () => {
+  const query = buildSearchQuery({ namespace: 'analytics', search: 'galaxy' });
+  assert.match(
+    query.text,
+    /to_tsvector\('simple', metastore_records\.record_key \|\| ' ' \|\| COALESCE\(metastore_records\.metadata::text, ''\)\) @@ plainto_tsquery\('simple', \$\d+\)/
+  );
+  assert.equal(query.values[1], 'galaxy');
+});

--- a/services/metastore/tests/unit/recordService.test.ts
+++ b/services/metastore/tests/unit/recordService.test.ts
@@ -172,9 +172,18 @@ function setupService(options?: SetupOptions) {
     service,
     events,
     published,
-    logger
+    logger,
+    searchRecords
   } as const;
 }
+
+test('searchRecords forwards full-text search term', async () => {
+  const ctx = setupService();
+  await ctx.service.searchRecords({ namespace: 'analytics', search: 'galaxy' });
+  const call = ctx.searchRecords.mock.calls.at(-1);
+  const options = call?.arguments?.[1] as { search?: string } | undefined;
+  assert.equal(options?.search, 'galaxy');
+});
 
 test('createRecord emits created events when record is newly inserted', async () => {
   const ctx = setupService();


### PR DESCRIPTION
## Summary
- add browse vs search modes + preferences in filestore explorer UI
- wire metastore explorer full-text search toggle and payload guards
- extend Vitest coverage for new metastore interactions and tidy lint issues

## Testing
- npm run lint
- npm run build
- npm run test
