### PR TITLE
feat: add managed secrets service

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -303,7 +303,7 @@ See `docs/filestore.md` for the full architecture, data model, and rollout plan.
 - Job handlers gain a `resolveSecret` helper that records audit entries whenever runtime secrets are fetched.
 
 ## Secret Management
-- Workflow service steps and job handlers resolve runtime credentials through a pluggable secret store (inline JSON or file-backed) rather than raw environment access.
+- Workflow service steps and job handlers resolve runtime credentials through the managed secrets service (with optional inline fallback) rather than raw environment access.
 - Secrets support optional version hints; mismatches and missing keys are surfaced as orchestration errors and captured in audit logs.
 - Secret access metadata (workflow run, step ID, job run) is persisted, enabling compliance reviews and least-privilege validation.
 

--- a/docs/secrets-service.md
+++ b/docs/secrets-service.md
@@ -1,0 +1,119 @@
+# Managed Secrets Service
+
+The managed secrets service brokers short-lived credentials for workflows, jobs, and
+extensions that need to access secret material without embedding raw values in the
+core process. The service centralizes auditing, supports multiple secret backends,
+and exposes a REST API for issuing, refreshing, and revoking scoped access tokens.
+
+## Running the service
+
+```
+npm run dev --workspace @apphub/secrets
+```
+
+The service listens on `0.0.0.0:4010` by default. Override the host or port with
+`SECRETS_SERVICE_HOST` / `SECRETS_SERVICE_PORT`.
+
+### Required configuration
+
+| Variable | Description |
+| --- | --- |
+| `SECRETS_SERVICE_ADMIN_TOKENS` | JSON array of admin token definitions (see below) |
+| `SECRETS_SERVICE_ADMIN_TOKENS_PATH` | Optional path to a JSON file with the same shape |
+
+Each admin token entry must provide:
+
+```json
+{
+  "token": "<opaque bearer token>",
+  "subject": "core.workflows",
+  "allowedKeys": ["*"],
+  "maxTtlSeconds": 3600,
+  "metadata": { "owner": "platform-ops" }
+}
+```
+
+`allowedKeys` accepts `"*"` for wildcard or a list of permitted keys. `maxTtlSeconds`
+clamps requests so callers cannot mint excessively long-lived credentials.
+
+### Backends
+
+Backends are enabled via `SECRETS_SERVICE_BACKENDS`. The default is `env,file`.
+
+- **Env backend (`env`)** — Parses JSON from `APPHUB_SECRET_STORE`. This is useful for
+development and for inline fallback during migrations.
+- **File backend (`file`)** — Reads JSON from `SECRETS_SERVICE_FILE_PATH` (falls back to
+`APPHUB_SECRET_STORE_PATH`). Set `SECRETS_SERVICE_FILE_OPTIONAL=1` to ignore missing files.
+- **Vault backend (`vault`)** — Loads JSON from `SECRETS_SERVICE_VAULT_FILE`. The loader is
+file-backed today so operators can sync material from HashiCorp Vault (or similar)
+brfore pointing the service at a managed mount. `SECRETS_SERVICE_VAULT_NAMESPACE` and
+`SECRETS_SERVICE_VAULT_OPTIONAL` control namespace tagging and optional loads.
+
+Backends can be combined; later backends overwrite earlier definitions for duplicate keys.
+
+### Refresh and inline fallback
+
+`SECRETS_SERVICE_REFRESH_INTERVAL_MS` triggers periodic reloads of every backend. The
+`POST /v1/secrets/refresh` endpoint forces a refresh on demand. Setting
+`SECRETS_SERVICE_INLINE_FALLBACK=1` keeps the legacy inline lookup available as a last
+resort when managed backends do not supply a value.
+
+## API surface
+
+All admin endpoints require the configured bearer token in the `Authorization: Bearer`
+header. Secret fetches require a scoped token issued by one of the admin endpoints.
+
+| Method & path | Description |
+| --- | --- |
+| `POST /v1/tokens` | Issue a new scoped secret token. Body: `{ "subject": "...", "keys": ["SECRET_KEY"], "ttlSeconds": 300 }`. Returns the opaque token and expiry. |
+| `POST /v1/tokens/:token/refresh` | Extend a token before it expires. Optional `ttlSeconds` overrides the default. |
+| `DELETE /v1/tokens/:token` | Revoke a token immediately. |
+| `GET /v1/secrets/:key` | Resolve a secret using a scoped token. Returns `{ key, value, version, metadata, backend, tokenExpiresAt }`. |
+| `POST /v1/secrets/refresh` | Force all backends to reload. Useful after rotations. |
+| `GET /v1/status` | Debug endpoint exposing the current registry snapshot and active tokens (metadata only). |
+| `GET /healthz` / `GET /readyz` | Health probes. |
+
+Secrets are cached in the service and in the shared client for a short time (`cacheTtlMs`),
+so rotations usually take effect without restarts. Calling the refresh endpoint after
+updating source material ensures the registry observes the latest values immediately.
+
+## Audit events
+
+Every token lifecycle change and secret access produces an event on the shared bus through
+`@apphub/event-bus`:
+
+- `secret.token.issued`
+- `secret.token.refreshed`
+- `secret.token.revoked`
+- `secret.access`
+
+The payloads include the token id/hash, subject, scopes, resolved backend, and outcome.
+These events drive compliance reporting and can feed anomaly detectors.
+
+## Client integration
+
+Core services and workers now use the shared `SecretsClient` (see `@apphub/shared`) to
+exchange admin credentials for scoped tokens automatically. Configure clients with:
+
+| Variable | Description |
+| --- | --- |
+| `SECRETS_SERVICE_URL` | Base URL for the secrets service (defaults to `http://127.0.0.1:4010`). |
+| `SECRETS_SERVICE_ADMIN_TOKEN` | Admin token used to mint scoped credentials. |
+| `APPHUB_SECRETS_SUBJECT` | Optional subject override when the client issues tokens. |
+| `APPHUB_SECRETS_TOKEN_TTL` | Requested TTL for short-lived tokens (seconds). |
+| `APPHUB_SECRETS_CACHE_TTL_MS` | Local cache TTL for resolved values. |
+| `APPHUB_SECRETS_MODE=inline` | Fallback to legacy inline secret resolution in emergencies. |
+
+With `APPHUB_SECRETS_MODE=inline`, the core reuses the previous `APPHUB_SECRET_STORE`
+behaviour. This provides a simple rollback mechanism while teams migrate their secret
+material into the dedicated service.
+
+## Rotation workflow
+
+1. Update the appropriate backend (Vault, file, etc.) with the new secret value.
+2. Call `POST /v1/secrets/refresh` or wait for the scheduled refresh interval.
+3. Clients automatically pick up the new value within their cache TTL.
+4. Revoke any outstanding scoped tokens if they should no longer access the updated key.
+
+There is no need to restart core services to pick up rotations—the managed client refreshes
+values lazily and invalidates cache entries when tokens expire.

--- a/docs/service-candidates.md
+++ b/docs/service-candidates.md
@@ -17,6 +17,8 @@ This note captures potential services that could complement the existing AppHub 
 - **Integration**: Replace the core `resolveSecret` helper with a lightweight client that requests scoped tokens. Emit access logs to the event bus for compliance workflows.
 - **Open Questions**: Do we need envelope encryption at rest beyond what vault integrations provide? Can we enforce per-tenant quotas or per-step policies without adding latency to job startup?
 
+_Status: shipped in `services/secrets`. Refer to `docs/secrets-service.md` for the API surface and migration guide._
+
 ## Search & Recommendation API
 - **Why**: Core shoulders ingestion, orchestration, and search. Future ranking, personalization, or vector-based discovery will outgrow the Postgres FTS tables currently embedded in core.
 - **What**: Extract indexing, scoring, and search persistence into its own service. Allow experimentation with alternative backends (Meilisearch, Vespa, pgvector) without coupling rollouts to core deployments.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15700,13 +15700,6 @@
         "typescript": "^5.9.2"
       }
     },
-    "services/streaming": {
-      "name": "@apphub/streaming",
-      "version": "0.1.0",
-      "dependencies": {
-        "kafkajs": "^2.2.4"
-      }
-    },
     "services/timestore": {
       "name": "@apphub/timestore",
       "version": "0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15700,6 +15700,13 @@
         "typescript": "^5.9.2"
       }
     },
+    "services/streaming": {
+      "name": "@apphub/streaming",
+      "version": "0.1.0",
+      "dependencies": {
+        "kafkajs": "^2.2.4"
+      }
+    },
     "services/timestore": {
       "name": "@apphub/timestore",
       "version": "0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -331,6 +331,10 @@
       "resolved": "packages/observatory-support",
       "link": true
     },
+    "node_modules/@apphub/secrets": {
+      "resolved": "services/secrets",
+      "link": true
+    },
     "node_modules/@apphub/shared": {
       "resolved": "packages/shared",
       "link": true
@@ -15677,6 +15681,23 @@
       "version": "0.1.0",
       "dependencies": {
         "kafkajs": "^2.2.4"
+      }
+    },
+    "services/secrets": {
+      "name": "@apphub/secrets",
+      "version": "0.1.0",
+      "dependencies": {
+        "@apphub/event-bus": "0.1.0",
+        "@apphub/shared": "0.1.1",
+        "fastify": "^5.6.1",
+        "fastify-plugin": "^5.0.1",
+        "zod": "^3.25.76"
+      },
+      "devDependencies": {
+        "@types/node": "^24.5.2",
+        "ts-node": "^10.9.2",
+        "tsx": "^4.20.5",
+        "typescript": "^5.9.2"
       }
     },
     "services/timestore": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "dev:services": "node scripts/dev-services.js",
     "dev:materializer": "npm run materializer --workspace @apphub/core",
     "dev:observatory": "node scripts/dev-load-observatory.mjs",
+    "dev:secrets": "npm run dev --workspace @apphub/secrets",
     "dev:metastore": "npm run dev --workspace @apphub/metastore",
     "dev:filestore": "npm run dev --workspace @apphub/filestore",
     "dev:filestore:reconcile": "npm run reconcile:watch --workspace @apphub/filestore",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -11,3 +11,5 @@ export * from './retries/config';
 export * from './workflowTopology';
 export * from './eventsExplorer';
 export * from './gitRepo';
+export * from './secretsClient';
+export * from './secretEvents';

