### PR TITLE
feat(timestore): enable streaming hot buffer for hybrid queries

### DIFF
--- a/docs/flink.md
+++ b/docs/flink.md
@@ -65,6 +65,10 @@ The repo ships a SQL-based demo that consumes events from Redpanda, performs a 1
    kubectl exec -n apphub-system statefulset/apphub-redpanda -- rpk topic consume apphub.streaming.aggregates -n 5
    ```
 
+## Streaming Micro-Batcher
+
+AppHub's timestore service includes a Redpanda-backed micro-batcher that consumes `apphub.streaming.aggregates`, groups records by dataset window, and publishes Parquet partitions via the standard ingestion pipeline. Configure batchers with `TIMESTORE_STREAMING_BATCHERS`—each descriptor specifies the dataset slug, schema, timestamp field, partition keys, and window duration. Once enabled, the worker updates watermarks (`streaming_watermarks` table) so hybrid queries can distinguish sealed intervals from hot streaming windows.
+
 ## Checkpoints & Savepoints
 
 - **Compose / E2E** – Mounted volume `./docker/demo-data/flink/checkpoints` keeps checkpoints between restarts. Remove the directory to reset state.

--- a/docs/flink.md
+++ b/docs/flink.md
@@ -69,6 +69,8 @@ The repo ships a SQL-based demo that consumes events from Redpanda, performs a 1
 
 AppHub's timestore service includes a Redpanda-backed micro-batcher that consumes `apphub.streaming.aggregates`, groups records by dataset window, and publishes Parquet partitions via the standard ingestion pipeline. Configure batchers with `TIMESTORE_STREAMING_BATCHERS`—each descriptor specifies the dataset slug, schema, timestamp field, partition keys, and window duration. Once enabled, the worker updates watermarks (`streaming_watermarks` table) so hybrid queries can distinguish sealed intervals from hot streaming windows.
 
+With `TIMESTORE_STREAMING_BUFFER_ENABLED=1`, timestore also keeps a short-lived hot buffer of streaming rows. Queries that target a range newer than the latest sealed partition automatically merge Parquet results with buffered events, returning a `streaming` metadata block that advertises buffer health, watermark timestamp, and freshness.
+
 ## Checkpoints & Savepoints
 
 - **Compose / E2E** – Mounted volume `./docker/demo-data/flink/checkpoints` keeps checkpoints between restarts. Remove the directory to reset state.

--- a/docs/timestore-observability.md
+++ b/docs/timestore-observability.md
@@ -17,6 +17,11 @@ Metrics are exposed via the Fastify `/metrics` endpoint and follow the `timestor
 | `timestore_query_duration_seconds` | Histogram | `dataset`, `mode` | End-to-end query execution time. |
 | `timestore_query_row_count` | Histogram | `dataset`, `mode` | Result row volume for sizing dashboards. |
 | `timestore_query_remote_partitions_total` | Counter | `dataset`, `cache_enabled` | Remote partition fetches, useful for cache hit/miss ratios (compare with total queries). |
+| `timestore_streaming_records_total` | Counter | `dataset`, `connector` | Streaming records processed by the micro-batcher/hot buffer loop. |
+| `timestore_streaming_flush_duration_seconds` | Histogram | `dataset`, `connector`, `reason` | Latency for streaming window flushes (max-rows, timer, shutdown). |
+| `timestore_streaming_flush_rows` | Histogram | `dataset`, `connector` | Row volume emitted per streaming flush. |
+| `timestore_streaming_backlog_seconds` | Gauge | `dataset`, `connector` | Lag between the sealed partition watermark and the newest buffered streaming event. |
+| `timestore_streaming_open_windows` | Gauge | `dataset`, `connector` | Number of streaming windows still held in the in-memory hot buffer. |
 | `timestore_lifecycle_jobs_total` | Counter | `dataset`, `status` | Lifecycle job execution outcomes. |
 | `timestore_lifecycle_job_duration_seconds` | Histogram | `status` | Lifecycle execution latency. |
 | `timestore_lifecycle_operations_total` | Counter | `operation`, `status` | Compaction, retention, and parquet export summaries. |
