### PR TITLE
fix: align observatory workflows with module-triggered events

### DIFF
--- a/apps/frontend/src/workflows/WorkflowsPage.tsx
+++ b/apps/frontend/src/workflows/WorkflowsPage.tsx
@@ -154,7 +154,6 @@ function WorkflowsPageContent() {
 
   const [searchParams] = useSearchParams();
   const [manualRunDialogOpen, setManualRunDialogOpen] = useState(false);
-  const [acknowledgedManualRunId, setAcknowledgedManualRunId] = useState<string | null>(null);
 
   useEffect(() => {
     const slugParam = searchParams.get('slug');
@@ -177,20 +176,11 @@ function WorkflowsPageContent() {
     }
   }, [searchParams, runs, selectedRunId, setSelectedRunId]);
 
-  const lastTriggeredRunId = lastTriggeredRun?.id ?? null;
-
   useEffect(() => {
-    if (!manualRunDialogOpen || !lastTriggeredRunId) {
-      return;
+    if (manualRunDialogOpen && lastTriggeredRun) {
+      setManualRunDialogOpen(false);
     }
-
-    if (lastTriggeredRunId === acknowledgedManualRunId) {
-      return;
-    }
-
-    setManualRunDialogOpen(false);
-    setAcknowledgedManualRunId(lastTriggeredRunId);
-  }, [manualRunDialogOpen, lastTriggeredRunId, acknowledgedManualRunId]);
+  }, [manualRunDialogOpen, lastTriggeredRun]);
 
   const analytics = selectedSlug ? workflowAnalytics[selectedSlug] : undefined;
   const stats = analytics?.stats ?? null;