--- a/packages/shared/src/secretEvents.ts
+++ b/packages/shared/src/secretEvents.ts
@@ -1,0 +1,54 @@
+import type { JsonValue } from './workflowTopology';
+
+type SecretEventBase = {
+  subject: string;
+  tokenId: string;
+  tokenHash: string;
+  metadata?: Record<string, JsonValue> | null;
+};
+
+export type SecretAccessEvent = {
+  type: 'secret.access';
+  data: SecretEventBase & {
+    key: string;
+    backend: string;
+    outcome: 'authorized' | 'forbidden' | 'missing' | 'expired';
+    version?: string | null;
+    reason?: string | null;
+    accessedAt: string;
+    issuedAt: string;
+    expiresAt: string;
+  };
+};
+
+export type SecretTokenIssuedEvent = {
+  type: 'secret.token.issued';
+  data: SecretEventBase & {
+    keys: string[] | '*';
+    issuedAt: string;
+    expiresAt: string;
+  };
+};
+
+export type SecretTokenRefreshedEvent = {
+  type: 'secret.token.refreshed';
+  data: SecretEventBase & {
+    keys: string[] | '*';
+    issuedAt: string;
+    previousExpiresAt: string;
+    expiresAt: string;
+  };
+};
+
+export type SecretTokenRevokedEvent = {
+  type: 'secret.token.revoked';
+  data: SecretEventBase & {
+    revokedAt: string;
+  };
+};
+
+export type SecretEvent =
+  | SecretAccessEvent
+  | SecretTokenIssuedEvent
+  | SecretTokenRefreshedEvent
+  | SecretTokenRevokedEvent;