@@ -32,6 +37,7 @@ Metrics are exposed via the Fastify `/metrics` endpoint and follow the `timestor
 - **Query latency**: alert on `histogram_quantile(0.95, rate(timestore_query_duration_seconds_bucket[5m])) > 2` seconds.
 - **Lifecycle failures**: page when `increase(timestore_lifecycle_jobs_total{status="failed"}[30m]) >= 1`.
 - **Remote partition spikes**: track ratio `rate(timestore_query_remote_partitions_total[5m]) / rate(timestore_query_requests_total[5m])` to catch cache regressions.
+- **Streaming freshness**: alert if `timestore_streaming_backlog_seconds` stays above 120s or `timestore_streaming_open_windows` grows unexpectedly—both indicate the hot buffer is falling behind the micro-batcher.
 
 ## Tracing
 

--- a/services/timestore/README.md
+++ b/services/timestore/README.md
@@ -67,6 +67,7 @@ Environment variables control networking, storage, and database access:
 | `TIMESTORE_INGEST_CONCURRENCY` | Worker concurrency when processing ingestion jobs. | `2` |
 | `TIMESTORE_CONNECTORS_ENABLED` | Toggle streaming/bulk ingestion connectors managed by the API node. | `false` |
 | `TIMESTORE_STREAMING_CONNECTORS` | JSON array describing streaming connectors (file driver supported). | `[]` |
+| `TIMESTORE_STREAMING_BATCHERS` | JSON array describing streaming micro-batcher definitions that consume Redpanda topics. | `[]` |
 | `TIMESTORE_BULK_CONNECTORS` | JSON array describing bulk loaders (file driver supported). | `[]` |
 | `TIMESTORE_CONNECTOR_BACKPRESSURE` | JSON object with queue depth thresholds controlling connector pause/resume. | `{}` |
 | `TIMESTORE_PARTITION_BUILD_QUEUE_NAME` | BullMQ queue backing remote partition builds. | `timestore_partition_build_queue` |
@@ -90,6 +91,7 @@ When the service boots it ensures the configured Postgres schema exists, runs ti
 ### Streaming & Bulk Connectors
 - Enable connector workers by setting `TIMESTORE_CONNECTORS_ENABLED=true`. When disabled, connector definitions are ignored even if configured.
 - `TIMESTORE_STREAMING_CONNECTORS` expects a JSON array. The file driver consumes newline-delimited JSON envelopes that match the ingestion schema (`offset`, `idempotencyKey`, `ingestion`). Provide `checkpointPath` and optional `dlqPath` to persist offsets and capture failures.
+- Streaming micro-batchers are configured through `TIMESTORE_STREAMING_BATCHERS`. Each descriptor maps a Kafka/Redpanda topic to a dataset slug, schema, and time window so high-frequency events are aggregated before entering the ingestion pipeline.
 - `TIMESTORE_BULK_CONNECTORS` tail directories for staged files (currently JSON). Each descriptor can override `chunkSize`, set `deleteAfterLoad`, or leave ingested files renamed with a `.processed` suffix.
 - Backpressure thresholds come from `TIMESTORE_CONNECTOR_BACKPRESSURE` (high/low watermarks + pause window); connectors pause polling when the ingestion queue depth crosses the configured limits.
 - Connector progress is tracked in JSON checkpoints so a restart resumes from the previous offset without reprocessing data.

--- a/services/timestore/README.md
+++ b/services/timestore/README.md
@@ -68,6 +68,12 @@ Environment variables control networking, storage, and database access:
 | `TIMESTORE_CONNECTORS_ENABLED` | Toggle streaming/bulk ingestion connectors managed by the API node. | `false` |
 | `TIMESTORE_STREAMING_CONNECTORS` | JSON array describing streaming connectors (file driver supported). | `[]` |
 | `TIMESTORE_STREAMING_BATCHERS` | JSON array describing streaming micro-batcher definitions that consume Redpanda topics. | `[]` |
+| `TIMESTORE_STREAMING_BUFFER_ENABLED` | Toggle the in-memory streaming hot buffer used for hybrid queries. | `false` |
+| `TIMESTORE_STREAMING_BUFFER_RETENTION_SECONDS` | Seconds of streaming data retained in the hot buffer per dataset. | `120` |
+| `TIMESTORE_STREAMING_BUFFER_MAX_ROWS_PER_DATASET` | Per-dataset row cap for buffered streaming events. | `10000` |
+| `TIMESTORE_STREAMING_BUFFER_MAX_TOTAL_ROWS` | Optional global row cap across all datasets (unset to disable). | _(unset)_ |
+| `TIMESTORE_STREAMING_BUFFER_REFRESH_MS` | Interval for refreshing sealed partition watermarks from metadata. | `5000` |
+| `TIMESTORE_STREAMING_BUFFER_FALLBACK` | Behaviour when the hot buffer is unavailable (`parquet_only` or `error`). | `parquet_only` |
 | `TIMESTORE_BULK_CONNECTORS` | JSON array describing bulk loaders (file driver supported). | `[]` |
 | `TIMESTORE_CONNECTOR_BACKPRESSURE` | JSON object with queue depth thresholds controlling connector pause/resume. | `{}` |
 | `TIMESTORE_PARTITION_BUILD_QUEUE_NAME` | BullMQ queue backing remote partition builds. | `timestore_partition_build_queue` |
@@ -92,9 +98,16 @@ When the service boots it ensures the configured Postgres schema exists, runs ti
 - Enable connector workers by setting `TIMESTORE_CONNECTORS_ENABLED=true`. When disabled, connector definitions are ignored even if configured.
 - `TIMESTORE_STREAMING_CONNECTORS` expects a JSON array. The file driver consumes newline-delimited JSON envelopes that match the ingestion schema (`offset`, `idempotencyKey`, `ingestion`). Provide `checkpointPath` and optional `dlqPath` to persist offsets and capture failures.
 - Streaming micro-batchers are configured through `TIMESTORE_STREAMING_BATCHERS`. Each descriptor maps a Kafka/Redpanda topic to a dataset slug, schema, and time window so high-frequency events are aggregated before entering the ingestion pipeline.
+- The streaming hot buffer rides on the same topic definitions. When `TIMESTORE_STREAMING_BUFFER_ENABLED=1`, the service tails high-water offsets for each batcher, keeps recent events in memory, and merges them with sealed Parquet partitions at query time. The buffer automatically evicts rows once the micro-batcher advances the watermark (persisted in `streaming_watermarks`).
 - `TIMESTORE_BULK_CONNECTORS` tail directories for staged files (currently JSON). Each descriptor can override `chunkSize`, set `deleteAfterLoad`, or leave ingested files renamed with a `.processed` suffix.
 - Backpressure thresholds come from `TIMESTORE_CONNECTOR_BACKPRESSURE` (high/low watermarks + pause window); connectors pause polling when the ingestion queue depth crosses the configured limits.
 - Connector progress is tracked in JSON checkpoints so a restart resumes from the previous offset without reprocessing data.
+
+#### Streaming Hot Buffer
+- Enable via `TIMESTORE_STREAMING_BUFFER_ENABLED=1` alongside the micro-batcher. Configure per-dataset retention and memory limits with the knobs above.
+- Hybrid queries automatically call the buffer when the requested range overlaps the streaming window. The JSON response now includes a `streaming` block (`bufferState`, merged row count, watermark, `fresh` flag) so clients can surface freshness indicators.
+- Operators can monitor buffer health through the new metrics: `timestore_streaming_records_total`, `timestore_streaming_flush_duration_seconds`, `timestore_streaming_flush_rows`, `timestore_streaming_backlog_seconds`, and `timestore_streaming_open_windows`. Querying the `streaming_watermarks` table reveals the most recent sealed partition per dataset.
+- If the buffer becomes unavailable, set `TIMESTORE_STREAMING_BUFFER_FALLBACK=parquet_only` to continue serving sealed partitions (with a warning) or `error` to fail fast until the streaming tier recovers.
 
 ### Filestore Integration
 

--- a/services/timestore/openapi.json
+++ b/services/timestore/openapi.json
@@ -2665,6 +2665,51 @@
             "items": {
               "type": "string"
             }
+          },
+          "streaming": {
+            "type": "object",
+            "required": [
+              "enabled",
+              "bufferState",
+              "rows",
+              "fresh"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "description": "Indicates whether streaming integration was active for the query."
+              },
+              "bufferState": {
+                "type": "string",
+                "enum": [
+                  "disabled",
+                  "ready",
+                  "unavailable"
+                ],
+                "description": "State of the streaming hot buffer during query execution."
+              },
+              "rows": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Number of streaming rows merged into the response."
+              },
+              "watermark": {
+                "type": "string",
+                "format": "date-time",
+                "nullable": true
+              },
+              "latestTimestamp": {
+                "type": "string",
+                "format": "date-time",
+                "nullable": true
+              },
+              "fresh": {
+                "type": "boolean",
+                "description": "True when streaming data covers the requested range end."
+              }
+            },
+            "nullable": true
           }
         }
       },
@@ -6200,6 +6245,57 @@
             "description": "Non-fatal issues encountered while executing the query.",
             "items": {
               "type": "string"
+            }
+          },
+          "streaming": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "required": [
+              "enabled",
+              "bufferState",
+              "rows",
+              "fresh"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "description": "Indicates whether streaming integration was active for the query."
+              },
+              "bufferState": {
+                "type": "string",
+                "enum": [
+                  "disabled",
+                  "ready",
+                  "unavailable"
+                ],
+                "description": "State of the streaming hot buffer during query execution."
+              },
+              "rows": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Number of streaming rows merged into the response."
+              },
+              "watermark": {
+                "type": [
+                  "null",
+                  "string"
+                ],
+                "format": "date-time"
+              },
+              "latestTimestamp": {
+                "type": [
+                  "null",
+                  "string"
+                ],
+                "format": "date-time"
+              },
+              "fresh": {
+                "type": "boolean",
+                "description": "True when streaming data covers the requested range end."
+              }
             }
           }
         },

--- a/services/timestore/package.json
+++ b/services/timestore/package.json
@@ -32,6 +32,7 @@
     "@apphub/event-bus": "0.1.0",
     "fastify-plugin": "^4.5.1",
     "ioredis": "^5.8.0",
+    "kafkajs": "^2.2.4",
     "pg": "^8.16.3",
     "js-yaml": "^4.1.0",
     "prom-client": "^15.1.3",

--- a/services/timestore/src/db/metadata.ts
+++ b/services/timestore/src/db/metadata.ts
@@ -1374,6 +1374,43 @@ export async function getStreamingWatermark(
   });
 }
 
+export async function listStreamingWatermarks(): Promise<StreamingWatermarkRecord[]> {
+  return withConnection(async (client) => {
+    const { rows } = await client.query(
+      `SELECT connector_id,
+              dataset_id,
+              dataset_slug,
+              sealed_through,
+              backlog_lag_ms,
+              records_processed,
+              updated_at
+         FROM streaming_watermarks`
+    );
+
+    return rows.map((row) => {
+      const record = row as {
+        connector_id: string;
+        dataset_id: string;
+        dataset_slug: string;
+        sealed_through: Date;
+        backlog_lag_ms: number;
+        records_processed: string | number;
+        updated_at: Date;
+      };
+
+      return {
+        connectorId: record.connector_id,
+        datasetId: record.dataset_id,
+        datasetSlug: record.dataset_slug,
+        sealedThrough: new Date(record.sealed_through).toISOString(),
+        backlogLagMs: Number(record.backlog_lag_ms ?? 0),
+        recordsProcessed: Number(record.records_processed ?? 0),
+        updatedAt: new Date(record.updated_at).toISOString()
+      } satisfies StreamingWatermarkRecord;
+    });
+  });
+}
+
 export interface DatasetAccessAuditCursor {
   createdAt: string;
   id: string;

--- a/services/timestore/src/db/metadata.ts
+++ b/services/timestore/src/db/metadata.ts
@@ -120,6 +120,25 @@ export interface DatasetManifestRecord {
   publishedAt: string | null;
 }
 
+export interface StreamingWatermarkRecord {
+  connectorId: string;
+  datasetId: string;
+  datasetSlug: string;
+  sealedThrough: string;
+  backlogLagMs: number;
+  recordsProcessed: number;
+  updatedAt: string;
+}
+
+export interface UpsertStreamingWatermarkInput {
+  connectorId: string;
+  datasetId: string;
+  datasetSlug: string;
+  sealedThrough: Date;
+  backlogLagMs: number;
+  recordsProcessedDelta?: number;
+}
+
 export interface DatasetPartitionRecord {
   id: string;
   datasetId: string;
@@ -1271,6 +1290,87 @@ export async function recordDatasetAccessEvent(
       ]
     );
     return mapDatasetAccessAudit(rows[0]);
+  });
+}
+
+export async function upsertStreamingWatermark(input: UpsertStreamingWatermarkInput): Promise<void> {
+  const recordsDelta = Number.isFinite(input.recordsProcessedDelta ?? NaN)
+    ? Math.max(0, Math.floor(input.recordsProcessedDelta ?? 0))
+    : 0;
+  const backlogLag = Math.max(0, Math.floor(input.backlogLagMs));
+
+  await withConnection(async (client) => {
+    await client.query(
+      `INSERT INTO streaming_watermarks (
+         connector_id,
+         dataset_id,
+         dataset_slug,
+         sealed_through,
+         backlog_lag_ms,
+         records_processed
+       )
+       VALUES ($1, $2, $3, $4, $5, $6)
+       ON CONFLICT (connector_id, dataset_id)
+       DO UPDATE SET
+         dataset_slug = EXCLUDED.dataset_slug,
+         sealed_through = GREATEST(streaming_watermarks.sealed_through, EXCLUDED.sealed_through),
+         backlog_lag_ms = EXCLUDED.backlog_lag_ms,
+         records_processed = streaming_watermarks.records_processed + EXCLUDED.records_processed,
+         updated_at = NOW();`,
+      [
+        input.connectorId,
+        input.datasetId,
+        input.datasetSlug,
+        input.sealedThrough.toISOString(),
+        backlogLag,
+        recordsDelta
+      ]
+    );
+  });
+}
+
+export async function getStreamingWatermark(
+  datasetId: string,
+  connectorId: string
+): Promise<StreamingWatermarkRecord | null> {
+  return withConnection(async (client) => {
+    const { rows } = await client.query(
+      `SELECT connector_id,
+              dataset_id,
+              dataset_slug,
+              sealed_through,
+              backlog_lag_ms,
+              records_processed,
+              updated_at
+         FROM streaming_watermarks
+        WHERE dataset_id = $1
+          AND connector_id = $2`,
+      [datasetId, connectorId]
+    );
+
+    if (rows.length === 0) {
+      return null;
+    }
+
+    const row = rows[0] as {
+      connector_id: string;
+      dataset_id: string;
+      dataset_slug: string;
+      sealed_through: Date;
+      backlog_lag_ms: number;
+      records_processed: string | number;
+      updated_at: Date;
+    };
+
+    return {
+      connectorId: row.connector_id,
+      datasetId: row.dataset_id,
+      datasetSlug: row.dataset_slug,
+      sealedThrough: new Date(row.sealed_through).toISOString(),
+      backlogLagMs: Number(row.backlog_lag_ms ?? 0),
+      recordsProcessed: Number(row.records_processed ?? 0),
+      updatedAt: new Date(row.updated_at).toISOString()
+    } satisfies StreamingWatermarkRecord;
   });
 }
 

--- a/services/timestore/src/db/migrations.ts
+++ b/services/timestore/src/db/migrations.ts
@@ -316,6 +316,23 @@ const migrations: Migration[] = [
          ON dataset_partitions(dataset_id, ingestion_signature)
          WHERE ingestion_signature IS NOT NULL;`
     ]
