### PR TITLE
chore: clarify website prototype messaging

### DIFF
--- a/apps/website/public/favicon.svg
+++ b/apps/website/public/favicon.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 48">
+  <defs>
+    <linearGradient id="eyeOuter" x1="6" y1="4" x2="66" y2="44" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0f766e" />
+      <stop offset="1" stop-color="#22d3ee" />
+    </linearGradient>
+    <radialGradient id="eyeInner" cx="50%" cy="50%" r="50%">
+      <stop offset="0" stop-color="#0f766e" stop-opacity="0.95" />
+      <stop offset="0.45" stop-color="#083b39" stop-opacity="0.88" />
+      <stop offset="1" stop-color="#011a19" stop-opacity="0.95" />
+    </radialGradient>
+    <radialGradient id="eyeHighlight" cx="36%" cy="32%" r="40%">
+      <stop offset="0" stop-color="#bef8ff" stop-opacity="0.9" />
+      <stop offset="1" stop-color="#bef8ff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <path
+    d="M36 4C20.5 4 8.09 13.73 3 24c5.09 10.27 17.5 20 33 20s27.91-9.73 33-20C63.91 13.73 51.5 4 36 4Z"
+    fill="url(#eyeOuter)"
+    fill-opacity="0.32"
+    stroke="url(#eyeOuter)"
+    stroke-width="2"
+    stroke-linejoin="round"
+  />
+  <ellipse cx="36" cy="24" rx="12.5" ry="12" fill="url(#eyeInner)" />
+  <circle cx="36" cy="24" r="6" fill="#22d3ee" opacity="0.9" />
+  <circle cx="30" cy="19" r="4" fill="url(#eyeHighlight)" />
+  <path
+    d="M12 24c5-6.5 13.3-10.5 24-10.5S55 17.5 60 24c-5 6.5-13.3 10.5-24 10.5S17 30.5 12 24Z"
+    fill="none"
+    stroke="rgba(34, 211, 238, 0.35)"
+    stroke-width="1.4"
+    stroke-linecap="round"
+  />
+</svg>

--- a/apps/website/src/layouts/BaseLayout.astro
+++ b/apps/website/src/layouts/BaseLayout.astro
@@ -17,6 +17,7 @@ const pathname = (Astro.url.pathname.replace(/\/$/, '') || '/')
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{title}</title>
     {description ? <meta name="description" content={description} /> : null}
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -212,6 +213,12 @@ const pathname = (Astro.url.pathname.replace(/\/$/, '') || '/')
         line-height: 1.15;
       }
 
+      .site-header__actions {
+        display: flex;
+        align-items: center;
+        gap: var(--apphub-spacing-xs);
+      }
+
       .site-header__cta {
         display: inline-flex;
         align-items: center;
@@ -222,12 +229,22 @@ const pathname = (Astro.url.pathname.replace(/\/$/, '') || '/')
         background: var(--apphub-color-surface);
         color: var(--apphub-color-text);
         font-weight: var(--apphub-typography-font-weight-semibold);
+        transition: color 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
       }
 
       .site-header__cta:hover,
       .site-header__cta:focus-visible {
         border-color: var(--apphub-color-accent-strong);
         color: var(--apphub-color-accent-strong);
+      }
+
+      .site-header__cta--ghost {
+        background: transparent;
+      }
+
+      .site-header__cta--ghost:hover,
+      .site-header__cta--ghost:focus-visible {
+        background: color-mix(in srgb, var(--apphub-color-accent-strong) 12%, transparent);
       }
 
       main {
@@ -382,9 +399,19 @@ const pathname = (Astro.url.pathname.replace(/\/$/, '') || '/')
             })}
           </ul>
         </nav>
-        <a class="site-header__cta" href="https://github.com/benediktbwimmer/apphub" target="_blank" rel="noreferrer">
-          GitHub
-        </a>
+        <div class="site-header__actions">
+          <a
+            class="site-header__cta site-header__cta--ghost"
+            href="https://demo.osiris-apphub.com"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Live demo
+          </a>
+          <a class="site-header__cta" href="https://github.com/benediktbwimmer/apphub" target="_blank" rel="noreferrer">
+            GitHub
+          </a>
+        </div>
       </div>
     </header>
     <main id="main-content">

--- a/apps/website/src/pages/adoption/index.astro
+++ b/apps/website/src/pages/adoption/index.astro
@@ -3,7 +3,7 @@ import BaseLayout from '@layouts/BaseLayout.astro';
 import { AdoptionJourneyDiagram } from '@components/diagrams';
 
 const title = 'Adoption services | Osiris AppHub';