--- a/packages/shared/src/secretsClient.ts
+++ b/packages/shared/src/secretsClient.ts
@@ -1,0 +1,236 @@
+import type { JsonValue } from './workflowTopology';
+
+export type ManagedSecret = {
+  key: string;
+  value: string | null;
+  version: string | null;
+  metadata: Record<string, JsonValue> | null;
+  backend: string;
+  tokenExpiresAt: string;
+};
+
+export type SecretsClientConfig = {
+  baseUrl: string;
+  adminToken: string;
+  subject?: string;
+  fetchImpl?: typeof fetch;
+  tokenTtlSeconds?: number;
+  tokenRenewalBufferMs?: number;
+  cacheTtlMs?: number;
+  logger?: {
+    debug?: (message: string, meta?: Record<string, unknown>) => void;
+    warn?: (message: string, meta?: Record<string, unknown>) => void;
+    error?: (message: string, meta?: Record<string, unknown>) => void;
+  };
+};
+
+export class SecretsClient {
+  private readonly baseUrl: string;
+  private readonly adminToken: string;
+  private readonly subject: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly tokenTtlSeconds: number;
+  private readonly tokenRenewalBufferMs: number;
+  private readonly cacheTtlMs: number;
+  private readonly logger?: SecretsClientConfig['logger'];
+
+  private readonly tokenCache = new Map<string, TokenCacheEntry>();
+  private readonly tokenPromises = new Map<string, Promise<TokenCacheEntry>>();
+  private readonly secretCache = new Map<string, SecretCacheEntry>();
+
+  constructor(config: SecretsClientConfig) {
+    if (!config.baseUrl) {
+      throw new Error('SecretsClient requires a baseUrl');
+    }
+    if (!config.adminToken) {
+      throw new Error('SecretsClient requires an adminToken');
+    }
+    this.baseUrl = config.baseUrl.replace(/\/?$/, '');
+    this.adminToken = config.adminToken;
+    this.subject = config.subject?.trim() || 'apphub.client';
+    this.fetchImpl = config.fetchImpl ?? globalThis.fetch?.bind(globalThis);
+    if (!this.fetchImpl) {
+      throw new Error('SecretsClient requires a fetch implementation');
+    }
+    this.tokenTtlSeconds = Math.max(config.tokenTtlSeconds ?? 300, 60);
+    this.tokenRenewalBufferMs = Math.max(config.tokenRenewalBufferMs ?? 5000, 1000);
+    this.cacheTtlMs = Math.max(config.cacheTtlMs ?? 10_000, 1000);
+    this.logger = config.logger;
+  }
+
+  async resolveSecret(key: string, options?: { forceRefresh?: boolean }): Promise<ManagedSecret | null> {
+    const trimmedKey = key.trim();
+    if (!trimmedKey) {
+      return null;
+    }
+    if (!options?.forceRefresh) {
+      const cached = this.secretCache.get(trimmedKey);
+      if (cached && cached.expiresAt > Date.now()) {
+        return cached.secret;
+      }
+    }
+
+    const token = await this.ensureToken(trimmedKey);
+    const secret = await this.fetchSecret(trimmedKey, token);
+    if (!secret) {
+      this.secretCache.delete(trimmedKey);
+      return null;
+    }
+
+    this.secretCache.set(trimmedKey, {
+      secret,
+      expiresAt: Date.now() + this.cacheTtlMs
+    });
+    return secret;
+  }
+
+  invalidate(key: string): void {
+    const trimmed = key.trim();
+    if (!trimmed) {
+      return;
+    }
+    this.secretCache.delete(trimmed);
+    this.tokenCache.delete(trimmed);
+  }
+
+  reset(): void {
+    this.secretCache.clear();
+    this.tokenCache.clear();
+    this.tokenPromises.clear();
+  }
+
+  private async ensureToken(key: string): Promise<TokenCacheEntry> {
+    const existing = this.tokenCache.get(key);
+    if (existing && existing.expiresAt - Date.now() > this.tokenRenewalBufferMs) {
+      return existing;
+    }
+    const pending = this.tokenPromises.get(key);
+    if (pending) {
+      return pending;
+    }
+    const promise = this.issueToken(key)
+      .then((token) => {
+        this.tokenCache.set(key, token);
+        return token;
+      })
+      .finally(() => {
+        this.tokenPromises.delete(key);
+      });
+    this.tokenPromises.set(key, promise);
+    return promise;
+  }
+
+  private async issueToken(key: string): Promise<TokenCacheEntry> {
+    const response = await this.fetchImpl(`${this.baseUrl}/v1/tokens`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${this.adminToken}`,
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify({
+        subject: this.subject,
+        keys: [key],
+        ttlSeconds: this.tokenTtlSeconds
+      })
+    });
+
+    if (!response.ok) {
+      const message = await safeReadError(response);
+      this.logger?.error?.('Failed to issue secret token', {
+        status: response.status,
+        statusText: response.statusText,
+        message
+      });
+      throw new Error(`Failed to issue secret token: ${response.status}`);
+    }
+
+    const data = (await response.json()) as SecretTokenResponse;
+    const expiresAt = Date.parse(data.expiresAt);
+    return {
+      token: data.token,
+      expiresAt: Number.isFinite(expiresAt) ? expiresAt : Date.now() + this.tokenTtlSeconds * 1000,
+      allowedKeys: data.allowedKeys === '*' ? '*' : new Set(data.allowedKeys)
+    } satisfies TokenCacheEntry;
+  }
+
+  private async fetchSecret(key: string, token: TokenCacheEntry): Promise<ManagedSecret | null> {
+    const response = await this.fetchImpl(`${this.baseUrl}/v1/secrets/${encodeURIComponent(key)}`, {
+      method: 'GET',
+      headers: {
+        authorization: `Bearer ${token.token}`
+      }
+    });
+
+    if (response.status === 404) {
+      return null;
+    }
+    if (response.status === 401 || response.status === 403) {
+      this.logger?.warn?.('Secret access denied, invalidating token', {
+        key,
+        status: response.status
+      });
+      this.tokenCache.delete(key);
+      this.secretCache.delete(key);
+      throw new Error(`Secret access forbidden for key ${key}`);
+    }
+    if (!response.ok) {
+      const message = await safeReadError(response);
+      this.logger?.error?.('Failed to fetch secret', {
+        key,
+        status: response.status,
+        message
+      });
+      throw new Error(`Failed to fetch secret: ${response.status}`);
+    }
+
+    const data = (await response.json()) as SecretValueResponse;
+    return {
+      key: data.key,
+      value: typeof data.value === 'string' ? data.value : null,
+      version: typeof data.version === 'string' ? data.version : null,
+      metadata: (data.metadata ?? null) as Record<string, JsonValue> | null,
+      backend: data.backend,
+      tokenExpiresAt: data.tokenExpiresAt
+    } satisfies ManagedSecret;
+  }
+}
+
+async function safeReadError(response: Response): Promise<string> {
+  try {
+    const text = await response.text();
+    return text.slice(0, 1024);
+  } catch {
+    return '';
+  }
+}
+
+type TokenCacheEntry = {
+  token: string;
+  expiresAt: number;
+  allowedKeys: Set<string> | '*';
+};
+
+type SecretCacheEntry = {
+  secret: ManagedSecret;
+  expiresAt: number;
+};
+
+type SecretTokenResponse = {
+  token: string;
+  tokenId: string;
+  subject: string;
+  issuedAt: string;
+  expiresAt: string;
+  allowedKeys: string[] | '*';
+  tokenHash: string;
+  refreshCount: number;
+};
+
+type SecretValueResponse = {
+  key: string;
+  value: string | null;
+  version: string | null;
+  metadata?: Record<string, JsonValue> | null;
+  backend: string;
+  tokenExpiresAt: string;
+};

--- a/services/core/src/jobs/runtime.ts
+++ b/services/core/src/jobs/runtime.ts
@@ -154,7 +154,7 @@ export type JobRunContext = {
   }): Promise<JobRunRecord>;
   heartbeat(): Promise<JobRunRecord>;
   logger: (message: string, meta?: Record<string, unknown>) => void;
-  resolveSecret(reference: SecretReference): string | null;
+  resolveSecret(reference: SecretReference): Promise<string | null>;
 };
 
 export type JobResult = {
@@ -344,8 +344,8 @@ export async function executeJobRun(runId: string): Promise<JobRunRecord | null>
     logger(message, meta) {
       log(definition.slug, message, meta);
     },
-    resolveSecret(reference) {
-      const result = resolveSecret(reference, {
+    async resolveSecret(reference) {
+      const result = await resolveSecret(reference, {
         actor: `job-run:${runId}`,
         actorType: 'job',
         metadata: {

--- a/services/core/src/secrets.ts
+++ b/services/core/src/secrets.ts
@@ -1,11 +1,14 @@
 import { type SecretReference } from './db/types';
 import { recordAuditLog } from './db/audit';
-import { getSecretFromStore } from './secretStore';
 import type { JsonValue } from './db/types';
+import { getSecretFromStore } from './secretStore';
+import { getSecretsClient, shouldUseManagedSecrets } from './secretsClient';
 
 export type ResolvedSecret = {
   reference: SecretReference;
   value: string | null;
+  backend?: string | null;
+  version?: string | null;
 };
 
 export type SecretAccessContext = {
@@ -15,21 +18,31 @@ export type SecretAccessContext = {
   metadata?: Record<string, JsonValue>;
 };
 
+type StoreSecretReference = Extract<SecretReference, { source: 'store' }>;
+
 function logSecretResolution(
   reference: SecretReference,
   value: string | null,
   context?: SecretAccessContext,
-  resolvedVersion?: string | null
+  resolvedVersion?: string | null,
+  backend?: string | null
 ): void {
+  let referenceVersion: string | null = null;
+  if (reference.source === 'store') {
+    referenceVersion = (reference as StoreSecretReference).version ?? null;
+  }
   const metadata: Record<string, JsonValue> = {
     reference: {
       source: reference.source,
       key: reference.key,
-      version: reference.source === 'store' ? reference.version ?? null : null
+      version: referenceVersion
     }
   };
   if (resolvedVersion !== undefined) {
     metadata.resolvedVersion = resolvedVersion;
+  }
+  if (backend) {
+    metadata.backend = backend;
   }
   if (context?.metadata) {
     Object.assign(metadata, context.metadata);
@@ -50,36 +63,78 @@ function logSecretResolution(
   });
 }
 
-export function resolveSecret(reference: SecretReference, context?: SecretAccessContext): ResolvedSecret {
+async function resolveStoreSecret(
+  reference: StoreSecretReference,
+  context?: SecretAccessContext
+): Promise<ResolvedSecret> {
+  let backend: string | null = null;
+  let resolvedVersion: string | null = null;
+  let value: string | null = null;
+
+  if (shouldUseManagedSecrets()) {
+    try {
+      const client = getSecretsClient();
+      const managed = await client.resolveSecret(reference.key);
+      if (managed) {
+        backend = managed.backend;
+        resolvedVersion = managed.version ?? null;
+        if (!reference.version || !managed.version || reference.version === managed.version) {
+          value = managed.value;
+        } else {
+          value = null;
+        }
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error('[secrets] failed to resolve secret from managed service', {
+        key: reference.key,
+        error: message
+      });
+      value = null;
+    }
+  } else {
+    const entry = getSecretFromStore(reference.key);
+    backend = entry ? 'inline-store' : null;
+    resolvedVersion = entry?.version ?? null;
+    if (entry) {
+      if (!reference.version || !entry.version || reference.version === entry.version) {
+        value = entry.value;
+      } else {
+        value = null;
+      }
+    }
+  }
+
+  logSecretResolution(reference, value, context, resolvedVersion, backend ?? 'store');
+  return {
+    reference,
+    value,
+    backend,
+    version: resolvedVersion
+  };
+}
+
+export async function resolveSecret(
+  reference: SecretReference,
+  context?: SecretAccessContext
+): Promise<ResolvedSecret> {
   switch (reference.source) {
     case 'env': {
       const value = process.env[reference.key] ?? null;
-      logSecretResolution(reference, value, context, null);
+      logSecretResolution(reference, value, context, null, 'env');
       return {
         reference,
-        value
+        value,
+        backend: 'env',
+        version: null
       };
     }
     case 'store': {
-      const entry = getSecretFromStore(reference.key);
-      let value: string | null = null;
-      let resolvedVersion: string | null = entry?.version ?? null;
-      if (entry) {
-        if (!reference.version || !entry.version || reference.version === entry.version) {
-          value = entry.value;
-        } else {
-          resolvedVersion = entry.version;
-        }
-      }
-      logSecretResolution(reference, value, context, resolvedVersion);
-      return {
-        reference,
-        value
-      };
+      return resolveStoreSecret(reference, context);
     }
     default: {
-      logSecretResolution(reference, null, context, null);
-      return { reference, value: null };
+      logSecretResolution(reference, null, context, null, null);
+      return { reference, value: null, backend: null, version: null };
     }
   }
 }

--- a/services/core/src/secretsClient.ts
+++ b/services/core/src/secretsClient.ts
@@ -1,0 +1,68 @@
+import { SecretsClient } from '@apphub/shared';
+
+let client: SecretsClient | null = null;
+
+function parseNumber(value: string | undefined, fallback: number): number {
+  if (!value) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function resolveBaseUrl(): string {
+  return (
+    process.env.SECRETS_SERVICE_URL ??
+    process.env.APPHUB_SECRETS_URL ??
+    'http://127.0.0.1:4010'
+  ).trim();
+}
+
+function resolveAdminToken(): string {
+  return (
+    process.env.SECRETS_SERVICE_ADMIN_TOKEN ?? process.env.APPHUB_SECRETS_ADMIN_TOKEN ?? ''
+  ).trim();
+}
+
+export function shouldUseManagedSecrets(): boolean {
+  const mode = (process.env.APPHUB_SECRETS_MODE ?? 'managed').trim().toLowerCase();
+  if (mode === 'inline') {
+    return false;
+  }
+  const token = resolveAdminToken();
+  if (!token) {
+    return false;
+  }
+  const baseUrl = resolveBaseUrl();
+  return baseUrl.length > 0;
+}
+
+export function getSecretsClient(): SecretsClient {
+  if (!client) {
+    const baseUrl = resolveBaseUrl();
+    const adminToken = resolveAdminToken();
+    if (!adminToken) {
+      throw new Error('SECRETS_SERVICE_ADMIN_TOKEN is not configured');
+    }
+    client = new SecretsClient({
+      baseUrl,
+      adminToken,
+      subject: process.env.APPHUB_SECRETS_SUBJECT ?? 'apphub.core',
+      tokenTtlSeconds: parseNumber(process.env.APPHUB_SECRETS_TOKEN_TTL, 300),
+      cacheTtlMs: parseNumber(process.env.APPHUB_SECRETS_CACHE_TTL_MS, 5_000),
+      logger: {
+        warn(message, meta) {
+          console.warn('[secrets-client]', message, meta);
+        },
+        error(message, meta) {
+          console.error('[secrets-client]', message, meta);
+        }
+      }
+    });
+  }
+  return client;
+}
+
+export function resetSecretsClient(): void {
+  client = null;
+}

--- a/services/core/src/workflow/executors.ts
+++ b/services/core/src/workflow/executors.ts
@@ -148,7 +148,7 @@ export type StepExecutorDependencies = {
       actorType: string;
       metadata?: Record<string, JsonValue | string | number | boolean | null>;
     }
-  ) => { value: string | null };
+  ) => Promise<{ value: string | null }>;
   maskSecret: (value: string) => string;
   describeSecret: (ref: SecretReference) => string;
   createJobRunForSlug: (
@@ -1094,7 +1094,7 @@ async function prepareServiceRequest(
       if (!secretRef) {
         continue;
       }
-      const resolved = deps.resolveSecret(secretRef as SecretReference, {
+      const resolved = await deps.resolveSecret(secretRef as SecretReference, {
         actor: `workflow-run:${run.id}`,
         actorType: 'workflow',
         metadata: {

--- a/services/core/src/workflowOrchestrator.ts
+++ b/services/core/src/workflowOrchestrator.ts
@@ -1733,7 +1733,7 @@ async function prepareServiceRequest(
       if (!secretRef) {
         continue;
       }
-      const resolved = resolveSecret(secretRef as SecretReference, {
+      const resolved = await resolveSecret(secretRef as SecretReference, {
         actor: `workflow-run:${run.id}`,
         actorType: 'workflow',
         metadata: {

--- a/services/core/tests/dockerRuntimeValidation.e2e.ts
+++ b/services/core/tests/dockerRuntimeValidation.e2e.ts
@@ -640,7 +640,7 @@ runE2E(async ({ registerCleanup }) => {
     timeoutMs: 10000,
     logger,
     update,
-    resolveSecret: () => null
+    resolveSecret: async () => null
   });
 
   assert.equal(result.jobResult.status, 'succeeded');

--- a/services/core/tests/workflowAssetRecovery.test.ts
+++ b/services/core/tests/workflowAssetRecovery.test.ts
@@ -242,7 +242,7 @@ test('workflow orchestrator schedules asset recovery and defers retry', async ()
       stepState = { ...stepState, producedAssets: [] } satisfies WorkflowRunStepRecord;
     },
     persistStepAssets: async () => [],
-    resolveSecret: () => ({ value: null }),
+    resolveSecret: async () => ({ value: null }),
     maskSecret: (value) => value,
     describeSecret: () => 'secret',
     createJobRunForSlug: async () => createdJobRun,
@@ -333,7 +333,7 @@ test('workflow orchestrator defers execution while recovery request is running',
       stepState = { ...stepState, producedAssets: [] } satisfies WorkflowRunStepRecord;
     },
     persistStepAssets: async () => [],
-    resolveSecret: () => ({ value: null }),
+    resolveSecret: async () => ({ value: null }),
     maskSecret: (value) => value,
     describeSecret: () => 'secret',
     createJobRunForSlug: async () => {
@@ -446,7 +446,7 @@ test('workflow orchestrator resumes execution after recovery succeeds', async ()
       stepState = { ...stepState, producedAssets: [] } satisfies WorkflowRunStepRecord;
     },
     persistStepAssets: async () => [],
-    resolveSecret: () => ({ value: null }),
+    resolveSecret: async () => ({ value: null }),
     maskSecret: (value) => value,
     describeSecret: () => 'secret',
     createJobRunForSlug: async () => createdJobRun,

--- a/services/core/tests/workflowEventContext.test.ts
+++ b/services/core/tests/workflowEventContext.test.ts
@@ -149,7 +149,7 @@ test('sandbox runner propagates workflow event context to child jobs', async () 
       exportName: null,
       logger: () => {},
       update: async () => jobRun,
-      resolveSecret: () => null,
+      resolveSecret: async () => null,
       workflowEventContext
     });
 

--- a/services/secrets/package.json
+++ b/services/secrets/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@apphub/secrets",
+  "version": "0.1.0",
+  "description": "Managed secrets broker service",
+  "main": "dist/server.js",
+  "type": "commonjs",
+  "scripts": {
+    "dev": "tsx watch src/server.ts",
+    "start": "node dist/server.js",
+    "build": "npm run build:ts",
+    "build:ts": "tsc -b",
+    "lint": "tsc -b --pretty false",
+    "test": "node --test --test-concurrency=1 --require ts-node/register --require ../../tests/helpers/node-test-force-exit.cjs tests/**/*.test.ts"
+  },
+  "dependencies": {
+    "@apphub/event-bus": "0.1.0",
+    "@apphub/shared": "0.1.1",
+    "fastify": "^5.6.1",
+    "fastify-plugin": "^5.0.1",
+    "zod": "^3.25.76"
+  },
+  "devDependencies": {
+    "@types/node": "^24.5.2",
+    "ts-node": "^10.9.2",
+    "tsx": "^4.20.5",
+    "typescript": "^5.9.2"
+  }
+}

--- a/services/secrets/src/app.ts
+++ b/services/secrets/src/app.ts
@@ -1,0 +1,105 @@
+import Fastify, { type FastifyInstance } from 'fastify';
+import { loadServiceConfig, type ServiceConfig } from './config/serviceConfig';
+import { EnvSecretBackend } from './backends/envBackend';
+import { FileSecretBackend } from './backends/fileBackend';
+import { VaultSecretBackend } from './backends/vaultBackend';
+import { SecretRegistry } from './backends/registry';
+import { SecretTokenManager } from './tokens/tokenManager';
+import { registerSystemRoutes } from './routes/system';
+import { registerTokenRoutes } from './routes/tokens';
+import { registerSecretRoutes } from './routes/secrets';
+import { closeAuditPublisher } from './audit/publisher';
+import type { SecretBackend } from './backends/base';
+
+export type BuildAppOptions = {
+  config?: ServiceConfig;
+  skipInitialRefresh?: boolean;
+};
+
+function createBackends(config: ServiceConfig): SecretBackend[] {
+  return config.backends.map((backend) => {
+    switch (backend.kind) {
+      case 'env':
+        return new EnvSecretBackend({ name: backend.name });
+      case 'file':
+        return new FileSecretBackend({ path: backend.path, name: backend.name, optional: backend.optional });
+      case 'vault':
+        return new VaultSecretBackend({ path: backend.path, namespace: backend.namespace, name: backend.name, optional: backend.optional });
+      default: {
+        const unknownBackend: never = backend;
+        throw new Error(`Unsupported backend kind: ${(unknownBackend as { kind: string }).kind}`);
+      }
+    }
+  });
+}
+
+export async function buildApp(options?: BuildAppOptions): Promise<{
+  app: FastifyInstance;
+  config: ServiceConfig;
+  registry: SecretRegistry;
+  tokenManager: SecretTokenManager;
+}> {
+  const config = options?.config ?? loadServiceConfig();
+  const app = Fastify({
+    logger: {
+      level: process.env.LOG_LEVEL ?? 'info'
+    }
+  });
+
+  const backends = createBackends(config);
+  const registry = new SecretRegistry(backends);
+  if (!options?.skipInitialRefresh) {
+    await registry.refresh();
+  }
+
+  const tokenManager = new SecretTokenManager({
+    defaultTtlSeconds: config.defaultTokenTtlSeconds,
+    maxTtlSeconds: config.maxTokenTtlSeconds
+  });
+
+  const pruneTimer = setInterval(() => {
+    const removed = tokenManager.pruneExpired();
+    if (removed > 0) {
+      app.log.debug({ removed }, 'pruned expired secret tokens');
+    }
+  }, 60_000);
+  pruneTimer.unref();
+
+  let refreshTimer: NodeJS.Timeout | null = null;
+  if (config.refreshIntervalMs && config.refreshIntervalMs > 0) {
+    refreshTimer = setInterval(() => {
+      registry
+        .refresh()
+        .then((snapshot) => {
+          app.log.debug({ total: snapshot.total }, 'refreshed secrets registry');
+        })
+        .catch((error) => {
+          app.log.error({ err: error }, 'failed to refresh secrets registry');
+        });
+    }, config.refreshIntervalMs);
+    refreshTimer.unref();
+  }
+
+  await registerSystemRoutes(app, { registry, tokenManager });
+  await registerTokenRoutes(app, {
+    tokenManager,
+    config,
+    adminTokens: config.adminTokens,
+    registry
+  });
+  await registerSecretRoutes(app, {
+    tokenManager,
+    registry,
+    allowInlineFallback: config.allowInlineFallback
+  });
+
+  app.addHook('onClose', async () => {
+    clearInterval(pruneTimer);
+    if (refreshTimer) {
+      clearInterval(refreshTimer);
+    }
+    await closeAuditPublisher();
+  });
+
+  return { app, config, registry, tokenManager };
+}

--- a/services/secrets/src/audit/publisher.ts
+++ b/services/secrets/src/audit/publisher.ts
@@ -1,0 +1,40 @@
+import { createEventPublisher, type EventEnvelope } from '@apphub/event-bus';
+import type { JsonValue } from '@apphub/shared';
+import type { SecretAuditEvent, SecretTokenAuditEvent } from '../types';
+
+const DEFAULT_SOURCE = process.env.SECRETS_SERVICE_AUDIT_SOURCE?.trim() || 'secrets.api';
+
+let publisherHandle: ReturnType<typeof createEventPublisher> | null = null;
+
+function getPublisher() {
+  if (!publisherHandle) {
+    publisherHandle = createEventPublisher();
+  }
+  return publisherHandle;
+}
+
+export async function publishSecretAuditEvent(event: SecretAuditEvent): Promise<EventEnvelope> {
+  const publisher = getPublisher();
+  return publisher.publish({
+    type: event.type,
+    source: DEFAULT_SOURCE,
+    payload: event as unknown as Record<string, JsonValue>
+  });
+}
+
+export async function publishSecretTokenEvent(event: SecretTokenAuditEvent): Promise<EventEnvelope> {
+  const publisher = getPublisher();
+  return publisher.publish({
+    type: event.type,
+    source: DEFAULT_SOURCE,
+    payload: event as unknown as Record<string, JsonValue>
+  });
+}
+
+export async function closeAuditPublisher(): Promise<void> {
+  if (!publisherHandle) {
+    return;
+  }
+  await publisherHandle.close();
+  publisherHandle = null;
+}

--- a/services/secrets/src/backends/base.ts
+++ b/services/secrets/src/backends/base.ts
@@ -1,0 +1,9 @@
+import type { SecretRecord } from '../types';
+import type { BackendKind } from '../config/serviceConfig';
+
+export interface SecretBackend {
+  readonly kind: BackendKind;
+  readonly name: string;
+  load(): Promise<SecretRecord[]>;
+  describe(): Record<string, unknown>;
+}

--- a/services/secrets/src/backends/envBackend.ts
+++ b/services/secrets/src/backends/envBackend.ts
@@ -1,0 +1,26 @@
+import { loadConfigFromString, normalizeSecretCollection } from './utils';
+import type { SecretBackend } from './base';
+import type { SecretRecord } from '../types';
+
+export class EnvSecretBackend implements SecretBackend {
+  readonly kind = 'env' as const;
+  readonly name: string;
+  private readonly envVar: string;
+
+  constructor(options?: { envVar?: string; name?: string }) {
+    this.envVar = options?.envVar ?? 'APPHUB_SECRET_STORE';
+    this.name = options?.name ?? 'inline-env';
+  }
+
+  async load(): Promise<SecretRecord[]> {
+    const raw = process.env[this.envVar] ?? null;
+    const parsed = loadConfigFromString(raw);
+    return normalizeSecretCollection(this.name, parsed);
+  }
+
+  describe(): Record<string, unknown> {
+    return {
+      envVar: this.envVar
+    };
+  }
+}

--- a/services/secrets/src/backends/fileBackend.ts
+++ b/services/secrets/src/backends/fileBackend.ts
@@ -1,0 +1,36 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { loadConfigFromString, normalizeSecretCollection } from './utils';
+import type { SecretBackend } from './base';
+import type { SecretRecord } from '../types';
+
+export class FileSecretBackend implements SecretBackend {
+  readonly kind = 'file' as const;
+  readonly name: string;
+  private readonly filePath: string;
+  private readonly optional: boolean;
+
+  constructor(options: { path: string; name?: string; optional?: boolean }) {
+    this.filePath = options.path;
+    this.optional = options.optional ?? false;
+    this.name = options.name ?? 'config-file';
+  }
+
+  async load(): Promise<SecretRecord[]> {
+    if (!existsSync(this.filePath)) {
+      if (this.optional) {
+        return [];
+      }
+      throw new Error(`Secret file ${this.filePath} does not exist`);
+    }
+    const contents = readFileSync(this.filePath, 'utf8');
+    const parsed = loadConfigFromString(contents);
+    return normalizeSecretCollection(this.name, parsed);
+  }
+
+  describe(): Record<string, unknown> {
+    return {
+      path: this.filePath,
+      optional: this.optional
+    };
+  }
+}

--- a/services/secrets/src/backends/registry.ts
+++ b/services/secrets/src/backends/registry.ts
@@ -1,0 +1,81 @@
+import { performance } from 'node:perf_hooks';
+import type { SecretBackend } from './base';
+import type { SecretRecord } from '../types';
+
+export type SecretRegistrySnapshot = {
+  total: number;
+  backends: Array<{
+    name: string;
+    kind: string;
+    count: number;
+  }>;
+  refreshedAt: string;
+  durationMs: number;
+};
+
+export class SecretRegistry {
+  private readonly backends: SecretBackend[];
+  private cache: Map<string, SecretRecord> = new Map();
+  private refreshedAt: Date | null = null;
+  private lastSnapshot: SecretRegistrySnapshot | null = null;
+
+  constructor(backends: SecretBackend[]) {
+    this.backends = backends;
+  }
+
+  async refresh(): Promise<SecretRegistrySnapshot> {
+    const next = new Map<string, SecretRecord>();
+    const backendSummaries: SecretRegistrySnapshot['backends'] = [];
+    const started = performance.now();
+
+    for (const backend of this.backends) {
+      try {
+        const records = await backend.load();
+        backendSummaries.push({ name: backend.name, kind: backend.kind, count: records.length });
+        for (const record of records) {
+          next.set(record.key, record);
+        }
+      } catch (error) {
+        const descriptor = backend.describe();
+        const optional = Boolean((descriptor.optional as boolean | undefined) ?? false);
+        const message = error instanceof Error ? error.message : String(error);
+        if (optional) {
+          console.warn(`[@apphub/secrets] optional backend ${backend.name} failed to load: ${message}`);
+          continue;
+        }
+        console.error(`[@apphub/secrets] backend ${backend.name} failed to load`, error);
+        throw error;
+      }
+    }
+
+    this.cache = next;
+    this.refreshedAt = new Date();
+    const ended = performance.now();
+
+    const snapshot: SecretRegistrySnapshot = {
+      total: next.size,
+      backends: backendSummaries,
+      refreshedAt: this.refreshedAt.toISOString(),
+      durationMs: Math.round(ended - started)
+    } satisfies SecretRegistrySnapshot;
+
+    this.lastSnapshot = snapshot;
+    return snapshot;
+  }
+
+  getSecret(key: string): SecretRecord | null {
+    const trimmed = key.trim();
+    if (!trimmed) {
+      return null;
+    }
+    return this.cache.get(trimmed) ?? null;
+  }
+
+  listSecrets(): SecretRecord[] {
+    return Array.from(this.cache.values());
+  }
+
+  getSnapshot(): SecretRegistrySnapshot | null {
+    return this.lastSnapshot;
+  }
+}

--- a/services/secrets/src/backends/utils.ts
+++ b/services/secrets/src/backends/utils.ts
@@ -1,0 +1,71 @@
+import type { SecretConfig, SecretConfigCollection, SecretRecord } from '../types';
+
+export function loadConfigFromString(raw: string | null | undefined): SecretConfigCollection | null {
+  if (!raw) {
+    return null;
+  }
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(trimmed) as SecretConfigCollection;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function parseSecretConfig(key: string, config: SecretConfig): SecretRecord | null {
+  if (typeof config === 'string') {
+    const value = config.trim();
+    if (!value) {
+      return null;
+    }
+    return {
+      key,
+      value,
+      backend: 'unknown'
+    } satisfies SecretRecord;
+  }
+  if (!config || typeof config !== 'object') {
+    return null;
+  }
+  const value = typeof config.value === 'string' ? config.value : '';
+  if (!value) {
+    return null;
+  }
+  const version = typeof config.version === 'string' ? config.version : null;
+  const metadata = config.metadata ?? null;
+  return {
+    key,
+    value,
+    version,
+    metadata: metadata ?? null,
+    backend: 'unknown'
+  } satisfies SecretRecord;
+}
+
+export function normalizeSecretCollection(
+  sourceName: string,
+  collection: SecretConfigCollection | null | undefined
+): SecretRecord[] {
+  if (!collection) {
+    return [];
+  }
+  const entries: SecretRecord[] = [];
+  for (const [key, config] of Object.entries(collection)) {
+    const trimmedKey = key.trim();
+    if (!trimmedKey) {
+      continue;
+    }
+    const entry = parseSecretConfig(trimmedKey, config);
+    if (entry) {
+      entries.push({ ...entry, backend: sourceName });
+    }
+  }
+  return entries;
+}

--- a/services/secrets/src/backends/vaultBackend.ts
+++ b/services/secrets/src/backends/vaultBackend.ts
@@ -1,0 +1,40 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { loadConfigFromString, normalizeSecretCollection } from './utils';
+import type { SecretBackend } from './base';
+import type { SecretRecord } from '../types';
+
+export class VaultSecretBackend implements SecretBackend {
+  readonly kind = 'vault' as const;
+  readonly name: string;
+  private readonly filePath: string;
+  private readonly namespace: string | null;
+  private readonly optional: boolean;
+
+  constructor(options: { path: string; namespace?: string | null; optional?: boolean; name?: string }) {
+    this.filePath = options.path;
+    this.namespace = options.namespace ?? null;
+    this.optional = options.optional ?? true;
+    const suffix = this.namespace ? `:${this.namespace}` : '';
+    this.name = options.name ?? `vault${suffix}`;
+  }
+
+  async load(): Promise<SecretRecord[]> {
+    if (!existsSync(this.filePath)) {
+      if (this.optional) {
+        return [];
+      }
+      throw new Error(`Vault secret file ${this.filePath} does not exist`);
+    }
+    const contents = readFileSync(this.filePath, 'utf8');
+    const parsed = loadConfigFromString(contents);
+    return normalizeSecretCollection(this.name, parsed);
+  }
+
+  describe(): Record<string, unknown> {
+    return {
+      path: this.filePath,
+      namespace: this.namespace,
+      optional: this.optional
+    };
+  }
+}

--- a/services/secrets/src/config/serviceConfig.ts
+++ b/services/secrets/src/config/serviceConfig.ts
@@ -1,0 +1,250 @@
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { z } from 'zod';
+import type { JsonValue } from '@apphub/shared';
+
+const TRUE_VALUES = new Set(['1', 'true', 'yes', 'on']);
+
+export type BackendKind = 'env' | 'file' | 'vault';
+
+export type EnvBackendConfig = {
+  kind: 'env';
+  name: string;
+};
+
+export type FileBackendConfig = {
+  kind: 'file';
+  name: string;
+  path: string;
+  optional: boolean;
+};
+
+export type VaultBackendConfig = {
+  kind: 'vault';
+  name: string;
+  path: string;
+  namespace?: string | null;
+  optional: boolean;
+};
+
+export type BackendConfig = EnvBackendConfig | FileBackendConfig | VaultBackendConfig;
+
+export type AdminTokenDefinition = {
+  token: string;
+  subject: string;
+  allowedKeys: string[] | '*';
+  maxTtlSeconds: number | null;
+  metadata?: Record<string, JsonValue> | null;
+};
+
+export type ServiceConfig = {
+  host: string;
+  port: number;
+  metricsEnabled: boolean;
+  auditEventSource: string;
+  defaultTokenTtlSeconds: number;
+  maxTokenTtlSeconds: number;
+  adminTokens: AdminTokenDefinition[];
+  backends: BackendConfig[];
+  refreshIntervalMs: number | null;
+  allowInlineFallback: boolean;
+};
+
+function parseBoolean(value: string | undefined, defaultValue: boolean): boolean {
+  if (!value) {
+    return defaultValue;
+  }
+  const normalized = value.trim().toLowerCase();
+  if (TRUE_VALUES.has(normalized)) {
+    return true;
+  }
+  if (['0', 'false', 'no', 'off'].includes(normalized)) {
+    return false;
+  }
+  return defaultValue;
+}
+
+function parsePort(value: string | undefined, defaultValue: number): number {
+  if (!value) {
+    return defaultValue;
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return defaultValue;
+  }
+  return parsed;
+}
+
+function parseNumber(value: string | undefined, defaultValue: number): number {
+  if (!value) {
+    return defaultValue;
+  }
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : defaultValue;
+}
+
+const ADMIN_TOKEN_SCHEMA = z
+  .object({
+    token: z.string().min(8, 'token must contain at least 8 characters'),
+    subject: z.string().min(1, 'subject is required'),
+    allowedKeys: z
+      .union([z.literal('*'), z.array(z.string().min(1, 'key cannot be empty'))])
+      .default('*'),
+    maxTtlSeconds: z
+      .number()
+      .int()
+      .positive()
+      .optional(),
+    metadata: z.record(z.any()).optional()
+  })
+  .transform((value) => {
+    const allowedKeys = value.allowedKeys === '*' ? '*' : Array.from(new Set(value.allowedKeys));
+    const trimmedMetadata = value.metadata ? (value.metadata as Record<string, JsonValue>) : null;
+    return {
+      token: value.token.trim(),
+      subject: value.subject.trim(),
+      allowedKeys,
+      maxTtlSeconds: value.maxTtlSeconds ?? null,
+      metadata: trimmedMetadata
+    } satisfies AdminTokenDefinition;
+  });
+
+function readJsonFile(filePath: string): unknown {
+  const absolute = path.resolve(filePath);
+  if (!existsSync(absolute)) {
+    throw new Error(`Admin token file ${absolute} does not exist`);
+  }
+  const contents = readFileSync(absolute, 'utf8');
+  try {
+    return JSON.parse(contents);
+  } catch (error) {
+    throw new Error(`Failed to parse JSON from ${absolute}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+function parseAdminTokens(raw: unknown, source: string): AdminTokenDefinition[] {
+  if (!raw) {
+    return [];
+  }
+  const schema = z.array(ADMIN_TOKEN_SCHEMA);
+  const parsed = schema.safeParse(raw);
+  if (!parsed.success) {
+    throw new Error(`Invalid admin token definitions from ${source}: ${parsed.error.message}`);
+  }
+  const tokens = parsed.data.filter((entry) => entry.token.length > 0 && entry.subject.length > 0);
+  return tokens;
+}
+
+function loadAdminTokens(): AdminTokenDefinition[] {
+  const tokens: AdminTokenDefinition[] = [];
+  const inlineRaw = process.env.SECRETS_SERVICE_ADMIN_TOKENS;
+  if (inlineRaw) {
+    try {
+      const parsed = JSON.parse(inlineRaw) as unknown;
+      tokens.push(...parseAdminTokens(parsed, 'SECRETS_SERVICE_ADMIN_TOKENS'));
+    } catch (error) {
+      throw new Error(
+        `Failed to parse SECRETS_SERVICE_ADMIN_TOKENS JSON: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+  const filePath = process.env.SECRETS_SERVICE_ADMIN_TOKENS_PATH;
+  if (filePath) {
+    const raw = readJsonFile(filePath);
+    tokens.push(...parseAdminTokens(raw, filePath));
+  }
+  return tokens;
+}
+
+function loadBackends(): BackendConfig[] {
+  const configured = (process.env.SECRETS_SERVICE_BACKENDS ?? 'env,file')
+    .split(',')
+    .map((entry) => entry.trim().toLowerCase())
+    .filter(Boolean);
+  const unique = Array.from(new Set(configured.length > 0 ? configured : ['env', 'file']));
+  const backends: BackendConfig[] = [];
+  for (const entry of unique) {
+    if (entry === 'env') {
+      backends.push({ kind: 'env', name: 'inline-env' });
+      continue;
+    }
+    if (entry === 'file') {
+      const filePath = process.env.SECRETS_SERVICE_FILE_PATH ?? process.env.APPHUB_SECRET_STORE_PATH ?? '';
+      if (!filePath.trim()) {
+        console.warn('[secrets-config] file backend requested but no path configured; skipping');
+        continue;
+      }
+      backends.push({
+        kind: 'file',
+        name: 'config-file',
+        path: path.resolve(filePath.trim()),
+        optional: parseBoolean(process.env.SECRETS_SERVICE_FILE_OPTIONAL, false)
+      });
+      continue;
+    }
+    if (entry === 'vault') {
+      const vaultPath = process.env.SECRETS_SERVICE_VAULT_FILE ?? '';
+      if (!vaultPath.trim()) {
+        console.warn('[secrets-config] vault backend requested but SECRETS_SERVICE_VAULT_FILE is not set; skipping');
+        continue;
+      }
+      backends.push({
+        kind: 'vault',
+        name: 'vault',
+        path: path.resolve(vaultPath.trim()),
+        namespace: process.env.SECRETS_SERVICE_VAULT_NAMESPACE?.trim() || null,
+        optional: parseBoolean(process.env.SECRETS_SERVICE_VAULT_OPTIONAL, true)
+      });
+      continue;
+    }
+    console.warn(`[secrets-config] unknown backend kind '${entry}', ignoring`);
+  }
+  if (backends.length === 0) {
+    throw new Error('No secret backends configured. Set SECRETS_SERVICE_BACKENDS to include env, file, or vault.');
+  }
+  return backends;
+}
+
+export function loadServiceConfig(): ServiceConfig {
+  const host = process.env.SECRETS_SERVICE_HOST?.trim() || '0.0.0.0';
+  const port = parsePort(process.env.SECRETS_SERVICE_PORT, 4010);
+  const metricsEnabled = parseBoolean(process.env.SECRETS_SERVICE_METRICS_ENABLED, true);
+  const auditEventSource = process.env.SECRETS_SERVICE_AUDIT_SOURCE?.trim() || 'secrets.api';
+  const defaultTokenTtlSeconds = Math.max(parseNumber(process.env.SECRETS_SERVICE_DEFAULT_TTL, 300), 30);
+  const maxTokenTtlSeconds = Math.max(
+    parseNumber(process.env.SECRETS_SERVICE_MAX_TTL, Math.max(defaultTokenTtlSeconds, 3600)),
+    defaultTokenTtlSeconds
+  );
+  const refreshIntervalMsRaw = process.env.SECRETS_SERVICE_REFRESH_INTERVAL_MS;
+  const refreshIntervalMs = (() => {
+    if (!refreshIntervalMsRaw) {
+      return null;
+    }
+    const parsed = Number.parseInt(refreshIntervalMsRaw, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      return null;
+    }
+    return parsed;
+  })();
+  const allowInlineFallback = parseBoolean(process.env.SECRETS_SERVICE_INLINE_FALLBACK, true);
+
+  const adminTokens = loadAdminTokens();
+  if (adminTokens.length === 0) {
+    throw new Error('No admin tokens configured. Provide SECRETS_SERVICE_ADMIN_TOKENS or SECRETS_SERVICE_ADMIN_TOKENS_PATH.');
+  }
+
+  const backends = loadBackends();
+
+  return {
+    host,
+    port,
+    metricsEnabled,
+    auditEventSource,
+    defaultTokenTtlSeconds,
+    maxTokenTtlSeconds,
+    adminTokens,
+    backends,
+    refreshIntervalMs,
+    allowInlineFallback
+  } satisfies ServiceConfig;
+}

--- a/services/secrets/src/routes/auth.ts
+++ b/services/secrets/src/routes/auth.ts
@@ -1,0 +1,57 @@
+import { timingSafeEqual } from 'node:crypto';
+import type { FastifyReply, FastifyRequest } from 'fastify';
+import type { AdminTokenDefinition } from '../config/serviceConfig';
+
+const BEARER_PREFIX = 'bearer ';
+
+export function getBearerToken(request: FastifyRequest): string | null {
+  const authHeader = request.headers.authorization ?? request.headers.Authorization;
+  if (!authHeader || typeof authHeader !== 'string') {
+    return null;
+  }
+  const trimmed = authHeader.trim();
+  if (!trimmed.toLowerCase().startsWith(BEARER_PREFIX)) {
+    return null;
+  }
+  const token = trimmed.slice(BEARER_PREFIX.length).trim();
+  return token || null;
+}
+
+function timingSafeCompare(a: string, b: string): boolean {
+  const aBuffer = Buffer.from(a);
+  const bBuffer = Buffer.from(b);
+  if (aBuffer.length !== bBuffer.length) {
+    return false;
+  }
+  return timingSafeEqual(aBuffer, bBuffer);
+}
+
+export function findAdminToken(
+  token: string,
+  adminTokens: AdminTokenDefinition[]
+): AdminTokenDefinition | null {
+  for (const candidate of adminTokens) {
+    if (timingSafeCompare(candidate.token, token)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+export function requireAdminToken(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  adminTokens: AdminTokenDefinition[]
+): AdminTokenDefinition | null {
+  const bearer = getBearerToken(request);
+  if (!bearer) {
+    void reply.status(401).send({ error: 'unauthorized', message: 'Missing bearer token' });
+    return null;
+  }
+  const admin = findAdminToken(bearer, adminTokens);
+  if (!admin) {
+    void reply.status(403).send({ error: 'forbidden', message: 'Invalid admin token' });
+    return null;
+  }
+  return admin;
+}

--- a/services/secrets/src/routes/secrets.ts
+++ b/services/secrets/src/routes/secrets.ts
@@ -1,0 +1,133 @@
+import type { FastifyInstance } from 'fastify';
+import type { SecretTokenManager } from '../tokens/tokenManager';
+import type { SecretRegistry } from '../backends/registry';
+import { getBearerToken } from './auth';
+import { publishSecretAuditEvent } from '../audit/publisher';
+import type { SecretAccessOutcome } from '../types';
+
+export type SecretsRouteDependencies = {
+  tokenManager: SecretTokenManager;
+  registry: SecretRegistry;
+  allowInlineFallback: boolean;
+};
+
+function isKeyAllowed(allowed: Set<string> | '*', key: string): boolean {
+  if (allowed === '*') {
+    return true;
+  }
+  return allowed.has(key);
+}
+
+function tryInlineFallback(key: string): { value: string; backend: string } | null {
+  const raw = process.env[key];
+  if (typeof raw === 'string' && raw.length > 0) {
+    return { value: raw, backend: 'env-inline' };
+  }
+  return null;
+}
+
+export async function registerSecretRoutes(
+  app: FastifyInstance,
+  deps: SecretsRouteDependencies
+): Promise<void> {
+  app.get('/v1/secrets/:key', async (request, reply) => {
+    const bearer = getBearerToken(request);
+    if (!bearer) {
+      return reply.status(401).send({ error: 'unauthorized', message: 'Missing bearer token' });
+    }
+
+    const tokenRecord = deps.tokenManager.get(bearer);
+    if (!tokenRecord) {
+      return reply.status(401).send({ error: 'unauthorized', message: 'Token expired or invalid' });
+    }
+
+    const params = request.params as { key: string };
+    const key = params.key.trim();
+    if (!key) {
+      return reply.status(400).send({ error: 'invalid_request', message: 'Key is required' });
+    }
+
+    let outcome: SecretAccessOutcome = 'authorized';
+    let reason: string | undefined;
+
+    if (!isKeyAllowed(tokenRecord.allowedKeys, key)) {
+      outcome = 'forbidden';
+      reason = 'scope_mismatch';
+      await publishSecretAuditEvent({
+        type: 'secret.access',
+        key,
+        backend: 'registry',
+        subject: tokenRecord.subject,
+        tokenId: tokenRecord.id,
+        tokenHash: tokenRecord.tokenHash,
+        outcome,
+        reason,
+        accessedAt: new Date().toISOString(),
+        issuedAt: tokenRecord.issuedAt.toISOString(),
+        expiresAt: tokenRecord.expiresAt.toISOString(),
+        metadata: tokenRecord.metadata ?? null
+      });
+      return reply.status(403).send({ error: 'forbidden', message: 'Token not authorized for key' });
+    }
+
+    let secret = deps.registry.getSecret(key);
+    if (!secret && deps.allowInlineFallback) {
+      const fallback = tryInlineFallback(key);
+      if (fallback) {
+        secret = {
+          key,
+          value: fallback.value,
+          backend: fallback.backend,
+          version: null,
+          metadata: null
+        };
+      }
+    }
+
+    if (!secret) {
+      outcome = 'missing';
+      reason = 'not_found';
+      await publishSecretAuditEvent({
+        type: 'secret.access',
+        key,
+        backend: 'registry',
+        subject: tokenRecord.subject,
+        tokenId: tokenRecord.id,
+        tokenHash: tokenRecord.tokenHash,
+        outcome,
+        reason,
+        accessedAt: new Date().toISOString(),
+        issuedAt: tokenRecord.issuedAt.toISOString(),
+        expiresAt: tokenRecord.expiresAt.toISOString(),
+        metadata: tokenRecord.metadata ?? null
+      });
+      return reply.status(404).send({ error: 'not_found', message: 'Secret not found' });
+    }
+
+    await publishSecretAuditEvent({
+      type: 'secret.access',
+      key,
+      backend: secret.backend,
+      subject: tokenRecord.subject,
+      tokenId: tokenRecord.id,
+      tokenHash: tokenRecord.tokenHash,
+      outcome,
+      version: secret.version ?? null,
+      accessedAt: new Date().toISOString(),
+      issuedAt: tokenRecord.issuedAt.toISOString(),
+      expiresAt: tokenRecord.expiresAt.toISOString(),
+      metadata: tokenRecord.metadata ?? null
+    });
+
+    return reply
+      .header('cache-control', 'no-store')
+      .send({
+        key: secret.key,
+        value: secret.value,
+        version: secret.version ?? null,
+        metadata: secret.metadata ?? null,
+        backend: secret.backend,
+        tokenExpiresAt: tokenRecord.expiresAt.toISOString()
+      });
+  });
+}

--- a/services/secrets/src/routes/system.ts
+++ b/services/secrets/src/routes/system.ts
@@ -1,0 +1,49 @@
+import type { FastifyInstance } from 'fastify';
+import type { SecretRegistry } from '../backends/registry';
+import type { SecretTokenManager } from '../tokens/tokenManager';
+
+export type SystemRouteDependencies = {
+  registry: SecretRegistry;
+  tokenManager: SecretTokenManager;
+};
+
+export async function registerSystemRoutes(
+  app: FastifyInstance,
+  deps: SystemRouteDependencies
+): Promise<void> {
+  app.get('/healthz', async () => {
+    const snapshot = deps.registry.getSnapshot();
+    return {
+      status: 'ok',
+      secrets: snapshot?.total ?? 0
+    };
+  });
+
+  app.get('/readyz', async (request, reply) => {
+    const snapshot = deps.registry.getSnapshot();
+    if (!snapshot) {
+      return reply.status(503).send({ status: 'initializing' });
+    }
+    return {
+      status: 'ready',
+      refreshedAt: snapshot.refreshedAt,
+      secrets: snapshot.total
+    };
+  });
+
+  app.get('/v1/status', async () => {
+    const snapshot = deps.registry.getSnapshot();
+    const tokens = deps.tokenManager.listActive();
+    return {
+      secrets: snapshot,
+      activeTokens: tokens.map((token) => ({
+        id: token.id,
+        subject: token.subject,
+        expiresAt: token.expiresAt.toISOString(),
+        issuedAt: token.issuedAt.toISOString(),
+        refreshCount: token.refreshCount,
+        allowedKeys: token.allowedKeys === '*' ? '*' : Array.from(token.allowedKeys)
+      }))
+    };
+  });
+}

--- a/services/secrets/src/routes/tokens.ts
+++ b/services/secrets/src/routes/tokens.ts
@@ -1,0 +1,217 @@
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import type { JsonValue } from '@apphub/shared';
+import type { SecretTokenManager } from '../tokens/tokenManager';
+import type { ServiceConfig, AdminTokenDefinition } from '../config/serviceConfig';
+import { publishSecretTokenEvent } from '../audit/publisher';
+import { requireAdminToken } from './auth';
+import type { SecretRegistry } from '../backends/registry';
+
+const ISSUE_BODY_SCHEMA = z.object({
+  subject: z.string().trim().min(1, 'subject is required'),
+  keys: z.union([z.literal('*'), z.array(z.string().trim().min(1, 'key cannot be empty'))]),
+  ttlSeconds: z.number().int().positive().optional(),
+  metadata: z.record(z.any()).optional()
+});
+
+const REFRESH_BODY_SCHEMA = z
+  .object({
+    ttlSeconds: z.number().int().positive().optional()
+  })
+  .optional();
+
+export type TokenRouteDependencies = {
+  tokenManager: SecretTokenManager;
+  config: ServiceConfig;
+  adminTokens: AdminTokenDefinition[];
+  registry: SecretRegistry;
+};
+
+function serializeKeys(keys: Set<string> | '*'): string[] | '*'
+{
+  if (keys === '*') {
+    return '*';
+  }
+  return Array.from(keys);
+}
+
+function ensureScopesAllowed(
+  admin: AdminTokenDefinition,
+  requested: string[] | '*'
+): void {
+  if (admin.allowedKeys === '*') {
+    return;
+  }
+  if (requested === '*') {
+    throw new Error('Admin token does not allow wildcard scopes');
+  }
+  const missing = requested.filter((key) => !admin.allowedKeys.includes(key));
+  if (missing.length > 0) {
+    throw new Error(`Admin token does not allow scopes: ${missing.join(', ')}`);
+  }
+}
+
+function resolveTtlSeconds(
+  requested: number | undefined,
+  admin: AdminTokenDefinition,
+  config: ServiceConfig
+): number {
+  const requestedTtl = requested ?? config.defaultTokenTtlSeconds;
+  const adminMax = admin.maxTtlSeconds ?? config.maxTokenTtlSeconds;
+  return Math.min(requestedTtl, adminMax, config.maxTokenTtlSeconds);
+}
+
+export async function registerTokenRoutes(
+  app: FastifyInstance,
+  deps: TokenRouteDependencies
+): Promise<void> {
+  app.post('/v1/tokens', async (request, reply) => {
+    const admin = requireAdminToken(request, reply, deps.adminTokens);
+    if (!admin) {
+      return reply;
+    }
+    const parsed = ISSUE_BODY_SCHEMA.safeParse(request.body ?? {});
+    if (!parsed.success) {
+      return reply.status(400).send({ error: 'invalid_request', message: parsed.error.message });
+    }
+    const body = parsed.data;
+    const subject = body.subject;
+    const normalizedKeys = body.keys === '*' ? '*' : Array.from(new Set(body.keys.map((key) => key.trim()).filter(Boolean)));
+    if (normalizedKeys !== '*' && normalizedKeys.length === 0) {
+      return reply.status(400).send({ error: 'invalid_request', message: 'At least one key must be provided' });
+    }
+
+    try {
+      ensureScopesAllowed(admin, normalizedKeys);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Scope validation failed';
+      return reply.status(403).send({ error: 'forbidden', message });
+    }
+
+    const ttlSeconds = resolveTtlSeconds(body.ttlSeconds, admin, deps.config);
+    const metadata = {
+      issuedBy: admin.subject,
+      ...(body.metadata ?? {})
+    } as Record<string, JsonValue>;
+
+    const issued = deps.tokenManager.issue({
+      subject,
+      keys: normalizedKeys,
+      ttlSeconds,
+      metadata
+    });
+
+    await publishSecretTokenEvent({
+      type: 'secret.token.issued',
+      tokenId: issued.id,
+      tokenHash: issued.tokenHash,
+      subject: issued.subject,
+      keys: serializeKeys(issued.allowedKeys),
+      issuedAt: issued.issuedAt.toISOString(),
+      expiresAt: issued.expiresAt.toISOString(),
+      metadata: issued.metadata ?? null
+    });
+
+    return reply.status(201).send({
+      token: issued.token,
+      tokenId: issued.id,
+      subject: issued.subject,
+      issuedAt: issued.issuedAt.toISOString(),
+      expiresAt: issued.expiresAt.toISOString(),
+      allowedKeys: serializeKeys(issued.allowedKeys),
+      tokenHash: issued.tokenHash,
+      refreshCount: issued.refreshCount
+    });
+  });
+
+  app.post('/v1/tokens/:token/refresh', async (request, reply) => {
+    const admin = requireAdminToken(request, reply, deps.adminTokens);
+    if (!admin) {
+      return reply;
+    }
+    const params = request.params as { token: string };
+    const parsed = REFRESH_BODY_SCHEMA.safeParse(request.body ?? {});
+    if (!parsed.success) {
+      return reply.status(400).send({ error: 'invalid_request', message: parsed.error.message });
+    }
+    const ttlSeconds = resolveTtlSeconds(parsed.data?.ttlSeconds, admin, deps.config);
+
+    const existing = deps.tokenManager.get(params.token);
+    if (!existing) {
+      return reply.status(404).send({ error: 'not_found', message: 'Token not found or expired' });
+    }
+
+    try {
+      const existingScopes = existing.allowedKeys === '*'
+        ? '*'
+        : Array.from(existing.allowedKeys);
+      ensureScopesAllowed(admin, existingScopes);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Scope validation failed';
+      return reply.status(403).send({ error: 'forbidden', message });
+    }
+
+    const result = deps.tokenManager.refresh(params.token, ttlSeconds);
+    if (!result) {
+      return reply.status(404).send({ error: 'not_found', message: 'Token not found or expired' });
+    }
+
+    await publishSecretTokenEvent({
+      type: 'secret.token.refreshed',
+      tokenId: result.token.id,
+      tokenHash: result.token.tokenHash,
+      subject: result.token.subject,
+      keys: serializeKeys(result.token.allowedKeys),
+      issuedAt: result.token.issuedAt.toISOString(),
+      previousExpiresAt: result.previousExpiresAt.toISOString(),
+      expiresAt: result.token.expiresAt.toISOString(),
+      metadata: result.token.metadata ?? null
+    });
+
+    return reply.send({
+      tokenId: result.token.id,
+      subject: result.token.subject,
+      expiresAt: result.token.expiresAt.toISOString(),
+      allowedKeys: serializeKeys(result.token.allowedKeys),
+      refreshCount: result.token.refreshCount
+    });
+  });
+
+  app.delete('/v1/tokens/:token', async (request, reply) => {
+    const admin = requireAdminToken(request, reply, deps.adminTokens);
+    if (!admin) {
+      return reply;
+    }
+    const params = request.params as { token: string };
+    const record = deps.tokenManager.revoke(params.token);
+    if (!record) {
+      return reply.status(404).send({ error: 'not_found', message: 'Token not found' });
+    }
+
+    await publishSecretTokenEvent({
+      type: 'secret.token.revoked',
+      tokenId: record.id,
+      tokenHash: record.tokenHash,
+      subject: record.subject,
+      revokedAt: new Date().toISOString(),
+      metadata: record.metadata ?? null
+    });
+
+    return reply.status(204).send();
+  });
+
+  app.post('/v1/secrets/refresh', async (request, reply) => {
+    const admin = requireAdminToken(request, reply, deps.adminTokens);
+    if (!admin) {
+      return reply;
+    }
+
+    try {
+      const snapshot = await deps.registry.refresh();
+      return reply.send({ status: 'ok', snapshot });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return reply.status(500).send({ error: 'refresh_failed', message });
+    }
+  });
+}

--- a/services/secrets/src/server.ts
+++ b/services/secrets/src/server.ts
@@ -1,0 +1,34 @@
+import { buildApp } from './app';
+
+async function start(): Promise<void> {
+  const { app, config } = await buildApp();
+
+  try {
+    await app.listen({ host: config.host, port: config.port });
+    app.log.info({ host: config.host, port: config.port }, 'secrets service listening');
+  } catch (error) {
+    app.log.error({ err: error }, 'failed to start secrets service');
+    await app.close();
+    throw error;
+  }
+
+  const shutdown = async (signal: string) => {
+    app.log.info({ signal }, 'shutting down secrets service');
+    try {
+      await app.close();
+    } catch (closeError) {
+      app.log.error({ err: closeError }, 'error during secrets service shutdown');
+    }
+  };
+
+  for (const signal of ['SIGINT', 'SIGTERM'] as const) {
+    process.on(signal, () => {
+      void shutdown(signal);
+    });
+  }
+}
+
+start().catch((error) => {
+  console.error('[secrets] fatal startup error', error);
+  process.exit(1);
+});

--- a/services/secrets/src/tokens/tokenManager.ts
+++ b/services/secrets/src/tokens/tokenManager.ts
@@ -1,0 +1,121 @@
+import { createHash, randomBytes, randomUUID } from 'node:crypto';
+import type { IssueTokenInput, IssuedSecretToken, RefreshTokenResult } from '../types';
+
+function generateToken(length = 48): string {
+  const buffer = randomBytes(length);
+  return buffer.toString('base64url');
+}
+
+function clampTtl(ttlSeconds: number, maxTtlSeconds: number): number {
+  if (!Number.isFinite(ttlSeconds) || ttlSeconds <= 0) {
+    return 0;
+  }
+  return Math.min(Math.floor(ttlSeconds), maxTtlSeconds);
+}
+
+export type SecretTokenManagerOptions = {
+  defaultTtlSeconds: number;
+  maxTtlSeconds: number;
+  now?: () => Date;
+};
+
+export class SecretTokenManager {
+  private readonly defaultTtlSeconds: number;
+  private readonly maxTtlSeconds: number;
+  private readonly now: () => Date;
+  private readonly tokens = new Map<string, IssuedSecretToken>();
+
+  constructor(options: SecretTokenManagerOptions) {
+    this.defaultTtlSeconds = Math.max(options.defaultTtlSeconds, 30);
+    this.maxTtlSeconds = Math.max(options.maxTtlSeconds, this.defaultTtlSeconds);
+    this.now = options.now ?? (() => new Date());
+  }
+
+  issue(input: IssueTokenInput): IssuedSecretToken {
+    const ttlCandidate = input.ttlSeconds ?? this.defaultTtlSeconds;
+    const ttlSeconds = clampTtl(ttlCandidate, this.maxTtlSeconds) || this.defaultTtlSeconds;
+    const issuedAt = this.now();
+    const expiresAt = new Date(issuedAt.getTime() + ttlSeconds * 1000);
+    const token = generateToken();
+    const tokenHash = createHash('sha256').update(token).digest('hex');
+    const allowedKeys = input.keys === '*' ? '*' : new Set(input.keys.map((key) => key.trim()).filter(Boolean));
+    if (allowedKeys !== '*' && allowedKeys.size === 0) {
+      throw new Error('Token scopes cannot be empty');
+    }
+
+    const record: IssuedSecretToken = {
+      id: randomUUID(),
+      token,
+      tokenHash,
+      subject: input.subject,
+      allowedKeys,
+      metadata: input.metadata ?? null,
+      issuedAt,
+      expiresAt,
+      refreshCount: 0
+    } satisfies IssuedSecretToken;
+
+    this.tokens.set(token, record);
+    return record;
+  }
+
+  get(token: string): IssuedSecretToken | null {
+    const trimmed = token.trim();
+    if (!trimmed) {
+      return null;
+    }
+    const record = this.tokens.get(trimmed);
+    if (!record) {
+      return null;
+    }
+    if (record.expiresAt.getTime() <= this.now().getTime()) {
+      this.tokens.delete(trimmed);
+      return null;
+    }
+    return record;
+  }
+
+  refresh(token: string, ttlSeconds?: number | null): RefreshTokenResult | null {
+    const record = this.get(token);
+    if (!record) {
+      return null;
+    }
+    const now = this.now();
+    const ttlCandidate = ttlSeconds ?? this.defaultTtlSeconds;
+    const ttl = clampTtl(ttlCandidate, this.maxTtlSeconds) || this.defaultTtlSeconds;
+    const previousExpiresAt = record.expiresAt;
+    const nextExpiresAt = new Date(now.getTime() + ttl * 1000);
+    record.expiresAt = nextExpiresAt;
+    record.refreshCount += 1;
+    return {
+      token: record,
+      previousExpiresAt
+    } satisfies RefreshTokenResult;
+  }
+
+  revoke(token: string): IssuedSecretToken | null {
+    const record = this.tokens.get(token);
+    if (!record) {
+      return null;
+    }
+    this.tokens.delete(token);
+    return record;
+  }
+
+  pruneExpired(): number {
+    const now = this.now().getTime();
+    let removed = 0;
+    for (const [token, record] of this.tokens.entries()) {
+      if (record.expiresAt.getTime() <= now) {
+        this.tokens.delete(token);
+        removed += 1;
+      }
+    }
+    return removed;
+  }
+
+  listActive(): IssuedSecretToken[] {
+    this.pruneExpired();
+    return Array.from(this.tokens.values()).map((token) => ({ ...token }));
+  }
+}

--- a/services/secrets/src/types.ts
+++ b/services/secrets/src/types.ts
@@ -1,0 +1,92 @@
+import type { JsonValue } from '@apphub/shared';
+
+export type SecretRecord = {
+  key: string;
+  value: string;
+  version?: string | null;
+  metadata?: Record<string, JsonValue> | null;
+  backend: string;
+};
+
+export type SecretConfigEntry = {
+  value: string;
+  version?: string | null;
+  metadata?: Record<string, JsonValue> | null;
+};
+
+export type SecretConfig = string | SecretConfigEntry;
+
+export type SecretConfigCollection = Record<string, SecretConfig>;
+
+export type SecretAccessOutcome = 'authorized' | 'forbidden' | 'missing' | 'expired';
+
+export type IssuedSecretToken = {
+  id: string;
+  token: string;
+  tokenHash: string;
+  subject: string;
+  allowedKeys: Set<string> | '*';
+  metadata?: Record<string, JsonValue> | null;
+  issuedAt: Date;
+  expiresAt: Date;
+  refreshCount: number;
+};
+
+export type IssueTokenInput = {
+  subject: string;
+  keys: string[] | '*';
+  ttlSeconds?: number | null;
+  metadata?: Record<string, JsonValue> | null;
+};
+
+export type RefreshTokenResult = {
+  token: IssuedSecretToken;
+  previousExpiresAt: Date;
+};
+
+export type SecretAuditEvent = {
+  type: 'secret.access';
+  key: string;
+  backend: string;
+  subject: string;
+  tokenId: string;
+  tokenHash: string;
+  outcome: SecretAccessOutcome;
+  version?: string | null;
+  reason?: string;
+  accessedAt: string;
+  expiresAt: string;
+  issuedAt: string;
+  metadata?: Record<string, JsonValue> | null;
+};
+
+export type SecretTokenAuditEvent =
+  | {
+      type: 'secret.token.issued';
+      tokenId: string;
+      tokenHash: string;
+      subject: string;
+      keys: string[] | '*';
+      issuedAt: string;
+      expiresAt: string;
+      metadata?: Record<string, JsonValue> | null;
+    }
+  | {
+      type: 'secret.token.refreshed';
+      tokenId: string;
+      tokenHash: string;
+      subject: string;
+      keys: string[] | '*';
+      issuedAt: string;
+      previousExpiresAt: string;
+      expiresAt: string;
+      metadata?: Record<string, JsonValue> | null;
+    }
+  | {
+      type: 'secret.token.revoked';
+      tokenId: string;
+      tokenHash: string;
+      subject: string;
+      revokedAt: string;
+      metadata?: Record<string, JsonValue> | null;
+    };

--- a/services/secrets/tests/tokenManager.test.ts
+++ b/services/secrets/tests/tokenManager.test.ts
@@ -1,0 +1,63 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { SecretTokenManager } from '../src/tokens/tokenManager';
+
+const NOW = new Date('2024-01-01T00:00:00.000Z');
+
+function nowProvider() {
+  return new Date(NOW);
+}
+
+test('issues token with clamped TTL and scope validation', () => {
+  const manager = new SecretTokenManager({
+    defaultTtlSeconds: 120,
+    maxTtlSeconds: 600,
+    now: nowProvider
+  });
+
+  const token = manager.issue({
+    subject: 'test-subject',
+    keys: ['foo', 'bar'],
+    ttlSeconds: 3600
+  });
+
+  assert.equal(token.subject, 'test-subject');
+  assert.equal(token.allowedKeys === '*' ? 'wildcard' : token.allowedKeys.size, 2);
+  assert.equal(token.issuedAt.toISOString(), NOW.toISOString());
+  assert.equal(token.expiresAt.toISOString(), new Date(NOW.getTime() + 600 * 1000).toISOString());
+});
+
+test('refresh extends expiration and increments counter', () => {
+  let current = NOW;
+  const manager = new SecretTokenManager({
+    defaultTtlSeconds: 60,
+    maxTtlSeconds: 300,
+    now: () => new Date(current)
+  });
+
+  const token = manager.issue({
+    subject: 'refresh-test',
+    keys: '*'
+  });
+
+  current = new Date(NOW.getTime() + 30 * 1000);
+  const result = manager.refresh(token.token, 120);
+  assert(result, 'expected refresh result');
+  assert.equal(result.token.refreshCount, 1);
+  assert.equal(
+    result.token.expiresAt.toISOString(),
+    new Date(current.getTime() + 120 * 1000).toISOString()
+  );
+});
+
+test('revoke removes token', () => {
+  const manager = new SecretTokenManager({
+    defaultTtlSeconds: 60,
+    maxTtlSeconds: 120,
+    now: nowProvider
+  });
+  const token = manager.issue({ subject: 'revoke', keys: '*' });
+  const revoked = manager.revoke(token.token);
+  assert.ok(revoked);
+  assert.equal(manager.get(token.token), null);
+});

--- a/services/secrets/tests/tokenRoutes.test.ts
+++ b/services/secrets/tests/tokenRoutes.test.ts
@@ -1,0 +1,70 @@
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
+import Fastify from 'fastify';
+import { registerTokenRoutes } from '../src/routes/tokens';
+import { SecretTokenManager } from '../src/tokens/tokenManager';
+import type { AdminTokenDefinition, ServiceConfig } from '../src/config/serviceConfig';
+import type { SecretRegistry } from '../src/backends/registry';
+import * as auditPublisher from '../src/audit/publisher';
+
+const noopPublish = mock.method(auditPublisher, 'publishSecretTokenEvent', async () => {
+  // no-op for tests
+});
+
+test('refresh denies when admin scopes do not cover token allowed keys', async () => {
+  const app = Fastify();
+  const manager = new SecretTokenManager({ defaultTtlSeconds: 60, maxTtlSeconds: 300 });
+  const adminToken: AdminTokenDefinition = {
+    token: 'admin-token',
+    subject: 'test-admin',
+    allowedKeys: ['foo'],
+    maxTtlSeconds: null,
+    metadata: null
+  };
+  const config: ServiceConfig = {
+    host: '127.0.0.1',
+    port: 0,
+    metricsEnabled: false,
+    auditEventSource: 'test',
+    defaultTokenTtlSeconds: 60,
+    maxTokenTtlSeconds: 300,
+    adminTokens: [adminToken],
+    backends: [],
+    refreshIntervalMs: null,
+    allowInlineFallback: false
+  };
+  const registry = {
+    refresh: async () => ({ total: 0, backends: [], refreshedAt: new Date().toISOString(), durationMs: 0 }),
+    getSecret: () => null,
+    listSecrets: () => [],
+    getSnapshot: () => null
+  } as unknown as SecretRegistry;
+
+  await registerTokenRoutes(app, {
+    tokenManager: manager,
+    config,
+    adminTokens: [adminToken],
+    registry
+  });
+
+  noopPublish.mock.resetCalls();
+
+  const issued = manager.issue({ subject: 'worker', keys: ['bar'] });
+
+  const response = await app.inject({
+    method: 'POST',
+    url: `/v1/tokens/${issued.token}/refresh`,
+    headers: {
+      authorization: `Bearer ${adminToken.token}`
+    }
+  });
+
+  assert.equal(response.statusCode, 403);
+  assert.deepEqual(JSON.parse(response.payload), {
+    error: 'forbidden',
+    message: 'Admin token does not allow scopes: bar'
+  });
+  assert.equal(noopPublish.mock.callCount(), 0);
+
+  await app.close();
+});

--- a/services/secrets/tsconfig.json
+++ b/services/secrets/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "composite": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "src"
+  ],
+  "references": [
+    {
+      "path": "../../packages/shared"
+    },
+    {
+      "path": "../../packages/event-bus"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add standalone secrets service with token issuance, audit events, and pluggable backends
- use shared SecretsClient in core to resolve store secrets asynchronously with fallback
- document setup, update workflow/job code paths, and expose client from @apphub/shared

Fixes #87

## Testing
- npm run lint --workspace @apphub/secrets
- npm run test --workspace @apphub/secrets
- npm run lint --workspace @apphub/core
- npx tsc -p packages/shared/tsconfig.json