+  },
+  {
+    id: '013_timestore_streaming_watermarks',
+    statements: [
+      `CREATE TABLE IF NOT EXISTS streaming_watermarks (
+         connector_id TEXT NOT NULL,
+         dataset_id TEXT NOT NULL REFERENCES datasets(id) ON DELETE CASCADE,
+         dataset_slug TEXT NOT NULL,
+         sealed_through TIMESTAMPTZ NOT NULL,
+         backlog_lag_ms BIGINT NOT NULL DEFAULT 0,
+         records_processed BIGINT NOT NULL DEFAULT 0,
+         updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+         PRIMARY KEY (connector_id, dataset_id)
+       );`,
+      `CREATE INDEX IF NOT EXISTS idx_streaming_watermarks_dataset
+         ON streaming_watermarks(dataset_id);`
+    ]
   }
 ];
 

--- a/services/timestore/src/openapi/definitions.ts
+++ b/services/timestore/src/openapi/definitions.ts
@@ -704,6 +704,34 @@ const datasetQueryRequestSchema: OpenAPIV3.SchemaObject = {
   }
 };
 
+const datasetQueryStreamingSchema: OpenAPIV3.SchemaObject = {
+  type: 'object',
+  required: ['enabled', 'bufferState', 'rows', 'fresh'],
+  additionalProperties: false,
+  properties: {
+    enabled: {
+      type: 'boolean',
+      description: 'Indicates whether streaming integration was active for the query.'
+    },
+    bufferState: {
+      type: 'string',
+      enum: ['disabled', 'ready', 'unavailable'],
+      description: 'State of the streaming hot buffer during query execution.'
+    },
+    rows: {
+      type: 'integer',
+      minimum: 0,
+      description: 'Number of streaming rows merged into the response.'
+    },
+    watermark: nullable(stringSchema('date-time')),
+    latestTimestamp: nullable(stringSchema('date-time')),
+    fresh: {
+      type: 'boolean',
+      description: 'True when streaming data covers the requested range end.'
+    }
+  }
+};
+
 const datasetQueryResponseSchema: OpenAPIV3.SchemaObject = {
   type: 'object',
   required: ['rows', 'columns', 'mode'],
@@ -727,7 +755,8 @@ const datasetQueryResponseSchema: OpenAPIV3.SchemaObject = {
       type: 'array',
       description: 'Non-fatal issues encountered while executing the query.',
       items: stringSchema()
-    }
+    },
+    streaming: nullable(datasetQueryStreamingSchema)
   }
 };
 

--- a/services/timestore/src/server.ts
+++ b/services/timestore/src/server.ts
@@ -16,6 +16,7 @@ import { setupTracing } from './observability/tracing';
 import { initializeFilestoreActivity, shutdownFilestoreActivity } from './filestore/consumer';
 import { shutdownManifestCache } from './cache/manifestCache';
 import { initializeIngestionConnectors, shutdownIngestionConnectors } from './ingestion/connectors';
+import { initializeStreamingBatchers, shutdownStreamingBatchers } from './streaming/batchers';
 import { initializeDatasetAccessCleanup, shutdownDatasetAccessCleanup } from './service/auditCleanup';
 import { registerOpenApi } from './openapi/plugin';
 
@@ -71,6 +72,7 @@ async function start(): Promise<void> {
     await shutdownManifestCache();
     await shutdownFilestoreActivity();
     await shutdownIngestionConnectors();
+    await shutdownStreamingBatchers();
     await shutdownDatasetAccessCleanup();
   });
 