-const description = 'Partner with the AppHub team to learn the platform, model your module, and launch in weeks.';
+const description = 'Help shape the AppHub adoption programme while we stabilise the early prototype and document the co-building path.';
 
 const sessions = [
   {
@@ -54,7 +54,7 @@ const signals = [
         <p class="page-hero__eyebrow">Adoption programme</p>
         <h1>Co-build your first AppHub module with us.</h1>
         <p class="page-hero__intro">
-          AppHub is open source. We teach your team the platform, model the module with you, and launch together—so you can run and extend it with confidence.
+          AppHub is open source and still an early prototype. We are designing the adoption programme with the community and will share pilot availability once the platform is production ready.
         </p>
         <div class="page-hero__actions">
           <a class="button button--primary" href="mailto:osirisapphub@gmail.com">Plan an onboarding sprint</a>
@@ -62,10 +62,10 @@ const signals = [
           <a class="button button--ghost" href="/module-sdk">Explore the Module SDK</a>
         </div>
         <div class="page-hero__notice">
-          <strong>Help build the Service Adoption team.</strong>
+          <strong>Planned programme:</strong>
           <span>
-            We are recruiting contributors, facilitators, and designers to co-create the onboarding experience. If you love shaping playbooks and polishing the UI,
-            reach out at <a href="mailto:osirisapphub@gmail.com">osirisapphub@gmail.com</a>.
+            Adoption services are in design and not yet available. We are looking for contributors across the platform, playbooks, and this website—if you want to co-create the experience, email
+            <a href="mailto:osirisapphub@gmail.com">osirisapphub@gmail.com</a>.
           </span>
         </div>
       </div>
@@ -137,9 +137,9 @@ const signals = [
   <section class="cta" aria-labelledby="cta-heading">
     <div class="container cta__inner">
       <div>
-        <h2 id="cta-heading" class="section-heading">Ready to build?</h2>
+        <h2 id="cta-heading" class="section-heading">Help us launch the programme</h2>
         <p>
-          Share your module idea and we will assemble the right crew—strategist, engineer, coach—to help you deploy faster while contributing back to the open-source platform.
+          Share your module idea or the contribution you want to make. We will coordinate the right crew—strategist, engineer, coach—to shape the adoption track and improve the open-source platform together.
         </p>
       </div>
       <div class="cta__actions">

--- a/apps/website/src/pages/business/index.astro
+++ b/apps/website/src/pages/business/index.astro
@@ -4,7 +4,7 @@ import { BusinessConstellationDiagram, BusinessObservatoryDiagram } from '@compo
 
 const title = 'Business value | Osiris AppHub';
 const description =
-  'Understand how AppHub modules accelerate operations programmes and how we partner with leadership teams to model use cases in weeks.';
+  'See how AppHub modules can accelerate operations programmes and learn how we plan to partner with leadership teams once the platform leaves its early prototype phase.';
 
 const reasons = [
   {
@@ -98,12 +98,19 @@ const observatoryHighlights = [
         <p class="page-hero__eyebrow">For leadership teams</p>
         <h1>Model any operations programme as an AppHub module.</h1>
         <p class="page-hero__intro">
-          AppHub is open source. We collaborate with business leaders to turn critical initiatives into modules that deploy in weeks—self-hosted or with our guidance.
+          AppHub is open source and currently an early prototype. We are outlining how we will partner with business leaders once the platform is production ready.
         </p>
         <div class="page-hero__actions">
           <a class="button button--primary" href="mailto:osirisapphub@gmail.com">Schedule a strategy workshop</a>
           <a class="button button--secondary" href="https://github.com/benediktbwimmer/apphub" target="_blank" rel="noreferrer">View on GitHub</a>
           <a class="button button--ghost" href="/adoption">Explore adoption services</a>
+        </div>
+        <div class="page-hero__notice">
+          <strong>Planning in progress:</strong>
+          <span>
+            Adoption services are not yet available. We are looking for contributors across the platform, operations playbooks, and this website to help shape the launch—email
+            <a href="mailto:osirisapphub@gmail.com">osirisapphub@gmail.com</a> if you would like to help.
+          </span>
         </div>
       </div>
       <figure>
@@ -131,7 +138,10 @@ const observatoryHighlights = [
 
   <section class="offerings" aria-labelledby="offerings-heading">
     <div class="container offerings__inner">
-      <h2 id="offerings-heading" class="section-heading">How we partner with you</h2>
+      <h2 id="offerings-heading" class="section-heading">How we plan to partner with you</h2>
+      <p class="offerings__intro">
+        These tracks are still being finalised—consider them a draft playbook while we build capacity for adoption services.
+      </p>
       <div class="cards-grid cards-grid--three">
         {offerings.map((item) => (
           <article>
@@ -170,7 +180,7 @@ const observatoryHighlights = [
 
   <section class="timeline" aria-labelledby="timeline-heading">
     <div class="container timeline__inner">
-      <h2 id="timeline-heading" class="section-heading">What the first six weeks look like</h2>
+      <h2 id="timeline-heading" class="section-heading">What the first six weeks could look like</h2>
       <ol>
         {engagementTimeline.map((item) => (
           <li>
@@ -180,7 +190,7 @@ const observatoryHighlights = [
         ))}
       </ol>
       <p class="timeline__note">
-        Combine internal teams with our strategists, solution engineers, and operator coaches—we meet you where you are on the open-source journey.
+        Combine internal teams with our strategists, solution engineers, and operator coaches once the programme launches—this draft timeline captures how we aim to support open-source adopters.
       </p>
     </div>
   </section>
@@ -264,6 +274,23 @@ const observatoryHighlights = [
     gap: var(--apphub-spacing-sm);
   }
 
+  .page-hero__notice {
+    margin-top: var(--apphub-spacing-md);
+    display: flex;
+    flex-direction: column;
+    gap: var(--apphub-spacing-xxs);
+    padding: var(--apphub-spacing-sm);
+    border: 1px solid var(--apphub-color-border);
+    border-radius: var(--apphub-radius-lg);
+    background: var(--apphub-color-surface-muted);
+    color: var(--apphub-color-text);
+    font-size: var(--apphub-typography-font-size-sm);
+  }
+
+  .page-hero__notice a {
+    color: var(--apphub-color-accent-strong);
+  }
+
   .page-hero figure {
     margin: 0;
     display: grid;
@@ -303,6 +330,17 @@ const observatoryHighlights = [
   .timeline,
   .observatory {
     padding: var(--apphub-spacing-3xl) 0;
+  }
+
+  .offerings__inner {
+    display: grid;
+    gap: var(--apphub-spacing-lg);
+  }
+
+  .offerings__intro {
+    margin: 0;
+    max-width: 65ch;
+    color: var(--apphub-color-text-muted);
   }
 
   .value__inner ul {

--- a/apps/website/src/pages/index.astro
+++ b/apps/website/src/pages/index.astro
@@ -158,18 +158,19 @@ const observatoryTakeaways = [
             <strong>Heads-up:</strong> the unified UI is mid-polish and will keep changing rapidly—expect frequent visual and UX updates as we harden the experience.
           </p>
           <p>
-            <strong>Early access:</strong> AppHub is not production ready yet. We are in the final hardening sprint and expect to flip the production-ready switch within the next couple of weeks.
+            <strong>Early prototype:</strong> AppHub is pre-production and evolving in the open. We will announce production readiness once the community validates the full workflow.
           </p>
         </div>
         <div class="hero__actions">
           <a class="button button--primary" href="mailto:osirisapphub@gmail.com">Book a module workshop</a>
           <a class="button button--secondary" href="/technical">Review the technical brief</a>
+          <a class="button button--ghost" href="https://demo.osiris-apphub.com" target="_blank" rel="noreferrer">Browse the live demo (read-only)</a>
           <a class="button button--ghost" href="https://github.com/benediktbwimmer/apphub" target="_blank" rel="noreferrer">View on GitHub</a>
         </div>
         <div class="hero__contributor">
           <strong>Join the crew:</strong>
           <span>
-            We are actively looking for open-source contributors and teammates for the Service Adoption team. If you want to shape onboarding playbooks or ship UI polish, email
+            We are actively looking for contributors across the stack—core services, SDKs, and this website. If you want to shape onboarding playbooks, harden the control plane, or ship UI polish, email
             <a href="mailto:osirisapphub@gmail.com">osirisapphub@gmail.com</a>.
           </span>
         </div>
@@ -326,7 +327,10 @@ const observatoryTakeaways = [
 
   <section class="services" aria-labelledby="services-heading">
     <div class="container services__inner">
-      <h2 id="services-heading" class="section-heading">What we offer today</h2>
+      <h2 id="services-heading" class="section-heading">Adoption services in the works</h2>
+      <p class="services__intro">
+        We are drafting these co-building tracks right now—adoption services are not yet available. Help us design and deliver them by contributing to the platform and playbooks.
+      </p>
       <div class="services__grid">
         {services.map((item) => (
           <article>
@@ -692,6 +696,12 @@ const observatoryTakeaways = [
   .services__inner {
     display: grid;
     gap: var(--apphub-spacing-xl);
+  }
+
+  .services__intro {
+    max-width: 65ch;
+    margin: 0 0 var(--apphub-spacing-md);
+    color: var(--apphub-color-text-muted);
   }
 
   .services__grid {

--- a/apps/website/src/pages/technical/index.astro
+++ b/apps/website/src/pages/technical/index.astro
@@ -126,7 +126,7 @@ const observability = [
         <div class="page-hero__notice">
           <strong>Current status:</strong>
           <span>
-            UI polish is ongoing and the control plane is still in early access. We expect production readiness within the next couple of weeks—contributors are welcome to help us reach the finish line.
+            UI polish is ongoing and the control plane is still an early prototype. We will publish production guidance once the modules and services are battle-tested—contributors are welcome to help us get there.
           </span>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- emphasise across marketing pages that AppHub is an early prototype and adoption services are still in design
- invite contributors for platform, playbooks, and website work while adding a read-only live demo CTA in the hero and header
- link the read-only demo, remove the production timeline copy, and add the Osiris eye favicon via the shared layout

## Testing
- npm run lint --workspace @apphub/website
- npm run build --workspace @apphub/website