--- a/examples/environmental-observatory-event-driven/scripts/lib/workflows.ts
+++ b/examples/environmental-observatory-event-driven/scripts/lib/workflows.ts
@@ -262,25 +262,58 @@ function buildTriggerDefinitions(config: EventDrivenObservatoryConfig): TriggerD
     {
       workflowSlug: config.workflows.ingestSlug,
       name: 'observatory-minute.raw-uploaded',
-      description: 'Kick off minute ingest whenever normalized inbox files are ready.',
-      eventType: 'observatory.minute.raw-uploaded',
-      predicates: [],
+      description:
+        'Kick off the minute ingest workflow whenever new observatory CSV uploads land in Filestore.',
+      eventType: 'filestore.command.completed',
+      eventSource: 'filestore.service',
+      predicates: [
+        {
+          path: '$.payload.command',
+          operator: 'equals',
+          value: 'uploadFile'
+        },
+        {
+          path: '$.payload.backendMountId',
+          operator: 'equals',
+          value: '{{ defaultParameters.filestoreBackendId }}'
+        },
+        {
+          path: '$.payload.node.metadata.minute',
+          operator: 'exists'
+        }
+      ],
       parameterTemplate: {
-        minute: '{{ trigger.payload.minute }}',
-        filestoreBaseUrl: config.filestore.baseUrl,
-        filestoreBackendId: config.filestore.backendMountId,
-        filestoreToken: config.filestore.token ?? null,
-        inboxPrefix: config.filestore.inboxPrefix,
-        stagingPrefix: config.filestore.stagingPrefix,
-        archivePrefix: config.filestore.archivePrefix,
-        filestorePrincipal: 'observatory-inbox-normalizer',
-        timestoreBaseUrl: config.timestore.baseUrl,
-        timestoreDatasetSlug: config.timestore.datasetSlug,
-        timestoreDatasetName: config.timestore.datasetName ?? null,
-        timestoreTableName: config.timestore.tableName ?? null,
-        timestoreStorageTargetId: config.timestore.storageTargetId ?? null,
-        timestoreAuthToken: config.timestore.authToken ?? null
+        minute: '{{ event.payload.node.metadata.minute }}',
+        instrumentId:
+          "{{ event.payload.node.metadata.instrumentId | default: event.payload.node.metadata.instrument_id | default: 'unknown' }}",
+        maxFiles: '{{ trigger.metadata.maxFiles }}',
+        filestoreBaseUrl: '{{ trigger.metadata.filestore.baseUrl }}',
+        filestoreBackendId: '{{ trigger.metadata.filestore.backendMountId }}',
+        filestoreToken: '{{ trigger.metadata.filestore.token }}',
+        inboxPrefix: '{{ trigger.metadata.filestore.inboxPrefix }}',
+        stagingPrefix: '{{ trigger.metadata.filestore.stagingPrefix }}',
+        archivePrefix: '{{ trigger.metadata.filestore.archivePrefix }}',
+        filestorePrincipal:
+          '{{ trigger.metadata.filestore.principal | default: event.payload.principal }}',
+        commandPath: '{{ event.payload.path }}',
+        timestoreBaseUrl: '{{ trigger.metadata.timestore.baseUrl }}',
+        timestoreDatasetSlug: '{{ trigger.metadata.timestore.datasetSlug }}',
+        timestoreDatasetName: '{{ trigger.metadata.timestore.datasetName }}',
+        timestoreTableName: '{{ trigger.metadata.timestore.tableName }}',
+        timestoreStorageTargetId: '{{ trigger.metadata.timestore.storageTargetId }}',
+        timestoreAuthToken: '{{ trigger.metadata.timestore.authToken }}',
+        metastoreBaseUrl: '{{ trigger.metadata.metastore.baseUrl }}',
+        metastoreNamespace: '{{ trigger.metadata.metastore.namespace }}',
+        metastoreAuthToken: '{{ trigger.metadata.metastore.authToken }}',
+        calibrationsBaseUrl: '{{ trigger.metadata.calibrations.baseUrl }}',
+        calibrationsNamespace: '{{ trigger.metadata.calibrations.namespace }}',
+        calibrationsAuthToken: '{{ trigger.metadata.calibrations.authToken }}',
+        filestoreBackendKey: '{{ trigger.metadata.filestore.backendMountKey }}'
       },
+      runKeyTemplate:
+        "observatory-ingest-{{ parameters.instrumentId | default: 'unknown' | replace: ':', '-' }}-{{ parameters.minute | replace: ':', '-' }}",
+      idempotencyKeyExpression:
+        "{{ event.payload.node.metadata.minute }}-{{ event.payload.path | replace: '/', '_' | replace: ':', '-' }}",
       metadata: ingestMetadata
     },
     {

--- a/examples/environmental-observatory-event-driven/scripts/lib/workflows.ts
+++ b/examples/environmental-observatory-event-driven/scripts/lib/workflows.ts
@@ -188,6 +188,7 @@ function buildTriggerDefinitions(config: EventDrivenObservatoryConfig): TriggerD
     filestore: {
       baseUrl: config.filestore.baseUrl,
       backendMountId: config.filestore.backendMountId,
+      backendMountKey: config.filestore.backendMountKey,
       token: config.filestore.token ?? null,
       inboxPrefix: config.filestore.inboxPrefix,
       stagingPrefix: config.filestore.stagingPrefix,

--- a/modules/environmental-observatory/scripts/lib/workflows.ts
+++ b/modules/environmental-observatory/scripts/lib/workflows.ts
@@ -339,8 +339,15 @@ export async function ensureWorkflow(
   }
 
   await request(baseUrl, token, 'PATCH', `/workflows/${slug}`, {
+    name: definition.name,
+    version: definition.version,
+    description: definition.description ?? null,
+    parametersSchema: definition.parametersSchema ?? {},
     defaultParameters: definition.defaultParameters,
-    metadata: definition.metadata ?? null
+    metadata: definition.metadata ?? null,
+    outputSchema: definition.outputSchema ?? undefined,
+    steps: definition.steps,
+    triggers: definition.triggers ?? undefined
   });
   logger.info?.('Updated workflow defaults', { slug });
   await ensureWorkflowSchedules(baseUrl, token, slug, definition, logger);
@@ -477,25 +484,58 @@ function buildTriggerDefinitions(config: EventDrivenObservatoryConfig): TriggerD
     {
       workflowSlug: config.workflows.ingestSlug,
       name: 'observatory-minute.raw-uploaded',
-      description: 'Kick off minute ingest whenever normalized inbox files are ready.',
-      eventType: 'observatory.minute.raw-uploaded',
-      predicates: [],
+      description:
+        'Kick off the minute ingest workflow whenever new observatory CSV uploads land in Filestore.',
+      eventType: 'filestore.command.completed',
+      eventSource: 'filestore.service',
+      predicates: [
+        {
+          path: '$.payload.command',
+          operator: 'equals',
+          value: 'uploadFile'
+        },
+        {
+          path: '$.payload.backendMountId',
+          operator: 'equals',
+          value: '{{ defaultParameters.filestoreBackendId }}'
+        },
+        {
+          path: '$.payload.node.metadata.minute',
+          operator: 'exists'
+        }
+      ],
       parameterTemplate: {
-        minute: '{{ trigger.payload.minute }}',
-        filestoreBaseUrl: config.filestore.baseUrl,
-        filestoreBackendId: config.filestore.backendMountId,
-        filestoreToken: config.filestore.token ?? null,
-        inboxPrefix: config.filestore.inboxPrefix,
-        stagingPrefix: config.filestore.stagingPrefix,
-        archivePrefix: config.filestore.archivePrefix,
-        filestorePrincipal: 'observatory-inbox-normalizer',
-        timestoreBaseUrl: config.timestore.baseUrl,
-        timestoreDatasetSlug: config.timestore.datasetSlug,
-        timestoreDatasetName: config.timestore.datasetName ?? null,
-        timestoreTableName: config.timestore.tableName ?? null,
-        timestoreStorageTargetId: config.timestore.storageTargetId ?? null,
-        timestoreAuthToken: config.timestore.authToken ?? null
+        minute: '{{ event.payload.node.metadata.minute }}',
+        instrumentId:
+          "{{ event.payload.node.metadata.instrumentId | default: event.payload.node.metadata.instrument_id | default: 'unknown' }}",
+        maxFiles: '{{ trigger.metadata.maxFiles }}',
+        filestoreBaseUrl: '{{ trigger.metadata.filestore.baseUrl }}',
+        filestoreBackendId: '{{ trigger.metadata.filestore.backendMountId }}',
+        filestoreToken: '{{ trigger.metadata.filestore.token }}',
+        inboxPrefix: '{{ trigger.metadata.filestore.inboxPrefix }}',
+        stagingPrefix: '{{ trigger.metadata.filestore.stagingPrefix }}',
+        archivePrefix: '{{ trigger.metadata.filestore.archivePrefix }}',
+        filestorePrincipal:
+          '{{ trigger.metadata.filestore.principal | default: event.payload.principal }}',
+        commandPath: '{{ event.payload.path }}',
+        timestoreBaseUrl: '{{ trigger.metadata.timestore.baseUrl }}',
+        timestoreDatasetSlug: '{{ trigger.metadata.timestore.datasetSlug }}',
+        timestoreDatasetName: '{{ trigger.metadata.timestore.datasetName }}',
+        timestoreTableName: '{{ trigger.metadata.timestore.tableName }}',
+        timestoreStorageTargetId: '{{ trigger.metadata.timestore.storageTargetId }}',
+        timestoreAuthToken: '{{ trigger.metadata.timestore.authToken }}',
+        metastoreBaseUrl: '{{ trigger.metadata.metastore.baseUrl }}',
+        metastoreNamespace: '{{ trigger.metadata.metastore.namespace }}',
+        metastoreAuthToken: '{{ trigger.metadata.metastore.authToken }}',
+        calibrationsBaseUrl: '{{ trigger.metadata.calibrations.baseUrl }}',
+        calibrationsNamespace: '{{ trigger.metadata.calibrations.namespace }}',
+        calibrationsAuthToken: '{{ trigger.metadata.calibrations.authToken }}',
+        filestoreBackendKey: '{{ trigger.metadata.filestore.backendMountKey }}'
       },
+      runKeyTemplate:
+        "observatory-ingest-{{ parameters.instrumentId | default: 'unknown' | replace: ':', '-' }}-{{ parameters.minute | replace: ':', '-' }}",
+      idempotencyKeyExpression:
+        "{{ event.payload.node.metadata.minute }}-{{ event.payload.path | replace: '/', '_' | replace: ':', '-' }}",
       metadata: ingestMetadata
     },
     {

--- a/modules/environmental-observatory/scripts/lib/workflows.ts
+++ b/modules/environmental-observatory/scripts/lib/workflows.ts
@@ -410,6 +410,7 @@ function buildTriggerDefinitions(config: EventDrivenObservatoryConfig): TriggerD
     filestore: {
       baseUrl: config.filestore.baseUrl,
       backendMountId: config.filestore.backendMountId,
+      backendMountKey: config.filestore.backendMountKey,
       token: config.filestore.token ?? null,
       inboxPrefix: config.filestore.inboxPrefix,
       stagingPrefix: config.filestore.stagingPrefix,

--- a/packages/observatory-support/src/observatorySupport.ts
+++ b/packages/observatory-support/src/observatorySupport.ts
@@ -168,10 +168,35 @@ export function applyObservatoryWorkflowDefaults(
         if (parameters.seed === undefined) {
           parameters.seed = '{{ defaultParameters.seed }}';
         }
-        if (parameters.minute === undefined) {
-          parameters.minute = '{{ run.trigger.schedule.occurrence | slice: 0, 16 }}';
-        }
         scheduleObject.parameters = parameters;
+      }
+
+      const steps = Array.isArray(definition.steps) ? definition.steps : [];
+      if (steps.length > 0) {
+        const stepEntry = steps[0];
+        if (stepEntry && typeof stepEntry === 'object' && !Array.isArray(stepEntry)) {
+          const stepObject = stepEntry as JsonObject;
+          const parameters = ensureJsonObject(stepObject.parameters as JsonValue | undefined);
+          const defaultMinute =
+            '{{ parameters.minute | default: run.trigger.schedule.occurrence | slice: 0, 16 }}';
+          if (
+            typeof parameters.minute !== 'string' ||
+            parameters.minute.trim().length === 0 ||
+            parameters.minute.trim() === '{{ parameters.minute }}'
+          ) {
+            parameters.minute = defaultMinute;
+          }
+
+          if (
+            typeof parameters.seed !== 'string' ||
+            parameters.seed.trim().length === 0 ||
+            parameters.seed.trim() === '{{ parameters.seed }}'
+          ) {
+            parameters.seed = '{{ parameters.seed | default: 1337 }}';
+          }
+
+          stepObject.parameters = parameters;
+        }
       }
       break;
     case 'observatory-minute-ingest':


### PR DESCRIPTION
## Summary
- update module registry defaults so the minute generator step and seed fallbacks come from TypeScript
- ensure observatory workflow sync script patches workflow definitions (steps, metadata, triggers) instead of just defaults
- allow the event-bus publisher to derive BullMQ connection settings from REDIS_URL so workers run off-container
- mirror the updated trigger wiring in the example scripts so post-migration repos stay in sync

## Testing
- npm run lint
- npm run build
- npm run test

Refs #119