@@ -80,6 +82,7 @@ async function start(): Promise<void> {
   await verifyLifecycleQueueConnection();
   await initializeFilestoreActivity({ config, logger: app.log });
   await initializeIngestionConnectors({ config, logger: app.log });
+  await initializeStreamingBatchers({ config, logger: app.log });
   await initializeDatasetAccessCleanup({ config, logger: app.log });
 
   try {

--- a/services/timestore/src/server.ts
+++ b/services/timestore/src/server.ts
@@ -17,6 +17,7 @@ import { initializeFilestoreActivity, shutdownFilestoreActivity } from './filest
 import { shutdownManifestCache } from './cache/manifestCache';
 import { initializeIngestionConnectors, shutdownIngestionConnectors } from './ingestion/connectors';
 import { initializeStreamingBatchers, shutdownStreamingBatchers } from './streaming/batchers';
+import { initializeStreamingHotBuffer, shutdownStreamingHotBuffer } from './streaming/hotBuffer';
 import { initializeDatasetAccessCleanup, shutdownDatasetAccessCleanup } from './service/auditCleanup';
 import { registerOpenApi } from './openapi/plugin';
 
@@ -73,6 +74,7 @@ async function start(): Promise<void> {
     await shutdownFilestoreActivity();
     await shutdownIngestionConnectors();
     await shutdownStreamingBatchers();
+    await shutdownStreamingHotBuffer();
     await shutdownDatasetAccessCleanup();
   });
 
@@ -83,6 +85,7 @@ async function start(): Promise<void> {
   await initializeFilestoreActivity({ config, logger: app.log });
   await initializeIngestionConnectors({ config, logger: app.log });
   await initializeStreamingBatchers({ config, logger: app.log });
+  await initializeStreamingHotBuffer({ config, logger: app.log });
   await initializeDatasetAccessCleanup({ config, logger: app.log });
 
   try {

--- a/services/timestore/src/streaming/batchProcessor.ts
+++ b/services/timestore/src/streaming/batchProcessor.ts
@@ -1,0 +1,355 @@
+import type { FastifyBaseLogger } from 'fastify';
+import type { StreamingBatcherConfig } from '../config/serviceConfig';
+import { processIngestionJob } from '../ingestion/processor';
+import type { IngestionJobPayload, IngestionProcessingResult } from '../ingestion/types';
+import { upsertStreamingWatermark, type UpsertStreamingWatermarkInput } from '../db/metadata';
+import {
+  observeStreamingRecords,
+  observeStreamingFlush,
+  updateStreamingBacklog,
+  type StreamingFlushMetricsInput
+} from '../observability/metrics';
+
+const DEFAULT_RETRY_DELAY_MS = 5_000;
+
+export type FlushReason = 'max_rows' | 'timer' | 'shutdown' | 'manual';
+
+export interface StreamingBatchProcessorDependencies {
+  ingest?: (payload: IngestionJobPayload) => Promise<IngestionProcessingResult>;
+  persistWatermark?: (input: UpsertStreamingWatermarkInput) => Promise<void>;
+  now?: () => number;
+  retryDelayMs?: number;
+}
+
+interface WindowState {
+  nextChunkIndex: number;
+  activeChunkIndex: number | null;
+  flushingChunks: Set<number>;
+}
+
+interface WindowBuffer {
+  key: string;
+  windowId: string;
+  chunkIndex: number;
+  windowStart: Date;
+  windowEnd: Date;
+  rows: Record<string, unknown>[];
+  createdAtMs: number;
+  lastUpdatedMs: number;
+  flushTimer: NodeJS.Timeout | null;
+  retryTimer: NodeJS.Timeout | null;
+}
+
+interface ParsedEvent {
+  row: Record<string, unknown>;
+  timestamp: Date;
+}
+
+export class StreamingBatchProcessor {
+  private readonly ingest: (payload: IngestionJobPayload) => Promise<IngestionProcessingResult>;
+  private readonly persistWatermark: (input: UpsertStreamingWatermarkInput) => Promise<void>;
+  private readonly now: () => number;
+  private readonly retryDelayMs: number;
+  private readonly buffers = new Map<string, WindowBuffer>();
+  private readonly windowStates = new Map<string, WindowState>();
+  private readonly datasetSlug: string;
+
+  constructor(
+    private readonly config: StreamingBatcherConfig,
+    private readonly logger: FastifyBaseLogger,
+    dependencies: StreamingBatchProcessorDependencies = {}
+  ) {
+    this.ingest = dependencies.ingest ?? processIngestionJob;
+    this.persistWatermark = dependencies.persistWatermark ?? upsertStreamingWatermark;
+    this.now = dependencies.now ?? Date.now;
+    this.retryDelayMs = dependencies.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS;
+    this.datasetSlug = config.datasetSlug;
+  }
+
+  async processRecord(event: Record<string, unknown>): Promise<void> {
+    const parsed = this.parseEvent(event);
+    if (!parsed) {
+      return;
+    }
+
+    const windowId = parsed.timestampWindowStart.toISOString();
+    const buffer = this.getOrCreateBuffer(windowId, parsed.timestampWindowStart, parsed.timestampWindowEnd);
+    buffer.rows.push(parsed.row);
+    buffer.lastUpdatedMs = this.now();
+    observeStreamingRecords({ datasetSlug: this.datasetSlug, connectorId: this.config.id, count: 1 });
+
+    if (buffer.rows.length >= this.config.maxRowsPerPartition) {
+      await this.flushBuffer(buffer.key, 'max_rows');
+    } else {
+      this.ensureFlushTimer(buffer.key, buffer);
+    }
+  }
+
+  async flushAll(reason: FlushReason = 'manual'): Promise<void> {
+    const pending = Array.from(this.buffers.keys()).map((key) => this.flushBuffer(key, reason).catch((error) => {
+      this.logger.error({ err: error, connectorId: this.config.id, bufferKey: key }, 'streaming batch flush failed during flushAll');
+    }));
+    await Promise.allSettled(pending);
+  }
+
+  private parseEvent(event: Record<string, unknown>): (ParsedEvent & { timestampWindowStart: Date; timestampWindowEnd: Date }) | null {
+    const rawTimestamp = event[this.config.timeField];
+    const timestamp = normalizeTimestamp(rawTimestamp);
+    if (!timestamp) {
+      this.logger.warn({ connectorId: this.config.id, field: this.config.timeField, value: rawTimestamp }, 'streaming event missing or invalid timestamp field');
+      return null;
+    }
+
+    const row: Record<string, unknown> = { ...event };
+    const windowStart = floorToWindow(timestamp, this.config.windowSeconds);
+    const windowEnd = new Date(windowStart.getTime() + this.config.windowSeconds * 1000);
+
+    return {
+      row,
+      timestamp,
+      timestampWindowStart: windowStart,
+      timestampWindowEnd: windowEnd
+    };
+  }
+
+  private getOrCreateBuffer(windowId: string, windowStart: Date, windowEnd: Date): WindowBuffer {
+    const state = this.getOrCreateWindowState(windowId);
+
+    if (state.activeChunkIndex !== null) {
+      const activeKey = buildBufferKey(windowId, state.activeChunkIndex);
+      const existing = this.buffers.get(activeKey);
+      if (existing) {
+        return existing;
+      }
+      state.activeChunkIndex = null;
+    }
+
+    const chunkIndex = state.nextChunkIndex;
+    state.nextChunkIndex += 1;
+    state.activeChunkIndex = chunkIndex;
+
+    const key = buildBufferKey(windowId, chunkIndex);
+    const buffer: WindowBuffer = {
+      key,
+      windowId,
+      chunkIndex,
+      windowStart,
+      windowEnd,
+      rows: [],
+      createdAtMs: this.now(),
+      lastUpdatedMs: this.now(),
+      flushTimer: null,
+      retryTimer: null
+    };
+    this.buffers.set(key, buffer);
+    this.ensureFlushTimer(key, buffer);
+    return buffer;
+  }
+
+  private ensureFlushTimer(key: string, buffer: WindowBuffer): void {
+    if (buffer.flushTimer) {
+      return;
+    }
+    buffer.flushTimer = setTimeout(() => {
+      void this.flushBuffer(key, 'timer').catch((error) => {
+        this.logger.error({ err: error, connectorId: this.config.id, bufferKey: key }, 'streaming batch timer flush failed');
+      });
+    }, this.config.maxBatchLatencyMs);
+    if (typeof buffer.flushTimer.unref === 'function') {
+      buffer.flushTimer.unref();
+    }
+  }
+
+  private clearFlushTimer(buffer: WindowBuffer): void {
+    if (buffer.flushTimer) {
+      clearTimeout(buffer.flushTimer);
+      buffer.flushTimer = null;
+    }
+  }
+
+  private async flushBuffer(key: string, reason: FlushReason): Promise<void> {
+    const buffer = this.buffers.get(key);
+    if (!buffer) {
+      return;
+    }
+    if (buffer.rows.length === 0) {
+      this.clearFlushTimer(buffer);
+      this.buffers.delete(key);
+      return;
+    }
+
+    this.clearFlushTimer(buffer);
+    const state = this.windowStates.get(buffer.windowId);
+    if (state && state.activeChunkIndex === buffer.chunkIndex) {
+      state.activeChunkIndex = null;
+    }
+    this.buffers.delete(key);
+    state?.flushingChunks.add(buffer.chunkIndex);
+
+    try {
+      await this.performFlush(buffer, reason);
+      if (state) {
+        state.flushingChunks.delete(buffer.chunkIndex);
+        this.cleanupWindowState(buffer.windowId, state);
+      }
+    } catch (error) {
+      if (state) {
+        state.flushingChunks.delete(buffer.chunkIndex);
+        if (state.activeChunkIndex === null) {
+          state.activeChunkIndex = buffer.chunkIndex;
+        }
+      }
+      this.buffers.set(key, buffer);
+      this.ensureRetryTimer(key, buffer);
+      throw error;
+    }
+  }
+
+  private ensureRetryTimer(key: string, buffer: WindowBuffer): void {
+    if (buffer.retryTimer) {
+      return;
+    }
+    buffer.retryTimer = setTimeout(() => {
+      buffer.retryTimer = null;
+      void this.flushBuffer(key, 'manual').catch((error) => {
+        this.logger.error({ err: error, connectorId: this.config.id, bufferKey: key }, 'streaming batch retry flush failed');
+      });
+    }, this.retryDelayMs);
+    if (typeof buffer.retryTimer.unref === 'function') {
+      buffer.retryTimer.unref();
+    }
+  }
+
+  private async performFlush(buffer: WindowBuffer, reason: FlushReason): Promise<void> {
+    const rows = [...buffer.rows];
+    rows.sort((a, b) => compareByTimeField(a, b, this.config.timeField));
+
+    const chunkLabel = buffer.chunkIndex.toString();
+    const partitionKey = {
+      ...this.config.partitionKey,
+      window: buffer.windowStart.toISOString(),
+      chunk: chunkLabel
+    } satisfies Record<string, string>;
+
+    const partitionAttributes = {
+      ...this.config.partitionAttributes,
+      window_end: buffer.windowEnd.toISOString(),
+      chunk: chunkLabel,
+      flush_reason: reason
+    } satisfies Record<string, string>;
+
+    const payload: IngestionJobPayload = {
+      datasetSlug: this.config.datasetSlug,
+      datasetName: this.config.datasetName,
+      tableName: this.config.tableName,
+      schema: this.config.schema,
+      partition: {
+        key: partitionKey,
+        attributes: partitionAttributes,
+        timeRange: {
+          start: buffer.windowStart.toISOString(),
+          end: buffer.windowEnd.toISOString()
+        }
+      },
+      rows,
+      idempotencyKey: `${this.config.id}:${buffer.windowStart.toISOString()}:${chunkLabel}`,
+      receivedAt: new Date().toISOString()
+    };
+
+    const ingestStart = this.now();
+    const result = await this.ingest(payload);
+    const ingestDurationSeconds = (this.now() - ingestStart) / 1_000;
+
+    observeStreamingFlush({
+      datasetSlug: this.config.datasetSlug,
+      connectorId: this.config.id,
+      rows: rows.length,
+      durationSeconds: ingestDurationSeconds,
+      reason
+    } satisfies StreamingFlushMetricsInput);
+
+    const lagSeconds = Math.max(0, (this.now() - buffer.windowEnd.getTime()) / 1_000);
+    updateStreamingBacklog({
+      datasetSlug: this.config.datasetSlug,
+      connectorId: this.config.id,
+      lagSeconds,
+      openWindows: this.getOpenWindowCount()
+    });
+
+    await this.persistWatermark({
+      connectorId: this.config.id,
+      datasetId: result.dataset.id,
+      datasetSlug: result.dataset.slug ?? this.config.datasetSlug,
+      sealedThrough: buffer.windowEnd,
+      backlogLagMs: Math.round(lagSeconds * 1_000),
+      recordsProcessedDelta: rows.length
+    });
+  }
+
+  private getOpenWindowCount(): number {
+    let total = 0;
+    for (const state of this.windowStates.values()) {
+      if (state.activeChunkIndex !== null || state.flushingChunks.size > 0) {
+        total += 1;
+      }
+    }
+    return total;
+  }
+
+  private getOrCreateWindowState(windowId: string): WindowState {
+    let state = this.windowStates.get(windowId);
+    if (!state) {
+      state = {
+        nextChunkIndex: 0,
+        activeChunkIndex: null,
+        flushingChunks: new Set<number>()
+      } satisfies WindowState;
+      this.windowStates.set(windowId, state);
+    }
+    return state;
+  }
+
+  private cleanupWindowState(windowId: string, state: WindowState): void {
+    if (state.activeChunkIndex === null && state.flushingChunks.size === 0) {
+      this.windowStates.delete(windowId);
+    }
+  }
+}
+
+function buildBufferKey(windowId: string, chunkIndex: number): string {
+  return `${windowId}#${chunkIndex}`;
+}
+
+function floorToWindow(timestamp: Date, windowSeconds: number): Date {
+  const totalSeconds = Math.floor(timestamp.getTime() / 1000);
+  const windowStartSeconds = totalSeconds - (totalSeconds % windowSeconds);
+  return new Date(windowStartSeconds * 1000);
+}
+
+function normalizeTimestamp(value: unknown): Date | null {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+  if (typeof value === 'number') {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+  if (typeof value === 'string') {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+  return null;
+}
+
+function compareByTimeField(
+  left: Record<string, unknown>,
+  right: Record<string, unknown>,
+  field: string
+): number {
+  const leftValue = normalizeTimestamp(left[field]);
+  const rightValue = normalizeTimestamp(right[field]);
+  if (!leftValue || !rightValue) {
+    return 0;
+  }
+  return leftValue.getTime() - rightValue.getTime();
+}

--- a/services/timestore/src/streaming/batchers.ts
+++ b/services/timestore/src/streaming/batchers.ts
@@ -1,0 +1,174 @@
+import type { FastifyBaseLogger } from 'fastify';
+import { Kafka, logLevel, type Consumer } from 'kafkajs';
+import type { ServiceConfig, StreamingBatcherConfig } from '../config/serviceConfig';
+import { StreamingBatchProcessor, type FlushReason } from './batchProcessor';
+
+interface StreamingBatcherContext {
+  config: StreamingBatcherConfig;
+  processor: StreamingBatchProcessor;
+  consumer: Consumer;
+  logger: FastifyBaseLogger;
+  runPromise?: Promise<void>;
+}
+
+class StreamingMicroBatcher {
+  private readonly context: StreamingBatcherContext;
+
+  constructor(
+    kafka: Kafka,
+    config: StreamingBatcherConfig,
+    logger: FastifyBaseLogger
+  ) {
+    const processorLogger = typeof logger.child === 'function'
+      ? logger.child({ connectorId: config.id })
+      : logger;
+
+    const processor = new StreamingBatchProcessor(config, processorLogger);
+    const consumer = kafka.consumer({ groupId: config.groupId });
+
+    this.context = {
+      config,
+      processor,
+      consumer,
+      logger: processorLogger
+    };
+  }
+
+  async start(): Promise<void> {
+    const { consumer, config, processor, logger } = this.context;
+    await consumer.connect();
+    await consumer.subscribe({ topic: config.topic, fromBeginning: config.startFromEarliest });
+
+    this.context.runPromise = consumer.run({
+      eachMessage: async ({ message }) => {
+        if (!message.value) {
+          logger.warn({ topic: config.topic, connectorId: config.id }, 'streaming message missing value');
+          return;
+        }
+        let payload: unknown;
+        try {
+          payload = JSON.parse(message.value.toString('utf8'));
+        } catch (error) {
+          logger.warn({ err: error, connectorId: config.id }, 'streaming message failed JSON parse');
+          return;
+        }
+        if (!payload || typeof payload !== 'object') {
+          logger.warn({ connectorId: config.id }, 'streaming message payload is not an object; skipping');
+          return;
+        }
+        try {
+          await processor.processRecord(payload as Record<string, unknown>);
+        } catch (error) {
+          logger.error({ err: error, connectorId: config.id }, 'streaming batch processor failed');
+          throw error;
+        }
+      }
+    }).catch((error) => {
+      logger.error({ err: error, connectorId: config.id }, 'streaming consumer terminated unexpectedly');
+    });
+
+    logger.info({ connectorId: config.id, topic: config.topic, groupId: config.groupId }, 'streaming micro-batcher started');
+  }
+
+  async stop(reason: FlushReason = 'shutdown'): Promise<void> {
+    const { consumer, processor, logger, config } = this.context;
+    try {
+      await consumer.stop();
+    } catch (error) {
+      logger.warn({ err: error, connectorId: config.id }, 'streaming consumer stop failed');
+    }
+    if (this.context.runPromise) {
+      await this.context.runPromise.catch(() => undefined);
+    }
+    await processor.flushAll(reason);
+    try {
+      await consumer.disconnect();
+    } catch (error) {
+      logger.warn({ err: error, connectorId: config.id }, 'streaming consumer disconnect failed');
+    }
+    logger.info({ connectorId: config.id }, 'streaming micro-batcher stopped');
+  }
+}
+
+class StreamingBatcherManager {
+  private readonly kafka: Kafka;
+  private readonly batchers: StreamingMicroBatcher[] = [];
+
+  constructor(
+    private readonly brokerUrl: string,
+    private readonly batcherConfigs: StreamingBatcherConfig[],
+    private readonly logger: FastifyBaseLogger
+  ) {
+    this.kafka = new Kafka({
+      clientId: 'timestore-streaming-batcher',
+      brokers: [brokerUrl],
+      logLevel: logLevel.ERROR
+    });
+  }
+
+  async start(): Promise<void> {
+    const baseLogger = typeof this.logger.child === 'function'
+      ? this.logger.child({ component: 'timestore.streaming.batchers' })
+      : this.logger;
+
+    for (const config of this.batcherConfigs) {
+      const connectorLogger = typeof baseLogger.child === 'function'
+        ? baseLogger.child({ connectorId: config.id })
+        : baseLogger;
+      const batcher = new StreamingMicroBatcher(this.kafka, config, connectorLogger);
+      await batcher.start();
+      this.batchers.push(batcher);
+    }
+  }
+
+  async stop(): Promise<void> {
+    const stops = this.batchers.map((batcher) => batcher.stop().catch((error) => {
+      this.logger.error({ err: error }, 'failed to stop streaming micro-batcher');
+    }));
+    await Promise.allSettled(stops);
+    this.batchers.length = 0;
+  }
+}
+
+let manager: StreamingBatcherManager | null = null;
+
+export async function initializeStreamingBatchers(
+  params: { config: ServiceConfig; logger: FastifyBaseLogger }
+): Promise<void> {
+  if (manager) {
+    await manager.stop().catch(() => undefined);
+    manager = null;
+  }
+
+  const streamingFeatureEnabled = params.config.features.streaming.enabled;
+  const brokerUrl = params.config.streaming.brokerUrl;
+  const batcherConfigs = params.config.streaming.batchers;
+
+  if (!streamingFeatureEnabled) {
+    return;
+  }
+  if (!brokerUrl) {
+    const warnLogger = typeof params.logger.child === 'function'
+      ? params.logger.child({ component: 'timestore.streaming.batchers' })
+      : params.logger;
+    warnLogger.warn('streaming enabled but APPHUB_STREAM_BROKER_URL is not configured; skipping micro-batchers');
+    return;
+  }
+  if (batcherConfigs.length === 0) {
+    return;
+  }
+
+  manager = new StreamingBatcherManager(brokerUrl, batcherConfigs, params.logger);
+  await manager.start();
+}
+
+export async function shutdownStreamingBatchers(): Promise<void> {
+  if (!manager) {
+    return;
+  }
+  const instance = manager;
+  manager = null;
+  await instance.stop();
+}
+
+export { StreamingBatchProcessor } from './batchProcessor';

--- a/services/timestore/src/streaming/hotBuffer.ts
+++ b/services/timestore/src/streaming/hotBuffer.ts
@@ -1,0 +1,501 @@
+import type { FastifyBaseLogger } from 'fastify';
+import { Kafka, logLevel, type Consumer } from 'kafkajs';
+import type {
+  ServiceConfig,
+  StreamingBatcherConfig,
+  StreamingHotBufferConfig
+} from '../config/serviceConfig';
+import { listStreamingWatermarks } from '../db/metadata';
+
+export interface HotBufferQueryOptions {
+  rangeStart: Date;
+  rangeEnd: Date;
+  limit?: number;
+  timestampColumn: string;
+}
+
+export interface HotBufferQueryResult {
+  rows: Record<string, unknown>[];
+  watermark: string | null;
+  latestTimestamp: string | null;
+  bufferState: 'disabled' | 'ready' | 'unavailable';
+}
+
+export interface HotBufferStatus {
+  enabled: boolean;
+  state: 'disabled' | 'ready' | 'unavailable';
+  datasets: number;
+  healthy: boolean;
+}
+
+interface BufferEvent {
+  timestampMs: number;
+  row: Record<string, unknown>;
+}
+
+interface DatasetBuffer {
+  events: BufferEvent[];
+  watermarkMs: number;
+  latestTimestampMs: number | null;
+}
+
+function toTimestampMs(value: unknown): number | null {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value.getTime();
+  }
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+  return null;
+}
+
+function insertSorted(events: BufferEvent[], entry: BufferEvent): void {
+  if (events.length === 0 || events[events.length - 1]!.timestampMs <= entry.timestampMs) {
+    events.push(entry);
+    return;
+  }
+  let low = 0;
+  let high = events.length - 1;
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    if (events[mid]!.timestampMs <= entry.timestampMs) {
+      low = mid + 1;
+    } else {
+      high = mid - 1;
+    }
+  }
+  events.splice(low, 0, entry);
+}
+
+export class HotBufferStore {
+  private readonly buffers = new Map<string, DatasetBuffer>();
+  private totalRows = 0;
+
+  constructor(private readonly config: StreamingHotBufferConfig) {}
+
+  ingest(datasetSlug: string, row: Record<string, unknown>, timestampMs: number): void {
+    if (!this.config.enabled) {
+      return;
+    }
+    const buffer = this.ensureBuffer(datasetSlug);
+    if (timestampMs <= buffer.watermarkMs) {
+      return;
+    }
+    insertSorted(buffer.events, { timestampMs, row });
+    this.totalRows += 1;
+    if (!buffer.latestTimestampMs || timestampMs > buffer.latestTimestampMs) {
+      buffer.latestTimestampMs = timestampMs;
+    }
+    this.pruneDataset(datasetSlug, buffer);
+    this.enforceGlobalLimit();
+  }
+
+  setWatermark(datasetSlug: string, watermarkMs: number): void {
+    const buffer = this.ensureBuffer(datasetSlug);
+    buffer.watermarkMs = Math.max(0, watermarkMs);
+    this.pruneDataset(datasetSlug, buffer);
+  }
+
+  query(datasetSlug: string, options: HotBufferQueryOptions): {
+    rows: Record<string, unknown>[];
+    watermarkMs: number | null;
+    latestTimestampMs: number | null;
+  } {
+    const buffer = this.buffers.get(datasetSlug);
+    if (!buffer || buffer.events.length === 0) {
+      return {
+        rows: [],
+        watermarkMs: null,
+        latestTimestampMs: null
+      };
+    }
+
+    const startBoundary = Math.max(
+      options.rangeStart.getTime(),
+      buffer.watermarkMs
+    );
+    const endBoundary = options.rangeEnd.getTime();
+    const rows: Record<string, unknown>[] = [];
+
+    for (const event of buffer.events) {
+      if (event.timestampMs <= startBoundary) {
+        continue;
+      }
+      if (event.timestampMs > endBoundary) {
+        break;
+      }
+      rows.push(event.row);
+      if (options.limit && rows.length >= options.limit) {
+        break;
+      }
+    }
+
+    return {
+      rows,
+      watermarkMs: buffer.watermarkMs > 0 ? buffer.watermarkMs : null,
+      latestTimestampMs: buffer.latestTimestampMs
+    };
+  }
+
+  datasetCount(): number {
+    return this.buffers.size;
+  }
+
+  clear(): void {
+    this.buffers.clear();
+    this.totalRows = 0;
+  }
+
+  private ensureBuffer(datasetSlug: string): DatasetBuffer {
+    let buffer = this.buffers.get(datasetSlug);
+    if (!buffer) {
+      buffer = {
+        events: [],
+        watermarkMs: 0,
+        latestTimestampMs: null
+      } satisfies DatasetBuffer;
+      this.buffers.set(datasetSlug, buffer);
+    }
+    return buffer;
+  }
+
+  private pruneDataset(datasetSlug: string, buffer: DatasetBuffer): void {
+    const retentionCutoff = Date.now() - this.config.retentionSeconds * 1000;
+    let removed = 0;
+    while (buffer.events.length > 0) {
+      const head = buffer.events[0]!;
+      if (head.timestampMs <= buffer.watermarkMs || head.timestampMs < retentionCutoff) {
+        buffer.events.shift();
+        removed += 1;
+        continue;
+      }
+      break;
+    }
+    if (removed > 0) {
+      this.totalRows = Math.max(0, this.totalRows - removed);
+    }
+    while (buffer.events.length > this.config.maxRowsPerDataset) {
+      buffer.events.shift();
+      this.totalRows = Math.max(0, this.totalRows - 1);
+    }
+    buffer.latestTimestampMs = buffer.events.length > 0
+      ? buffer.events[buffer.events.length - 1]!.timestampMs
+      : null;
+  }
+
+  private enforceGlobalLimit(): void {
+    const maxTotal = this.config.maxTotalRows;
+    if (!maxTotal || maxTotal <= 0) {
+      return;
+    }
+    while (this.totalRows > maxTotal) {
+      const oldestEntry = this.findOldestDatasetEntry();
+      if (!oldestEntry) {
+        break;
+      }
+      const buffer = this.buffers.get(oldestEntry.dataset);
+      if (!buffer || buffer.events.length === 0) {
+        break;
+      }
+      buffer.events.shift();
+      this.totalRows = Math.max(0, this.totalRows - 1);
+      buffer.latestTimestampMs = buffer.events.length > 0
+        ? buffer.events[buffer.events.length - 1]!.timestampMs
+        : null;
+    }
+  }
+
+  private findOldestDatasetEntry(): { dataset: string; timestampMs: number } | null {
+    let result: { dataset: string; timestampMs: number } | null = null;
+    this.buffers.forEach((buffer, dataset) => {
+      if (buffer.events.length === 0) {
+        return;
+      }
+      const candidate = buffer.events[0]!;
+      if (!result || candidate.timestampMs < (result?.timestampMs ?? Number.POSITIVE_INFINITY)) {
+        result = { dataset, timestampMs: candidate.timestampMs };
+      }
+    });
+    return result;
+  }
+}
+
+class StreamingHotBufferManager {
+  private readonly store: HotBufferStore;
+  private readonly kafka: Kafka;
+  private readonly consumers: Consumer[] = [];
+  private watermarkTimer: NodeJS.Timeout | null = null;
+  private healthy = true;
+  private started = false;
+
+  constructor(
+    private readonly config: StreamingHotBufferConfig,
+    private readonly batchers: StreamingBatcherConfig[],
+    private readonly brokerUrl: string,
+    private readonly logger: FastifyBaseLogger
+  ) {
+    this.store = new HotBufferStore(config);
+    this.kafka = new Kafka({
+      clientId: 'timestore-hot-buffer',
+      brokers: [brokerUrl],
+      logLevel: logLevel.ERROR
+    });
+  }
+
+  getStore(): HotBufferStore {
+    return this.store;
+  }
+
+  async start(): Promise<void> {
+    if (this.started) {
+      return;
+    }
+    this.started = true;
+
+    await this.refreshWatermarks();
+
+    for (const batcher of this.batchers) {
+      try {
+        const consumer = this.kafka.consumer({ groupId: `timestore-hot-buffer-${batcher.id}` });
+        await consumer.connect();
+        await consumer.subscribe({ topic: batcher.topic, fromBeginning: batcher.startFromEarliest });
+        const datasetSlug = batcher.datasetSlug;
+        const timeField = batcher.timeField;
+        consumer
+          .run({
+            eachMessage: async ({ message }) => {
+              if (!message.value) {
+                return;
+              }
+              try {
+                const payload = JSON.parse(message.value.toString('utf8'));
+                if (!payload || typeof payload !== 'object') {
+                  return;
+                }
+                const timestamp = toTimestampMs((payload as Record<string, unknown>)[timeField]);
+                if (!timestamp) {
+                  this.logger.debug({ datasetSlug }, 'hot buffer skipped event with invalid timestamp');
+                  return;
+                }
+                this.store.ingest(datasetSlug, payload as Record<string, unknown>, timestamp);
+              } catch (error) {
+                this.logger.warn({ err: error, datasetSlug }, 'hot buffer failed to process streaming event');
+              }
+            }
+          })
+          .catch((error) => {
+            this.healthy = false;
+            this.logger.error({ err: error, datasetSlug }, 'hot buffer consumer terminated unexpectedly');
+          });
+        this.consumers.push(consumer);
+      } catch (error) {
+        this.healthy = false;
+        this.logger.error({ err: error, connectorId: batcher.id }, 'failed to start hot buffer consumer');
+      }
+    }
+
+    const refreshInterval = Math.max(this.config.refreshWatermarkMs, 1_000);
+    this.watermarkTimer = setInterval(() => {
+      void this.refreshWatermarks().catch((error) => {
+        this.healthy = false;
+        this.logger.error({ err: error }, 'hot buffer failed to refresh watermarks');
+      });
+    }, refreshInterval);
+    if (typeof this.watermarkTimer.unref === 'function') {
+      this.watermarkTimer.unref();
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (!this.started) {
+      return;
+    }
+    this.started = false;
+    if (this.watermarkTimer) {
+      clearInterval(this.watermarkTimer);
+      this.watermarkTimer = null;
+    }
+    const shutdowns = this.consumers.map((consumer) => consumer.stop().then(() => consumer.disconnect()).catch(() => undefined));
+    this.consumers.length = 0;
+    await Promise.allSettled(shutdowns);
+    this.store.clear();
+  }
+
+  query(datasetSlug: string, options: HotBufferQueryOptions): HotBufferQueryResult {
+    if (!this.config.enabled) {
+      return {
+        rows: [],
+        watermark: null,
+        latestTimestamp: null,
+        bufferState: 'disabled'
+      };
+    }
+
+    if (!this.healthy) {
+      return {
+        rows: [],
+        watermark: null,
+        latestTimestamp: null,
+        bufferState: 'unavailable'
+      };
+    }
+
+    const { rows, watermarkMs, latestTimestampMs } = this.store.query(datasetSlug, options);
+    return {
+      rows,
+      watermark: watermarkMs ? new Date(watermarkMs).toISOString() : null,
+      latestTimestamp: latestTimestampMs ? new Date(latestTimestampMs).toISOString() : null,
+      bufferState: 'ready'
+    } satisfies HotBufferQueryResult;
+  }
+
+  status(): HotBufferStatus {
+    if (!this.config.enabled) {
+      return {
+        enabled: false,
+        state: 'disabled',
+        datasets: 0,
+        healthy: true
+      } satisfies HotBufferStatus;
+    }
+    return {
+      enabled: true,
+      state: this.healthy ? 'ready' : 'unavailable',
+      datasets: this.store.datasetCount(),
+      healthy: this.healthy
+    } satisfies HotBufferStatus;
+  }
+
+  private async refreshWatermarks(): Promise<void> {
+    if (!this.config.enabled) {
+      return;
+    }
+    const records = await listStreamingWatermarks();
+    for (const record of records) {
+      const parsed = Date.parse(record.sealedThrough);
+      if (Number.isNaN(parsed)) {
+        continue;
+      }
+      this.store.setWatermark(record.datasetSlug, parsed);
+    }
+  }
+}
+
+let manager: StreamingHotBufferManager | null = null;
+let testHarness:
+  | {
+      store: HotBufferStore;
+      state: 'ready' | 'unavailable';
+      enabled: boolean;
+    }
+  | null = null;
+
+export function setHotBufferTestHarness(harness: {
+  store: HotBufferStore;
+  state?: 'ready' | 'unavailable';
+  enabled?: boolean;
+} | null): void {
+  testHarness = harness
+    ? {
+        store: harness.store,
+        state: harness.state ?? 'ready',
+        enabled: harness.enabled ?? true
+      }
+    : null;
+}
+
+export function getHotBufferTestStore(): HotBufferStore | null {
+  return testHarness?.store ?? null;
+}
+
+export async function initializeStreamingHotBuffer(
+  params: { config: ServiceConfig; logger: FastifyBaseLogger }
+): Promise<void> {
+  if (testHarness) {
+    return;
+  }
+  const runtime = params.config.streaming;
+  if (!runtime.hotBuffer.enabled || !runtime.brokerUrl || runtime.batchers.length === 0) {
+    manager = null;
+    return;
+  }
+  manager = new StreamingHotBufferManager(runtime.hotBuffer, runtime.batchers, runtime.brokerUrl, params.logger);
+  await manager.start();
+}
+
+export async function shutdownStreamingHotBuffer(): Promise<void> {
+  if (manager) {
+    await manager.stop().catch(() => undefined);
+    manager = null;
+  }
+  testHarness = null;
+}
+
+function resolveResultState(): 'disabled' | 'ready' | 'unavailable' {
+  if (testHarness) {
+    if (!testHarness.enabled) {
+      return 'disabled';
+    }
+    return testHarness.state;
+  }
+  if (!manager) {
+    return 'disabled';
+  }
+  return manager.status().state;
+}
+
+export function queryStreamingHotBuffer(
+  datasetSlug: string,
+  options: HotBufferQueryOptions
+): HotBufferQueryResult {
+  if (testHarness) {
+    if (!testHarness.enabled) {
+      return {
+        rows: [],
+        watermark: null,
+        latestTimestamp: null,
+        bufferState: 'disabled'
+      };
+    }
+    const { rows, watermarkMs, latestTimestampMs } = testHarness.store.query(datasetSlug, options);
+    return {
+      rows,
+      watermark: watermarkMs ? new Date(watermarkMs).toISOString() : null,
+      latestTimestamp: latestTimestampMs ? new Date(latestTimestampMs).toISOString() : null,
+      bufferState: testHarness.state
+    } satisfies HotBufferQueryResult;
+  }
+  if (!manager) {
+    return {
+      rows: [],
+      watermark: null,
+      latestTimestamp: null,
+      bufferState: 'disabled'
+    } satisfies HotBufferQueryResult;
+  }
+  return manager.query(datasetSlug, options);
+}
+
+export function getStreamingHotBufferStatus(): HotBufferStatus {
+  if (testHarness) {
+    return {
+      enabled: testHarness.enabled,
+      state: testHarness.enabled ? testHarness.state : 'disabled',
+      datasets: testHarness.store.datasetCount(),
+      healthy: testHarness.enabled ? testHarness.state === 'ready' : true
+    } satisfies HotBufferStatus;
+  }
+  if (!manager) {
+    return {
+      enabled: false,
+      state: 'disabled',
+      datasets: 0,
+      healthy: true
+    } satisfies HotBufferStatus;
+  }
+  return manager.status();
+}

--- a/services/timestore/tests/ingestionConnectors.test.ts
+++ b/services/timestore/tests/ingestionConnectors.test.ts
@@ -72,6 +72,7 @@ before(async () => {
   process.env.TIMESTORE_PARTITION_HISTOGRAM_COLUMNS = '';
   process.env.TIMESTORE_PARTITION_BLOOM_COLUMNS = '';
   process.env.TIMESTORE_PARTITION_INDEX_CONFIG = '';
+  process.env.APPHUB_STREAMING_ENABLED = 'true';
   process.env.TIMESTORE_CONNECTORS_ENABLED = 'false';
   process.env.TIMESTORE_STREAMING_CONNECTORS = '[]';
   process.env.TIMESTORE_BULK_CONNECTORS = '[]';
@@ -107,6 +108,7 @@ after(async () => {
   if (bulkDir) {
     await rm(bulkDir, { recursive: true, force: true });
   }
+  process.env.APPHUB_STREAMING_ENABLED = 'false';
 });
 
 function buildStreamingEvent(options: {

--- a/services/timestore/tests/streamingHotBufferStore.test.ts
+++ b/services/timestore/tests/streamingHotBufferStore.test.ts
@@ -1,0 +1,78 @@
+import './testEnv';
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { HotBufferStore } from '../src/streaming/hotBuffer';
+
+const baseConfig = {
+  enabled: true,
+  retentionSeconds: 365 * 24 * 3600,
+  maxRowsPerDataset: 10,
+  maxTotalRows: undefined as number | undefined,
+  refreshWatermarkMs: 5_000,
+  fallbackMode: 'parquet_only' as const
+};
+
+test('HotBufferStore prunes rows that fall behind the watermark', () => {
+  const store = new HotBufferStore(baseConfig);
+  const datasetSlug = 'hybrid-test';
+  const base = Date.now();
+
+  store.ingest(datasetSlug, { timestamp: new Date(base).toISOString(), value: 1 }, base);
+  store.ingest(datasetSlug, { timestamp: new Date(base + 15_000).toISOString(), value: 2 }, base + 15_000);
+
+  let query = store.query(datasetSlug, {
+    rangeStart: new Date(base - 5_000),
+    rangeEnd: new Date(base + 30_000),
+    timestampColumn: 'timestamp'
+  });
+  assert.equal(query.rows.length, 2);
+
+  store.setWatermark(datasetSlug, base + 10_000);
+
+  query = store.query(datasetSlug, {
+    rangeStart: new Date(base - 5_000),
+    rangeEnd: new Date(base + 30_000),
+    timestampColumn: 'timestamp'
+  });
+  assert.equal(query.rows.length, 1);
+  assert.equal(query.rows[0]?.value, 2);
+  assert.equal(query.watermarkMs, base + 10_000);
+});
+
+test('HotBufferStore enforces global max rows across datasets', () => {
+  const store = new HotBufferStore({
+    ...baseConfig,
+    maxRowsPerDataset: 10,
+    maxTotalRows: 3
+  });
+
+  const base = Date.now();
+
+  store.ingest('ds-a', { timestamp: new Date(base).toISOString(), v: 1 }, base);
+  store.ingest('ds-b', { timestamp: new Date(base + 5_000).toISOString(), v: 2 }, base + 5_000);
+  store.ingest('ds-a', { timestamp: new Date(base + 10_000).toISOString(), v: 3 }, base + 10_000);
+  store.ingest('ds-c', { timestamp: new Date(base + 15_000).toISOString(), v: 4 }, base + 15_000);
+
+  const queryA = store.query('ds-a', {
+    rangeStart: new Date(base - 1_000),
+    rangeEnd: new Date(base + 60_000),
+    timestampColumn: 'timestamp'
+  });
+  const queryB = store.query('ds-b', {
+    rangeStart: new Date(base - 1_000),
+    rangeEnd: new Date(base + 60_000),
+    timestampColumn: 'timestamp'
+  });
+  const queryC = store.query('ds-c', {
+    rangeStart: new Date(base - 1_000),
+    rangeEnd: new Date(base + 60_000),
+    timestampColumn: 'timestamp'
+  });
+
+  const totalRows = queryA.rows.length + queryB.rows.length + queryC.rows.length;
+  assert.equal(totalRows, 3);
+  assert.equal(store.datasetCount(), 3);
+  // Oldest row from ds-a should have been pruned to respect the global max.
+  assert.deepEqual(queryA.rows.map((row) => row.v), [3]);
+});

--- a/services/timestore/tests/streamingHybridQuery.test.ts
+++ b/services/timestore/tests/streamingHybridQuery.test.ts
@@ -1,0 +1,242 @@
+/// <reference path="../src/types/embeddedPostgres.d.ts" />
+
+import './testEnv';
+
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import { mkdtemp, rm } from 'node:fs/promises';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import EmbeddedPostgres from 'embedded-postgres';
+import { loadServiceConfig, resetCachedServiceConfig } from '../src/config/serviceConfig';
+import { ensureSchemaExists } from '../src/db/schema';
+import { POSTGRES_SCHEMA, closePool, resetPool } from '../src/db/client';
+import { runMigrations } from '../src/db/migrations';
+import { ensureDefaultStorageTarget } from '../src/service/bootstrap';
+import { processIngestionJob } from '../src/ingestion/processor';
+import { buildQueryPlan } from '../src/query/planner';
+import { executeQueryPlan } from '../src/query/executor';
+import { HotBufferStore, setHotBufferTestHarness } from '../src/streaming/hotBuffer';
+
+let postgres: EmbeddedPostgres | null = null;
+let dataDirectory: string | null = null;
+let storageRoot: string | null = null;
+
+before(async () => {
+  const dataRoot = await mkdtemp(path.join(tmpdir(), 'timestore-hybrid-pg-'));
+  dataDirectory = dataRoot;
+  const port = 58000 + Math.floor(Math.random() * 1000);
+  const embedded = new EmbeddedPostgres({
+    databaseDir: dataRoot,
+    port,
+    user: 'postgres',
+    password: 'postgres',
+    persistent: false,
+    postgresFlags: ['-c', 'dynamic_shared_memory_type=posix'],
+    onError(message) {
+      console.error('[embedded-postgres:hybrid]', message);
+    }
+  });
+
+  await embedded.initialise();
+  await embedded.start();
+  await embedded.createDatabase('apphub');
+  postgres = embedded;
+
+  storageRoot = await mkdtemp(path.join(tmpdir(), 'timestore-hybrid-storage-'));
+
+  process.env.TIMESTORE_DATABASE_URL = `postgres://postgres:postgres@127.0.0.1:${port}/apphub`;
+  process.env.TIMESTORE_PG_SCHEMA = `timestore_hybrid_${randomUUID().slice(0, 8)}`;
+  process.env.TIMESTORE_PGPOOL_MAX = '4';
+  process.env.TIMESTORE_STORAGE_ROOT = storageRoot;
+  process.env.REDIS_URL = 'inline';
+  process.env.APPHUB_ALLOW_INLINE_MODE = 'true';
+  process.env.APPHUB_STREAMING_ENABLED = 'true';
+  process.env.TIMESTORE_STREAMING_BUFFER_ENABLED = 'true';
+  process.env.TIMESTORE_STREAMING_CONNECTORS = '[]';
+  process.env.TIMESTORE_STREAMING_BATCHERS = '[]';
+  process.env.TIMESTORE_BULK_CONNECTORS = '[]';
+
+  resetCachedServiceConfig();
+  await resetPool();
+  await ensureSchemaExists(POSTGRES_SCHEMA);
+  await runMigrations();
+  await ensureDefaultStorageTarget();
+});
+
+after(async () => {
+  setHotBufferTestHarness(null);
+  await closePool();
+  if (postgres) {
+    await postgres.stop();
+  }
+  if (dataDirectory) {
+    await rm(dataDirectory, { recursive: true, force: true });
+  }
+  if (storageRoot) {
+    await rm(storageRoot, { recursive: true, force: true });
+  }
+});
+
+test('hybrid queries merge parquet partitions with streaming buffer rows', async () => {
+  const datasetSlug = `hybrid-${randomUUID().slice(0, 8)}`;
+  const partitionStart = Date.now();
+  const partitionEnd = partitionStart + 60_000;
+
+  await processIngestionJob({
+    datasetSlug,
+    datasetName: 'Hybrid Dataset',
+    tableName: 'observations',
+    schema: {
+      fields: [
+        { name: 'timestamp', type: 'timestamp' },
+        { name: 'reading', type: 'double' }
+      ]
+    },
+    partition: {
+      key: { window: '2024-01-01T00:00:00Z' },
+      attributes: { source: 'hybrid-test' },
+      timeRange: {
+        start: new Date(partitionStart).toISOString(),
+        end: new Date(partitionEnd).toISOString()
+      }
+    },
+    rows: [
+      {
+        timestamp: new Date(partitionStart + 5_000).toISOString(),
+        reading: 10.5
+      },
+      {
+        timestamp: new Date(partitionStart + 20_000).toISOString(),
+        reading: 11.1
+      }
+    ],
+    receivedAt: new Date().toISOString()
+  });
+
+  const store = new HotBufferStore({
+    enabled: true,
+    retentionSeconds: 3600,
+    maxRowsPerDataset: 100,
+    maxTotalRows: undefined,
+    refreshWatermarkMs: 5_000,
+    fallbackMode: 'parquet_only'
+  });
+
+  setHotBufferTestHarness({ store, state: 'ready', enabled: true });
+  store.setWatermark(datasetSlug, partitionEnd);
+  store.ingest(
+    datasetSlug,
+    {
+      timestamp: new Date(partitionEnd + 10_000).toISOString(),
+      reading: 12.2
+    },
+    partitionEnd + 10_000
+  );
+  store.ingest(
+    datasetSlug,
+    {
+      timestamp: new Date(partitionEnd + 30_000).toISOString(),
+      reading: 12.6
+    },
+    partitionEnd + 30_000
+  );
+
+  const preview = store.query(datasetSlug, {
+    rangeStart: new Date(partitionStart - 5_000),
+    rangeEnd: new Date(partitionEnd + 30_000),
+    timestampColumn: 'timestamp'
+  });
+  assert.equal(preview.rows.length, 2);
+
+  const config = loadServiceConfig();
+  assert.ok(config.streaming.hotBuffer.enabled, 'hot buffer must be enabled for hybrid queries');
+
+  const plan = await buildQueryPlan(datasetSlug, {
+    timeRange: {
+      start: new Date(partitionStart - 5_000).toISOString(),
+      end: new Date(partitionEnd + 30_000).toISOString()
+    },
+    timestampColumn: 'timestamp'
+  });
+
+  const result = await executeQueryPlan(plan);
+
+  assert.ok(result.streaming, 'streaming metadata should be present');
+  assert.equal(result.streaming?.bufferState, 'ready');
+  assert.equal(result.streaming?.rows, 2);
+  assert.equal(result.streaming?.fresh, true);
+  assert.ok(result.rows.length >= 4);
+
+  const timestamps = result.rows.map((row) => new Date(String(row.timestamp)).getTime());
+  const sorted = [...timestamps].sort((a, b) => a - b);
+  assert.deepEqual(timestamps, sorted, 'rows should be sorted by timestamp');
+
+  const streamingValues = result.rows.slice(-2).map((row) => row.reading);
+  assert.deepEqual(streamingValues, [12.2, 12.6]);
+
+  setHotBufferTestHarness(null);
+});
+
+test('hybrid query errors when buffer unavailable and fallback=error', async () => {
+  const datasetSlug = `hybrid-error-${randomUUID().slice(0, 8)}`;
+  const partitionStart = Date.now();
+  const partitionEnd = partitionStart + 60_000;
+
+  process.env.TIMESTORE_STREAMING_BUFFER_FALLBACK = 'error';
+  resetCachedServiceConfig();
+
+  await processIngestionJob({
+    datasetSlug,
+    datasetName: 'Hybrid Dataset Error Path',
+    tableName: 'observations',
+    schema: {
+      fields: [
+        { name: 'timestamp', type: 'timestamp' },
+        { name: 'reading', type: 'double' }
+      ]
+    },
+    partition: {
+      key: { window: '2024-01-02T00:00:00Z' },
+      attributes: { source: 'hybrid-test-error' },
+      timeRange: {
+        start: new Date(partitionStart).toISOString(),
+        end: new Date(partitionEnd).toISOString()
+      }
+    },
+    rows: [
+      {
+        timestamp: new Date(partitionStart + 5_000).toISOString(),
+        reading: 21.5
+      }
+    ],
+    receivedAt: new Date().toISOString()
+  });
+
+  const store = new HotBufferStore({
+    enabled: true,
+    retentionSeconds: 3600,
+    maxRowsPerDataset: 100,
+    maxTotalRows: undefined,
+    refreshWatermarkMs: 5_000,
+    fallbackMode: 'error'
+  });
+
+  setHotBufferTestHarness({ store, state: 'unavailable', enabled: true });
+  store.setWatermark(datasetSlug, partitionEnd);
+
+  const plan = await buildQueryPlan(datasetSlug, {
+    timeRange: {
+      start: new Date(partitionStart - 5_000).toISOString(),
+      end: new Date(partitionEnd + 30_000).toISOString()
+    },
+    timestampColumn: 'timestamp'
+  });
+
+  await assert.rejects(async () => executeQueryPlan(plan), /Streaming hot buffer is unavailable/);
+
+  setHotBufferTestHarness(null);
+  delete process.env.TIMESTORE_STREAMING_BUFFER_FALLBACK;
+  resetCachedServiceConfig();
+});

--- a/services/timestore/tests/streamingMicroBatcher.test.ts
+++ b/services/timestore/tests/streamingMicroBatcher.test.ts
@@ -1,0 +1,164 @@
+/// <reference path="../src/types/embeddedPostgres.d.ts" />
+
+import './testEnv';
+
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import { mkdtemp, rm } from 'node:fs/promises';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import { after, before, test } from 'node:test';
+import EmbeddedPostgres from 'embedded-postgres';
+import { loadServiceConfig, resetCachedServiceConfig } from '../src/config/serviceConfig';
+import { ensureSchemaExists } from '../src/db/schema';
+import { POSTGRES_SCHEMA, closePool, resetPool } from '../src/db/client';
+import { runMigrations } from '../src/db/migrations';
+import { ensureDefaultStorageTarget } from '../src/service/bootstrap';
+import { StreamingBatchProcessor } from '../src/streaming/batchers';
+import { getDatasetBySlug, getLatestPublishedManifest, getStreamingWatermark } from '../src/db/metadata';
+import type { FastifyBaseLogger } from 'fastify';
+
+let postgres: EmbeddedPostgres | null = null;
+let dataDirectory: string | null = null;
+let storageRoot: string | null = null;
+
+const logger: FastifyBaseLogger = {
+  level: 'info',
+  silent: false,
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+  debug: () => undefined,
+  trace: () => undefined,
+  fatal: () => undefined,
+  child: () => logger
+} as unknown as FastifyBaseLogger;
+
+before(async () => {
+  const dataRoot = await mkdtemp(path.join(tmpdir(), 'timestore-stream-batcher-pg-'));
+  dataDirectory = dataRoot;
+  const port = 57000 + Math.floor(Math.random() * 1000);
+  const embedded = new EmbeddedPostgres({
+    databaseDir: dataRoot,
+    port,
+    user: 'postgres',
+    password: 'postgres',
+    persistent: false,
+    postgresFlags: ['-c', 'dynamic_shared_memory_type=posix'],
+    onError(message) {
+      console.error('[embedded-postgres:streaming-batcher]', message);
+    }
+  });
+
+  await embedded.initialise();
+  await embedded.start();
+  await embedded.createDatabase('apphub');
+  postgres = embedded;
+
+  storageRoot = await mkdtemp(path.join(tmpdir(), 'timestore-stream-batcher-storage-'));
+
+  process.env.TIMESTORE_DATABASE_URL = `postgres://postgres:postgres@127.0.0.1:${port}/apphub`;
+  process.env.TIMESTORE_PG_SCHEMA = `timestore_stream_${randomUUID().slice(0, 8)}`;
+  process.env.TIMESTORE_PGPOOL_MAX = '4';
+  process.env.TIMESTORE_STORAGE_ROOT = storageRoot;
+  process.env.REDIS_URL = 'inline';
+  process.env.APPHUB_ALLOW_INLINE_MODE = 'true';
+  process.env.TIMESTORE_STREAMING_CONNECTORS = '[]';
+  process.env.TIMESTORE_BULK_CONNECTORS = '[]';
+  process.env.TIMESTORE_STREAMING_BATCHERS = '[]';
+  process.env.APPHUB_STREAMING_ENABLED = 'true';
+
+  resetCachedServiceConfig();
+  await resetPool();
+  await ensureSchemaExists(POSTGRES_SCHEMA);
+  await runMigrations();
+  await ensureDefaultStorageTarget();
+});
+
+after(async () => {
+  await closePool();
+  if (postgres) {
+    await postgres.stop();
+  }
+  if (dataDirectory) {
+    await rm(dataDirectory, { recursive: true, force: true });
+  }
+  if (storageRoot) {
+    await rm(storageRoot, { recursive: true, force: true });
+  }
+});
+
+test('streaming batch processor aggregates windows and records watermarks', async () => {
+  const datasetSlug = `stream-${randomUUID().slice(0, 8)}`;
+  const config = loadServiceConfig();
+  assert.ok(config.streaming.batchers.length === 0);
+
+  const processor = new StreamingBatchProcessor(
+    {
+      id: 'test-batcher',
+      topic: 'apphub.streaming.aggregates',
+      groupId: 'test-batcher-group',
+      datasetSlug,
+      datasetName: 'Streaming Observations',
+      tableName: 'streaming_observations',
+      schema: {
+        fields: [
+          { name: 'timestamp', type: 'timestamp' },
+          { name: 'user_id', type: 'string' },
+          { name: 'total_amount', type: 'double' }
+        ]
+      },
+      timeField: 'timestamp',
+      windowSeconds: 60,
+      maxRowsPerPartition: 5,
+      maxBatchLatencyMs: 250,
+      partitionKey: { dataset: datasetSlug },
+      partitionAttributes: { source: 'unit_test' },
+      startFromEarliest: true
+    },
+    logger
+  );
+
+  const baseTime = new Date('2024-01-01T00:00:00.000Z');
+  const events = Array.from({ length: 5 }, (_, index) => ({
+    timestamp: new Date(baseTime.getTime() + index * 10_000).toISOString(),
+    user_id: `user-${index % 2}`,
+    total_amount: 40 + index
+  }));
+
+  for (const event of events) {
+    await processor.processRecord(event);
+  }
+
+  await processor.flushAll('manual');
+
+  const dataset = await getDatasetBySlug(datasetSlug);
+  assert.ok(dataset, 'dataset created');
+
+  const manifest = await getLatestPublishedManifest(dataset.id);
+  assert.ok(manifest, 'manifest published');
+  assert.equal(manifest.partitionCount, 1);
+  assert.equal(manifest.totalRows, 5);
+
+  const watermark = await getStreamingWatermark(dataset.id, 'test-batcher');
+  assert.ok(watermark, 'watermark persisted');
+  assert.equal(watermark.datasetSlug, datasetSlug);
+  assert.equal(new Date(watermark.sealedThrough).toISOString(), new Date(baseTime.getTime() + 60_000).toISOString());
+  assert.ok(Number(watermark.recordsProcessed) >= 5);
+
+  // Replaying the same events should not create additional partitions.
+  for (const event of events) {
+    await processor.processRecord(event);
+  }
+  await processor.flushAll('manual');
+
+  const manifestAfterReplay = await getLatestPublishedManifest(dataset.id);
+  assert.ok(manifestAfterReplay);
+  assert.equal(manifestAfterReplay.partitionCount, 1);
+  assert.equal(manifestAfterReplay.totalRows, 5);
+
+  const watermarkAfterReplay = await getStreamingWatermark(dataset.id, 'test-batcher');
+  assert.ok(watermarkAfterReplay);
+  assert.equal(new Date(watermarkAfterReplay.sealedThrough).toISOString(), new Date(baseTime.getTime() + 60_000).toISOString());
+  assert.ok(Number(watermarkAfterReplay.recordsProcessed) >= 5);
+});


### PR DESCRIPTION
## Summary
- add streaming hot buffer manager that tracks watermarks, retains recent rows, and feeds hybrid queries
- merge buffered streaming rows into query results with freshness metadata and optional fallback handling
- document new streaming configuration and observability metrics alongside targeted tests

Refs #132

## Testing
- npm run lint --workspace @apphub/timestore
- npm run build --workspace @apphub/timestore
- npm run test
