### PR TITLE
feat: streaming observability readiness

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "build": "tsc -b",
     "dev": "tsx watch src/index.ts",
+    "lint": "tsc --project tsconfig.json --noEmit",
     "test": "tsx --test tests/**/*.test.ts"
   },
   "dependencies": {

--- a/docs/flink.md
+++ b/docs/flink.md
@@ -89,7 +89,7 @@ curl -X POST "$APPHUB_FLINK_REST_URL/jobs/<jobId>/savepoints" \
 
 - **Scaling** – Increase `apphub-flink-taskmanager` replicas (or adjust task slots) to add compute capacity. For compose, start additional TaskManagers (`docker compose up -d flink-taskmanager`).
 - **Upgrades** – Rolling updates: drain TaskManagers first (`kubectl rollout restart deployment/apphub-flink-taskmanager`), then restart the JobManager. Validate checkpoint restore before promoting changes.
-- **Monitoring** – Scrape the JobManager Prometheus endpoint (`/metrics` on port 8081). Key metrics: `numRegisteredTaskManagers`, `checkpointing_duration`, `numRestarts`, and the Prometheus reporter configured in `flink-conf.yaml`.
+- **Monitoring** – Scrape the JobManager Prometheus endpoint (`/metrics` on port 8081). Kubernetes services expose `prometheus.io/scrape` annotations so the platform scraper discovers them automatically. Track `numRegisteredTaskManagers`, `flink_jobmanager_job_last_checkpoint_duration`, `flink_jobmanager_checkpoint_failed_total`, and the bundled reporter counters.
 - **Failure recovery** – If the JobManager restarts, the cluster automatically restores from the latest completed checkpoint. For catastrophic failures, restore a savepoint by passing `--fromSavepoint <path>` when submitting the job.
 - **Topic hygiene** – Redpanda bootstrap scripts create the input/output topics automatically; adjust the retention window via `rpk topic alter-config apphub.streaming.aggregates --set retention.ms=...` if downstream consumers need longer history.
 

--- a/docs/redpanda.md
+++ b/docs/redpanda.md
@@ -58,6 +58,12 @@ The `infra/minikube` overlay now includes a three-node `StatefulSet`:
 4. **Disaster recovery** – configure periodic snapshots (e.g., S3) of `/var/lib/redpanda/data`. The runbook recommends hourly incremental backups and demonstrates partition reassignment with `rpk cluster move-partitions`.
 5. **Upgrades** – roll nodes sequentially. Drain each pod (`kubectl exec ... -- rpk cluster maintenance enable`) before restart to avoid controller churn.
 
+## Metrics & Alerting
+
+- Kubernetes services ship with `prometheus.io/scrape` annotations targeting port 9644 so the platform Prometheus stack automatically ingests broker metrics.
+- Core streaming alerts rely on `vectorized_kafka_broker_partition_under_replicated`, `vectorized_kafka_recovery_partition_movement_recency`, and `timestore_streaming_backlog_seconds` to detect lag and durability regressions.
+- Local compose environments expose the admin API via `${APPHUB_REDPANDA_ADMIN_PORT:-19644}` for ad-hoc inspection or temporary Prometheus scrapes.
+
 ## Integration Summary
 
 - Core and Timestore read `APPHUB_STREAM_BROKER_URL` when `APPHUB_STREAMING_ENABLED=1`; health endpoints return `503` if the broker is misconfigured.

--- a/docs/runbooks/streaming-operations.md
+++ b/docs/runbooks/streaming-operations.md
@@ -1,0 +1,66 @@
+# Streaming Operations Runbook
+
+This runbook codifies day-two procedures for AppHub's streaming stack (Redpanda, Flink, and the timestore streaming runtime). It captures startup order, recovery flows, and sizing guidance so on-call engineers can restore service quickly.
+
+## Startup Order
+
+1. **Redpanda** – start the broker before any downstream consumers.
+   - Docker Compose: `docker compose -f docker/demo-stack.compose.yml up -d redpanda redpanda-init`
+   - Minikube: `kubectl apply -k infra/minikube && kubectl rollout status statefulset/apphub-redpanda -n apphub-system`
+   - Verify metrics on `http://<broker-host>:9644/metrics` and health via `rpk cluster info`.
+2. **Flink** – launch the JobManager/TaskManagers after Redpanda reports healthy.
+   - Compose: `docker compose ... up -d flink-jobmanager flink-taskmanager`
+   - Minikube: `kubectl rollout status deployment/apphub-flink-jobmanager -n apphub-system`
+   - Confirm `/v1/cluster/health` returns `HEALTHY` and `/metrics` exposes checkpoint gauges.
+3. **Timestore** – boot the API, then enable streaming batchers/hot buffer.
+   - `npm run dev --workspace @apphub/timestore`
+   - Check `/streaming/status` and `/ready` for state `ready`.
+4. **Core** – once the above are green, start `npm run dev --workspace @apphub/core` and validate `/readyz` replies with status `ready`.
+5. **Smoke check** – run `npm run runSmoke --workspace @apphub/tests` or `apps/cli/bin/apphub status` to confirm streaming readiness.
+
+## Failure Recovery
+
+### Broker outage (Redpanda)
+
+1. Alert: `vectorized_cluster_health_status` or `apphub_streaming_backlog_seconds` will fire (`PagerDuty` + `#apphub-ops`).
+2. Inspect broker state: `kubectl logs statefulset/apphub-redpanda -n apphub-system` or `docker logs redpanda`.
+3. If the pod crashed, restart sequentially (`kubectl rollout restart statefulset/apphub-redpanda`). Wait for leadership to stabilise (`rpk cluster info`).
+4. After recovery, ensure `/streaming/status` reports `broker.reachable=true` and backlog gauges fall towards zero.
+5. If data loss suspected, trigger partition reassignment or restore from the latest S3 snapshot (see `docs/redpanda.md#operational-checklist`).
+
+### Micro-batcher failures
+
+1. Alert: `timestore_streaming_flush_duration_seconds` > p95 or connectors stuck (`Streaming micro-batchers degraded`).
+2. Check Timestore logs for connector errors (`npm run dev --workspace @apphub/timestore` logs or `journalctl` in prod).
+3. Flush in-flight windows by restarting the streaming workers (`pkill -f timestore && npm run dev --workspace @apphub/timestore`) or redeploying the pod (`kubectl rollout restart deployment/apphub-timestore -n apphub-system`).
+4. Confirm `apps/cli status` shows `batchers: N/N running` and backlog gauges decay.
+
+### Flink checkpoint restore
+
+1. Alert: `flink_jobmanager_completed_checkpoints_total` stalls or `flink_checkpoint_failed_total` spikes.
+2. Trigger savepoint for inspection (if JobManager reachable):
+   ```bash
+   curl -X POST "$APPHUB_FLINK_REST_URL/jobs/<jobId>/savepoints" \
+     -H 'Content-Type: application/json' \
+     -d '{"target-directory": "s3://apphub-flink-checkpoints/savepoints"}'
+   ```
+3. Restart job from last successful checkpoint or savepoint:
+   ```bash
+   flink run-application \
+     --target kubernetes-application \
+     --fromSavepoint s3://apphub-flink-checkpoints/savepoints/<id> \
+     -Dkubernetes.cluster-id=apphub-flink \
+     gs://apphub-streaming-jobs/tumbling-window.jar
+   ```
+4. After restart, watch `/streaming/status` (`hotBuffer.state`) and `timestore_streaming_backlog_seconds` to ensure backlog clears.
+
+## Capacity Planning
+
+Track these signals to resize streaming components:
+
+- **Topic lag** – `timestore_streaming_backlog_seconds` > 120s (add batchers) or `vectorized_kafka_partition_under_replicated` (scale brokers).
+- **Flush throughput** – `timestore_streaming_flush_duration_seconds` and `timestore_streaming_flush_rows` (increase batch parallelism or window size).
+- **Hot buffer footprint** – `timestore_streaming_hot_buffer_rows` and `timestore_streaming_hot_buffer_staleness_seconds` (tune `maxTotalRows`, `retentionSeconds`).
+- **Flink checkpoints** – `flink_jobmanager_job_last_checkpoint_duration` and `flink_jobmanager_checkpoint_failed_total` (scale TaskManagers or widen checkpoint interval).
+
+Reassess quotas monthly or after onboarding a workload that emits >50k events/minute. Update `TIMESTORE_STREAMING_BATCHERS` window sizes and Redpanda retention accordingly.

--- a/infra/minikube/flink/service.yaml
+++ b/infra/minikube/flink/service.yaml
@@ -6,6 +6,10 @@ metadata:
     app.kubernetes.io/name: flink
     app.kubernetes.io/component: jobmanager
     app.kubernetes.io/part-of: apphub-streaming
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8081"
+    prometheus.io/path: "/metrics"
 spec:
   type: ClusterIP
   selector:

--- a/infra/minikube/redpanda/service.yaml
+++ b/infra/minikube/redpanda/service.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     app.kubernetes.io/name: redpanda
     app.kubernetes.io/part-of: apphub-streaming
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9644"
+    prometheus.io/path: "/metrics"
 spec:
   type: ClusterIP
   selector:

--- a/services/core/openapi.json
+++ b/services/core/openapi.json
@@ -16007,6 +16007,397 @@
           }
         }
       },
+      "StreamingBrokerStatus": {
+        "type": "object",
+        "required": [
+          "configured",
+          "reachable",
+          "lastCheckedAt",
+          "error"
+        ],
+        "properties": {
+          "configured": {
+            "type": "boolean"
+          },
+          "reachable": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "lastCheckedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "error": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "StreamingBatcherConnectorStatus": {
+        "type": "object",
+        "required": [
+          "connectorId",
+          "datasetSlug",
+          "topic",
+          "groupId",
+          "state",
+          "bufferedWindows",
+          "bufferedRows",
+          "openWindows",
+          "lastMessageAt",
+          "lastFlushAt",
+          "lastEventTimestamp",
+          "lastError"
+        ],
+        "properties": {
+          "connectorId": {
+            "type": "string"
+          },
+          "datasetSlug": {
+            "type": "string"
+          },
+          "topic": {
+            "type": "string"
+          },
+          "groupId": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "starting",
+              "running",
+              "stopped",
+              "error"
+            ]
+          },
+          "bufferedWindows": {
+            "type": "integer"
+          },
+          "bufferedRows": {
+            "type": "integer"
+          },
+          "openWindows": {
+            "type": "integer"
+          },
+          "lastMessageAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "lastFlushAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "lastEventTimestamp": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "lastError": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "StreamingBatcherStatus": {
+        "type": "object",
+        "required": [
+          "configured",
+          "running",
+          "failing",
+          "state",
+          "connectors"
+        ],
+        "properties": {
+          "configured": {
+            "type": "integer"
+          },
+          "running": {
+            "type": "integer"
+          },
+          "failing": {
+            "type": "integer"
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "disabled",
+              "ready",
+              "degraded"
+            ]
+          },
+          "connectors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "connectorId",
+                "datasetSlug",
+                "topic",
+                "groupId",
+                "state",
+                "bufferedWindows",
+                "bufferedRows",
+                "openWindows",
+                "lastMessageAt",
+                "lastFlushAt",
+                "lastEventTimestamp",
+                "lastError"
+              ],
+              "properties": {
+                "connectorId": {
+                  "type": "string"
+                },
+                "datasetSlug": {
+                  "type": "string"
+                },
+                "topic": {
+                  "type": "string"
+                },
+                "groupId": {
+                  "type": "string"
+                },
+                "state": {
+                  "type": "string",
+                  "enum": [
+                    "starting",
+                    "running",
+                    "stopped",
+                    "error"
+                  ]
+                },
+                "bufferedWindows": {
+                  "type": "integer"
+                },
+                "bufferedRows": {
+                  "type": "integer"
+                },
+                "openWindows": {
+                  "type": "integer"
+                },
+                "lastMessageAt": {
+                  "type": "string",
+                  "format": "date-time",
+                  "nullable": true
+                },
+                "lastFlushAt": {
+                  "type": "string",
+                  "format": "date-time",
+                  "nullable": true
+                },
+                "lastEventTimestamp": {
+                  "type": "string",
+                  "format": "date-time",
+                  "nullable": true
+                },
+                "lastError": {
+                  "type": "string",
+                  "nullable": true
+                }
+              }
+            }
+          }
+        }
+      },
+      "StreamingStatus": {
+        "type": "object",
+        "required": [
+          "enabled",
+          "state",
+          "reason",
+          "broker",
+          "batchers",
+          "hotBuffer"
+        ],
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "disabled",
+              "ready",
+              "degraded",
+              "unconfigured"
+            ]
+          },
+          "reason": {
+            "type": "string",
+            "nullable": true
+          },
+          "broker": {
+            "type": "object",
+            "required": [
+              "configured",
+              "reachable",
+              "lastCheckedAt",
+              "error"
+            ],
+            "properties": {
+              "configured": {
+                "type": "boolean"
+              },
+              "reachable": {
+                "type": "boolean",
+                "nullable": true
+              },
+              "lastCheckedAt": {
+                "type": "string",
+                "format": "date-time",
+                "nullable": true
+              },
+              "error": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          },
+          "batchers": {
+            "type": "object",
+            "required": [
+              "configured",
+              "running",
+              "failing",
+              "state",
+              "connectors"
+            ],
+            "properties": {
+              "configured": {
+                "type": "integer"
+              },
+              "running": {
+                "type": "integer"
+              },
+              "failing": {
+                "type": "integer"
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "disabled",
+                  "ready",
+                  "degraded"
+                ]
+              },
+              "connectors": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "connectorId",
+                    "datasetSlug",
+                    "topic",
+                    "groupId",
+                    "state",
+                    "bufferedWindows",
+                    "bufferedRows",
+                    "openWindows",
+                    "lastMessageAt",
+                    "lastFlushAt",
+                    "lastEventTimestamp",
+                    "lastError"
+                  ],
+                  "properties": {
+                    "connectorId": {
+                      "type": "string"
+                    },
+                    "datasetSlug": {
+                      "type": "string"
+                    },
+                    "topic": {
+                      "type": "string"
+                    },
+                    "groupId": {
+                      "type": "string"
+                    },
+                    "state": {
+                      "type": "string",
+                      "enum": [
+                        "starting",
+                        "running",
+                        "stopped",
+                        "error"
+                      ]
+                    },
+                    "bufferedWindows": {
+                      "type": "integer"
+                    },
+                    "bufferedRows": {
+                      "type": "integer"
+                    },
+                    "openWindows": {
+                      "type": "integer"
+                    },
+                    "lastMessageAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "lastFlushAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "lastEventTimestamp": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "lastError": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "hotBuffer": {
+            "type": "object",
+            "required": [
+              "enabled",
+              "state",
+              "datasets",
+              "healthy",
+              "lastRefreshAt",
+              "lastIngestAt"
+            ],
+            "properties": {
+              "enabled": {
+                "type": "boolean"
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "disabled",
+                  "ready",
+                  "unavailable"
+                ]
+              },
+              "datasets": {
+                "type": "integer"
+              },
+              "healthy": {
+                "type": "boolean"
+              },
+              "lastRefreshAt": {
+                "type": "string",
+                "format": "date-time",
+                "nullable": true
+              },
+              "lastIngestAt": {
+                "type": "string",
+                "format": "date-time",
+                "nullable": true
+              }
+            }
+          }
+        }
+      },
       "HealthResponse": {
         "type": "object",
         "required": [
@@ -16038,7 +16429,10 @@
                 "required": [
                   "enabled",
                   "state",
-                  "brokerConfigured"
+                  "reason",
+                  "broker",
+                  "batchers",
+                  "hotBuffer"
                 ],
                 "properties": {
                   "enabled": {
@@ -16049,6 +16443,7 @@
                     "enum": [
                       "disabled",
                       "ready",
+                      "degraded",
                       "unconfigured"
                     ]
                   },
@@ -16056,8 +16451,172 @@
                     "type": "string",
                     "nullable": true
                   },
-                  "brokerConfigured": {
-                    "type": "boolean"
+                  "broker": {
+                    "type": "object",
+                    "required": [
+                      "configured",
+                      "reachable",
+                      "lastCheckedAt",
+                      "error"
+                    ],
+                    "properties": {
+                      "configured": {
+                        "type": "boolean"
+                      },
+                      "reachable": {
+                        "type": "boolean",
+                        "nullable": true
+                      },
+                      "lastCheckedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                      },
+                      "error": {
+                        "type": "string",
+                        "nullable": true
+                      }
+                    }
+                  },
+                  "batchers": {
+                    "type": "object",
+                    "required": [
+                      "configured",
+                      "running",
+                      "failing",
+                      "state",
+                      "connectors"
+                    ],
+                    "properties": {
+                      "configured": {
+                        "type": "integer"
+                      },
+                      "running": {
+                        "type": "integer"
+                      },
+                      "failing": {
+                        "type": "integer"
+                      },
+                      "state": {
+                        "type": "string",
+                        "enum": [
+                          "disabled",
+                          "ready",
+                          "degraded"
+                        ]
+                      },
+                      "connectors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": [
+                            "connectorId",
+                            "datasetSlug",
+                            "topic",
+                            "groupId",
+                            "state",
+                            "bufferedWindows",
+                            "bufferedRows",
+                            "openWindows",
+                            "lastMessageAt",
+                            "lastFlushAt",
+                            "lastEventTimestamp",
+                            "lastError"
+                          ],
+                          "properties": {
+                            "connectorId": {
+                              "type": "string"
+                            },
+                            "datasetSlug": {
+                              "type": "string"
+                            },
+                            "topic": {
+                              "type": "string"
+                            },
+                            "groupId": {
+                              "type": "string"
+                            },
+                            "state": {
+                              "type": "string",
+                              "enum": [
+                                "starting",
+                                "running",
+                                "stopped",
+                                "error"
+                              ]
+                            },
+                            "bufferedWindows": {
+                              "type": "integer"
+                            },
+                            "bufferedRows": {
+                              "type": "integer"
+                            },
+                            "openWindows": {
+                              "type": "integer"
+                            },
+                            "lastMessageAt": {
+                              "type": "string",
+                              "format": "date-time",
+                              "nullable": true
+                            },
+                            "lastFlushAt": {
+                              "type": "string",
+                              "format": "date-time",
+                              "nullable": true
+                            },
+                            "lastEventTimestamp": {
+                              "type": "string",
+                              "format": "date-time",
+                              "nullable": true
+                            },
+                            "lastError": {
+                              "type": "string",
+                              "nullable": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "hotBuffer": {
+                    "type": "object",
+                    "required": [
+                      "enabled",
+                      "state",
+                      "datasets",
+                      "healthy",
+                      "lastRefreshAt",
+                      "lastIngestAt"
+                    ],
+                    "properties": {
+                      "enabled": {
+                        "type": "boolean"
+                      },
+                      "state": {
+                        "type": "string",
+                        "enum": [
+                          "disabled",
+                          "ready",
+                          "unavailable"
+                        ]
+                      },
+                      "datasets": {
+                        "type": "integer"
+                      },
+                      "healthy": {
+                        "type": "boolean"
+                      },
+                      "lastRefreshAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                      },
+                      "lastIngestAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                      }
+                    }
                   }
                 }
               }
@@ -16095,7 +16654,10 @@
                 "required": [
                   "enabled",
                   "state",
-                  "brokerConfigured"
+                  "reason",
+                  "broker",
+                  "batchers",
+                  "hotBuffer"
                 ],
                 "properties": {
                   "enabled": {
@@ -16106,6 +16668,7 @@
                     "enum": [
                       "disabled",
                       "ready",
+                      "degraded",
                       "unconfigured"
                     ]
                   },
@@ -16113,8 +16676,623 @@
                     "type": "string",
                     "nullable": true
                   },
-                  "brokerConfigured": {
+                  "broker": {
+                    "type": "object",
+                    "required": [
+                      "configured",
+                      "reachable",
+                      "lastCheckedAt",
+                      "error"
+                    ],
+                    "properties": {
+                      "configured": {
+                        "type": "boolean"
+                      },
+                      "reachable": {
+                        "type": "boolean",
+                        "nullable": true
+                      },
+                      "lastCheckedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                      },
+                      "error": {
+                        "type": "string",
+                        "nullable": true
+                      }
+                    }
+                  },
+                  "batchers": {
+                    "type": "object",
+                    "required": [
+                      "configured",
+                      "running",
+                      "failing",
+                      "state",
+                      "connectors"
+                    ],
+                    "properties": {
+                      "configured": {
+                        "type": "integer"
+                      },
+                      "running": {
+                        "type": "integer"
+                      },
+                      "failing": {
+                        "type": "integer"
+                      },
+                      "state": {
+                        "type": "string",
+                        "enum": [
+                          "disabled",
+                          "ready",
+                          "degraded"
+                        ]
+                      },
+                      "connectors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": [
+                            "connectorId",
+                            "datasetSlug",
+                            "topic",
+                            "groupId",
+                            "state",
+                            "bufferedWindows",
+                            "bufferedRows",
+                            "openWindows",
+                            "lastMessageAt",
+                            "lastFlushAt",
+                            "lastEventTimestamp",
+                            "lastError"
+                          ],
+                          "properties": {
+                            "connectorId": {
+                              "type": "string"
+                            },
+                            "datasetSlug": {
+                              "type": "string"
+                            },
+                            "topic": {
+                              "type": "string"
+                            },
+                            "groupId": {
+                              "type": "string"
+                            },
+                            "state": {
+                              "type": "string",
+                              "enum": [
+                                "starting",
+                                "running",
+                                "stopped",
+                                "error"
+                              ]
+                            },
+                            "bufferedWindows": {
+                              "type": "integer"
+                            },
+                            "bufferedRows": {
+                              "type": "integer"
+                            },
+                            "openWindows": {
+                              "type": "integer"
+                            },
+                            "lastMessageAt": {
+                              "type": "string",
+                              "format": "date-time",
+                              "nullable": true
+                            },
+                            "lastFlushAt": {
+                              "type": "string",
+                              "format": "date-time",
+                              "nullable": true
+                            },
+                            "lastEventTimestamp": {
+                              "type": "string",
+                              "format": "date-time",
+                              "nullable": true
+                            },
+                            "lastError": {
+                              "type": "string",
+                              "nullable": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "hotBuffer": {
+                    "type": "object",
+                    "required": [
+                      "enabled",
+                      "state",
+                      "datasets",
+                      "healthy",
+                      "lastRefreshAt",
+                      "lastIngestAt"
+                    ],
+                    "properties": {
+                      "enabled": {
+                        "type": "boolean"
+                      },
+                      "state": {
+                        "type": "string",
+                        "enum": [
+                          "disabled",
+                          "ready",
+                          "unavailable"
+                        ]
+                      },
+                      "datasets": {
+                        "type": "integer"
+                      },
+                      "healthy": {
+                        "type": "boolean"
+                      },
+                      "lastRefreshAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                      },
+                      "lastIngestAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "ReadyResponse": {
+        "type": "object",
+        "required": [
+          "status",
+          "features"
+        ],
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "ready"
+            ]
+          },
+          "warnings": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": []
+          },
+          "features": {
+            "type": "object",
+            "required": [
+              "streaming"
+            ],
+            "properties": {
+              "streaming": {
+                "type": "object",
+                "required": [
+                  "enabled",
+                  "state",
+                  "reason",
+                  "broker",
+                  "batchers",
+                  "hotBuffer"
+                ],
+                "properties": {
+                  "enabled": {
                     "type": "boolean"
+                  },
+                  "state": {
+                    "type": "string",
+                    "enum": [
+                      "disabled",
+                      "ready",
+                      "degraded",
+                      "unconfigured"
+                    ]
+                  },
+                  "reason": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "broker": {
+                    "type": "object",
+                    "required": [
+                      "configured",
+                      "reachable",
+                      "lastCheckedAt",
+                      "error"
+                    ],
+                    "properties": {
+                      "configured": {
+                        "type": "boolean"
+                      },
+                      "reachable": {
+                        "type": "boolean",
+                        "nullable": true
+                      },
+                      "lastCheckedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                      },
+                      "error": {
+                        "type": "string",
+                        "nullable": true
+                      }
+                    }
+                  },
+                  "batchers": {
+                    "type": "object",
+                    "required": [
+                      "configured",
+                      "running",
+                      "failing",
+                      "state",
+                      "connectors"
+                    ],
+                    "properties": {
+                      "configured": {
+                        "type": "integer"
+                      },
+                      "running": {
+                        "type": "integer"
+                      },
+                      "failing": {
+                        "type": "integer"
+                      },
+                      "state": {
+                        "type": "string",
+                        "enum": [
+                          "disabled",
+                          "ready",
+                          "degraded"
+                        ]
+                      },
+                      "connectors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": [
+                            "connectorId",
+                            "datasetSlug",
+                            "topic",
+                            "groupId",
+                            "state",
+                            "bufferedWindows",
+                            "bufferedRows",
+                            "openWindows",
+                            "lastMessageAt",
+                            "lastFlushAt",
+                            "lastEventTimestamp",
+                            "lastError"
+                          ],
+                          "properties": {
+                            "connectorId": {
+                              "type": "string"
+                            },
+                            "datasetSlug": {
+                              "type": "string"
+                            },
+                            "topic": {
+                              "type": "string"
+                            },
+                            "groupId": {
+                              "type": "string"
+                            },
+                            "state": {
+                              "type": "string",
+                              "enum": [
+                                "starting",
+                                "running",
+                                "stopped",
+                                "error"
+                              ]
+                            },
+                            "bufferedWindows": {
+                              "type": "integer"
+                            },
+                            "bufferedRows": {
+                              "type": "integer"
+                            },
+                            "openWindows": {
+                              "type": "integer"
+                            },
+                            "lastMessageAt": {
+                              "type": "string",
+                              "format": "date-time",
+                              "nullable": true
+                            },
+                            "lastFlushAt": {
+                              "type": "string",
+                              "format": "date-time",
+                              "nullable": true
+                            },
+                            "lastEventTimestamp": {
+                              "type": "string",
+                              "format": "date-time",
+                              "nullable": true
+                            },
+                            "lastError": {
+                              "type": "string",
+                              "nullable": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "hotBuffer": {
+                    "type": "object",
+                    "required": [
+                      "enabled",
+                      "state",
+                      "datasets",
+                      "healthy",
+                      "lastRefreshAt",
+                      "lastIngestAt"
+                    ],
+                    "properties": {
+                      "enabled": {
+                        "type": "boolean"
+                      },
+                      "state": {
+                        "type": "string",
+                        "enum": [
+                          "disabled",
+                          "ready",
+                          "unavailable"
+                        ]
+                      },
+                      "datasets": {
+                        "type": "integer"
+                      },
+                      "healthy": {
+                        "type": "boolean"
+                      },
+                      "lastRefreshAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                      },
+                      "lastIngestAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "ReadyUnavailableResponse": {
+        "type": "object",
+        "required": [
+          "status",
+          "features"
+        ],
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "unavailable"
+            ]
+          },
+          "warnings": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "features": {
+            "type": "object",
+            "required": [
+              "streaming"
+            ],
+            "properties": {
+              "streaming": {
+                "type": "object",
+                "required": [
+                  "enabled",
+                  "state",
+                  "reason",
+                  "broker",
+                  "batchers",
+                  "hotBuffer"
+                ],
+                "properties": {
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "state": {
+                    "type": "string",
+                    "enum": [
+                      "disabled",
+                      "ready",
+                      "degraded",
+                      "unconfigured"
+                    ]
+                  },
+                  "reason": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "broker": {
+                    "type": "object",
+                    "required": [
+                      "configured",
+                      "reachable",
+                      "lastCheckedAt",
+                      "error"
+                    ],
+                    "properties": {
+                      "configured": {
+                        "type": "boolean"
+                      },
+                      "reachable": {
+                        "type": "boolean",
+                        "nullable": true
+                      },
+                      "lastCheckedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                      },
+                      "error": {
+                        "type": "string",
+                        "nullable": true
+                      }
+                    }
+                  },
+                  "batchers": {
+                    "type": "object",
+                    "required": [
+                      "configured",
+                      "running",
+                      "failing",
+                      "state",
+                      "connectors"
+                    ],
+                    "properties": {
+                      "configured": {
+                        "type": "integer"
+                      },
+                      "running": {
+                        "type": "integer"
+                      },
+                      "failing": {
+                        "type": "integer"
+                      },
+                      "state": {
+                        "type": "string",
+                        "enum": [
+                          "disabled",
+                          "ready",
+                          "degraded"
+                        ]
+                      },
+                      "connectors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": [
+                            "connectorId",
+                            "datasetSlug",
+                            "topic",
+                            "groupId",
+                            "state",
+                            "bufferedWindows",
+                            "bufferedRows",
+                            "openWindows",
+                            "lastMessageAt",
+                            "lastFlushAt",
+                            "lastEventTimestamp",
+                            "lastError"
+                          ],
+                          "properties": {
+                            "connectorId": {
+                              "type": "string"
+                            },
+                            "datasetSlug": {
+                              "type": "string"
+                            },
+                            "topic": {
+                              "type": "string"
+                            },
+                            "groupId": {
+                              "type": "string"
+                            },
+                            "state": {
+                              "type": "string",
+                              "enum": [
+                                "starting",
+                                "running",
+                                "stopped",
+                                "error"
+                              ]
+                            },
+                            "bufferedWindows": {
+                              "type": "integer"
+                            },
+                            "bufferedRows": {
+                              "type": "integer"
+                            },
+                            "openWindows": {
+                              "type": "integer"
+                            },
+                            "lastMessageAt": {
+                              "type": "string",
+                              "format": "date-time",
+                              "nullable": true
+                            },
+                            "lastFlushAt": {
+                              "type": "string",
+                              "format": "date-time",
+                              "nullable": true
+                            },
+                            "lastEventTimestamp": {
+                              "type": "string",
+                              "format": "date-time",
+                              "nullable": true
+                            },
+                            "lastError": {
+                              "type": "string",
+                              "nullable": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "hotBuffer": {
+                    "type": "object",
+                    "required": [
+                      "enabled",
+                      "state",
+                      "datasets",
+                      "healthy",
+                      "lastRefreshAt",
+                      "lastIngestAt"
+                    ],
+                    "properties": {
+                      "enabled": {
+                        "type": "boolean"
+                      },
+                      "state": {
+                        "type": "string",
+                        "enum": [
+                          "disabled",
+                          "ready",
+                          "unavailable"
+                        ]
+                      },
+                      "datasets": {
+                        "type": "integer"
+                      },
+                      "healthy": {
+                        "type": "boolean"
+                      },
+                      "lastRefreshAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                      },
+                      "lastIngestAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                      }
+                    }
                   }
                 }
               }
@@ -34233,6 +35411,443 @@
       "def-88": {
         "type": "object",
         "required": [
+          "configured",
+          "reachable",
+          "lastCheckedAt",
+          "error"
+        ],
+        "properties": {
+          "configured": {
+            "type": "boolean"
+          },
+          "reachable": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "lastCheckedAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "error": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "title": "https://core.apphub/schemas/StreamingBrokerStatus.json"
+      },
+      "def-89": {
+        "type": "object",
+        "required": [
+          "connectorId",
+          "datasetSlug",
+          "topic",
+          "groupId",
+          "state",
+          "bufferedWindows",
+          "bufferedRows",
+          "openWindows",
+          "lastMessageAt",
+          "lastFlushAt",
+          "lastEventTimestamp",
+          "lastError"
+        ],
+        "properties": {
+          "connectorId": {
+            "type": "string"
+          },
+          "datasetSlug": {
+            "type": "string"
+          },
+          "topic": {
+            "type": "string"
+          },
+          "groupId": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "starting",
+              "running",
+              "stopped",
+              "error"
+            ]
+          },
+          "bufferedWindows": {
+            "type": "integer"
+          },
+          "bufferedRows": {
+            "type": "integer"
+          },
+          "openWindows": {
+            "type": "integer"
+          },
+          "lastMessageAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "lastFlushAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "lastEventTimestamp": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "lastError": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "title": "https://core.apphub/schemas/StreamingBatcherConnectorStatus.json"
+      },
+      "def-90": {
+        "type": "object",
+        "required": [
+          "configured",
+          "running",
+          "failing",
+          "state",
+          "connectors"
+        ],
+        "properties": {
+          "configured": {
+            "type": "integer"
+          },
+          "running": {
+            "type": "integer"
+          },
+          "failing": {
+            "type": "integer"
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "disabled",
+              "ready",
+              "degraded"
+            ]
+          },
+          "connectors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "connectorId",
+                "datasetSlug",
+                "topic",
+                "groupId",
+                "state",
+                "bufferedWindows",
+                "bufferedRows",
+                "openWindows",
+                "lastMessageAt",
+                "lastFlushAt",
+                "lastEventTimestamp",
+                "lastError"
+              ],
+              "properties": {
+                "connectorId": {
+                  "type": "string"
+                },
+                "datasetSlug": {
+                  "type": "string"
+                },
+                "topic": {
+                  "type": "string"
+                },
+                "groupId": {
+                  "type": "string"
+                },
+                "state": {
+                  "type": "string",
+                  "enum": [
+                    "starting",
+                    "running",
+                    "stopped",
+                    "error"
+                  ]
+                },
+                "bufferedWindows": {
+                  "type": "integer"
+                },
+                "bufferedRows": {
+                  "type": "integer"
+                },
+                "openWindows": {
+                  "type": "integer"
+                },
+                "lastMessageAt": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "format": "date-time"
+                },
+                "lastFlushAt": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "format": "date-time"
+                },
+                "lastEventTimestamp": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "format": "date-time"
+                },
+                "lastError": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "title": "https://core.apphub/schemas/StreamingBatcherStatus.json"
+      },
+      "def-91": {
+        "type": "object",
+        "required": [
+          "enabled",
+          "state",
+          "reason",
+          "broker",
+          "batchers",
+          "hotBuffer"
+        ],
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "disabled",
+              "ready",
+              "degraded",
+              "unconfigured"
+            ]
+          },
+          "reason": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "broker": {
+            "type": "object",
+            "required": [
+              "configured",
+              "reachable",
+              "lastCheckedAt",
+              "error"
+            ],
+            "properties": {
+              "configured": {
+                "type": "boolean"
+              },
+              "reachable": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "lastCheckedAt": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "date-time"
+              },
+              "error": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          },
+          "batchers": {
+            "type": "object",
+            "required": [
+              "configured",
+              "running",
+              "failing",
+              "state",
+              "connectors"
+            ],
+            "properties": {
+              "configured": {
+                "type": "integer"
+              },
+              "running": {
+                "type": "integer"
+              },
+              "failing": {
+                "type": "integer"
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "disabled",
+                  "ready",
+                  "degraded"
+                ]
+              },
+              "connectors": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "connectorId",
+                    "datasetSlug",
+                    "topic",
+                    "groupId",
+                    "state",
+                    "bufferedWindows",
+                    "bufferedRows",
+                    "openWindows",
+                    "lastMessageAt",
+                    "lastFlushAt",
+                    "lastEventTimestamp",
+                    "lastError"
+                  ],
+                  "properties": {
+                    "connectorId": {
+                      "type": "string"
+                    },
+                    "datasetSlug": {
+                      "type": "string"
+                    },
+                    "topic": {
+                      "type": "string"
+                    },
+                    "groupId": {
+                      "type": "string"
+                    },
+                    "state": {
+                      "type": "string",
+                      "enum": [
+                        "starting",
+                        "running",
+                        "stopped",
+                        "error"
+                      ]
+                    },
+                    "bufferedWindows": {
+                      "type": "integer"
+                    },
+                    "bufferedRows": {
+                      "type": "integer"
+                    },
+                    "openWindows": {
+                      "type": "integer"
+                    },
+                    "lastMessageAt": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "format": "date-time"
+                    },
+                    "lastFlushAt": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "format": "date-time"
+                    },
+                    "lastEventTimestamp": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "format": "date-time"
+                    },
+                    "lastError": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "hotBuffer": {
+            "type": "object",
+            "required": [
+              "enabled",
+              "state",
+              "datasets",
+              "healthy",
+              "lastRefreshAt",
+              "lastIngestAt"
+            ],
+            "properties": {
+              "enabled": {
+                "type": "boolean"
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "disabled",
+                  "ready",
+                  "unavailable"
+                ]
+              },
+              "datasets": {
+                "type": "integer"
+              },
+              "healthy": {
+                "type": "boolean"
+              },
+              "lastRefreshAt": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "date-time"
+              },
+              "lastIngestAt": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "title": "https://core.apphub/schemas/StreamingStatus.json"
+      },
+      "def-92": {
+        "type": "object",
+        "required": [
           "status",
           "features"
         ],
@@ -34261,7 +35876,10 @@
                 "required": [
                   "enabled",
                   "state",
-                  "brokerConfigured"
+                  "reason",
+                  "broker",
+                  "batchers",
+                  "hotBuffer"
                 ],
                 "properties": {
                   "enabled": {
@@ -34272,6 +35890,7 @@
                     "enum": [
                       "disabled",
                       "ready",
+                      "degraded",
                       "unconfigured"
                     ]
                   },
@@ -34281,8 +35900,190 @@
                       "string"
                     ]
                   },
-                  "brokerConfigured": {
-                    "type": "boolean"
+                  "broker": {
+                    "type": "object",
+                    "required": [
+                      "configured",
+                      "reachable",
+                      "lastCheckedAt",
+                      "error"
+                    ],
+                    "properties": {
+                      "configured": {
+                        "type": "boolean"
+                      },
+                      "reachable": {
+                        "type": [
+                          "null",
+                          "boolean"
+                        ]
+                      },
+                      "lastCheckedAt": {
+                        "type": [
+                          "null",
+                          "string"
+                        ],
+                        "format": "date-time"
+                      },
+                      "error": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      }
+                    }
+                  },
+                  "batchers": {
+                    "type": "object",
+                    "required": [
+                      "configured",
+                      "running",
+                      "failing",
+                      "state",
+                      "connectors"
+                    ],
+                    "properties": {
+                      "configured": {
+                        "type": "integer"
+                      },
+                      "running": {
+                        "type": "integer"
+                      },
+                      "failing": {
+                        "type": "integer"
+                      },
+                      "state": {
+                        "type": "string",
+                        "enum": [
+                          "disabled",
+                          "ready",
+                          "degraded"
+                        ]
+                      },
+                      "connectors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": [
+                            "connectorId",
+                            "datasetSlug",
+                            "topic",
+                            "groupId",
+                            "state",
+                            "bufferedWindows",
+                            "bufferedRows",
+                            "openWindows",
+                            "lastMessageAt",
+                            "lastFlushAt",
+                            "lastEventTimestamp",
+                            "lastError"
+                          ],
+                          "properties": {
+                            "connectorId": {
+                              "type": "string"
+                            },
+                            "datasetSlug": {
+                              "type": "string"
+                            },
+                            "topic": {
+                              "type": "string"
+                            },
+                            "groupId": {
+                              "type": "string"
+                            },
+                            "state": {
+                              "type": "string",
+                              "enum": [
+                                "starting",
+                                "running",
+                                "stopped",
+                                "error"
+                              ]
+                            },
+                            "bufferedWindows": {
+                              "type": "integer"
+                            },
+                            "bufferedRows": {
+                              "type": "integer"
+                            },
+                            "openWindows": {
+                              "type": "integer"
+                            },
+                            "lastMessageAt": {
+                              "type": [
+                                "null",
+                                "string"
+                              ],
+                              "format": "date-time"
+                            },
+                            "lastFlushAt": {
+                              "type": [
+                                "null",
+                                "string"
+                              ],
+                              "format": "date-time"
+                            },
+                            "lastEventTimestamp": {
+                              "type": [
+                                "null",
+                                "string"
+                              ],
+                              "format": "date-time"
+                            },
+                            "lastError": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "hotBuffer": {
+                    "type": "object",
+                    "required": [
+                      "enabled",
+                      "state",
+                      "datasets",
+                      "healthy",
+                      "lastRefreshAt",
+                      "lastIngestAt"
+                    ],
+                    "properties": {
+                      "enabled": {
+                        "type": "boolean"
+                      },
+                      "state": {
+                        "type": "string",
+                        "enum": [
+                          "disabled",
+                          "ready",
+                          "unavailable"
+                        ]
+                      },
+                      "datasets": {
+                        "type": "integer"
+                      },
+                      "healthy": {
+                        "type": "boolean"
+                      },
+                      "lastRefreshAt": {
+                        "type": [
+                          "null",
+                          "string"
+                        ],
+                        "format": "date-time"
+                      },
+                      "lastIngestAt": {
+                        "type": [
+                          "null",
+                          "string"
+                        ],
+                        "format": "date-time"
+                      }
+                    }
                   }
                 }
               }
@@ -34291,7 +36092,7 @@
         },
         "title": "https://core.apphub/schemas/HealthResponse.json"
       },
-      "def-89": {
+      "def-93": {
         "type": "object",
         "required": [
           "status",
@@ -34321,7 +36122,10 @@
                 "required": [
                   "enabled",
                   "state",
-                  "brokerConfigured"
+                  "reason",
+                  "broker",
+                  "batchers",
+                  "hotBuffer"
                 ],
                 "properties": {
                   "enabled": {
@@ -34332,6 +36136,7 @@
                     "enum": [
                       "disabled",
                       "ready",
+                      "degraded",
                       "unconfigured"
                     ]
                   },
@@ -34341,8 +36146,190 @@
                       "string"
                     ]
                   },
-                  "brokerConfigured": {
-                    "type": "boolean"
+                  "broker": {
+                    "type": "object",
+                    "required": [
+                      "configured",
+                      "reachable",
+                      "lastCheckedAt",
+                      "error"
+                    ],
+                    "properties": {
+                      "configured": {
+                        "type": "boolean"
+                      },
+                      "reachable": {
+                        "type": [
+                          "null",
+                          "boolean"
+                        ]
+                      },
+                      "lastCheckedAt": {
+                        "type": [
+                          "null",
+                          "string"
+                        ],
+                        "format": "date-time"
+                      },
+                      "error": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      }
+                    }
+                  },
+                  "batchers": {
+                    "type": "object",
+                    "required": [
+                      "configured",
+                      "running",
+                      "failing",
+                      "state",
+                      "connectors"
+                    ],
+                    "properties": {
+                      "configured": {
+                        "type": "integer"
+                      },
+                      "running": {
+                        "type": "integer"
+                      },
+                      "failing": {
+                        "type": "integer"
+                      },
+                      "state": {
+                        "type": "string",
+                        "enum": [
+                          "disabled",
+                          "ready",
+                          "degraded"
+                        ]
+                      },
+                      "connectors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": [
+                            "connectorId",
+                            "datasetSlug",
+                            "topic",
+                            "groupId",
+                            "state",
+                            "bufferedWindows",
+                            "bufferedRows",
+                            "openWindows",
+                            "lastMessageAt",
+                            "lastFlushAt",
+                            "lastEventTimestamp",
+                            "lastError"
+                          ],
+                          "properties": {
+                            "connectorId": {
+                              "type": "string"
+                            },
+                            "datasetSlug": {
+                              "type": "string"
+                            },
+                            "topic": {
+                              "type": "string"
+                            },
+                            "groupId": {
+                              "type": "string"
+                            },
+                            "state": {
+                              "type": "string",
+                              "enum": [
+                                "starting",
+                                "running",
+                                "stopped",
+                                "error"
+                              ]
+                            },
+                            "bufferedWindows": {
+                              "type": "integer"
+                            },
+                            "bufferedRows": {
+                              "type": "integer"
+                            },
+                            "openWindows": {
+                              "type": "integer"
+                            },
+                            "lastMessageAt": {
+                              "type": [
+                                "null",
+                                "string"
+                              ],
+                              "format": "date-time"
+                            },
+                            "lastFlushAt": {
+                              "type": [
+                                "null",
+                                "string"
+                              ],
+                              "format": "date-time"
+                            },
+                            "lastEventTimestamp": {
+                              "type": [
+                                "null",
+                                "string"
+                              ],
+                              "format": "date-time"
+                            },
+                            "lastError": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "hotBuffer": {
+                    "type": "object",
+                    "required": [
+                      "enabled",
+                      "state",
+                      "datasets",
+                      "healthy",
+                      "lastRefreshAt",
+                      "lastIngestAt"
+                    ],
+                    "properties": {
+                      "enabled": {
+                        "type": "boolean"
+                      },
+                      "state": {
+                        "type": "string",
+                        "enum": [
+                          "disabled",
+                          "ready",
+                          "unavailable"
+                        ]
+                      },
+                      "datasets": {
+                        "type": "integer"
+                      },
+                      "healthy": {
+                        "type": "boolean"
+                      },
+                      "lastRefreshAt": {
+                        "type": [
+                          "null",
+                          "string"
+                        ],
+                        "format": "date-time"
+                      },
+                      "lastIngestAt": {
+                        "type": [
+                          "null",
+                          "string"
+                        ],
+                        "format": "date-time"
+                      }
+                    }
                   }
                 }
               }
@@ -34351,7 +36338,500 @@
         },
         "title": "https://core.apphub/schemas/HealthUnavailableResponse.json"
       },
-      "def-90": {
+      "def-94": {
+        "type": "object",
+        "required": [
+          "status",
+          "features"
+        ],
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "ready"
+            ]
+          },
+          "warnings": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": []
+          },
+          "features": {
+            "type": "object",
+            "required": [
+              "streaming"
+            ],
+            "properties": {
+              "streaming": {
+                "type": "object",
+                "required": [
+                  "enabled",
+                  "state",
+                  "reason",
+                  "broker",
+                  "batchers",
+                  "hotBuffer"
+                ],
+                "properties": {
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "state": {
+                    "type": "string",
+                    "enum": [
+                      "disabled",
+                      "ready",
+                      "degraded",
+                      "unconfigured"
+                    ]
+                  },
+                  "reason": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "broker": {
+                    "type": "object",
+                    "required": [
+                      "configured",
+                      "reachable",
+                      "lastCheckedAt",
+                      "error"
+                    ],
+                    "properties": {
+                      "configured": {
+                        "type": "boolean"
+                      },
+                      "reachable": {
+                        "type": [
+                          "null",
+                          "boolean"
+                        ]
+                      },
+                      "lastCheckedAt": {
+                        "type": [
+                          "null",
+                          "string"
+                        ],
+                        "format": "date-time"
+                      },
+                      "error": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      }
+                    }
+                  },
+                  "batchers": {
+                    "type": "object",
+                    "required": [
+                      "configured",
+                      "running",
+                      "failing",
+                      "state",
+                      "connectors"
+                    ],
+                    "properties": {
+                      "configured": {
+                        "type": "integer"
+                      },
+                      "running": {
+                        "type": "integer"
+                      },
+                      "failing": {
+                        "type": "integer"
+                      },
+                      "state": {
+                        "type": "string",
+                        "enum": [
+                          "disabled",
+                          "ready",
+                          "degraded"
+                        ]
+                      },
+                      "connectors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": [
+                            "connectorId",
+                            "datasetSlug",
+                            "topic",
+                            "groupId",
+                            "state",
+                            "bufferedWindows",
+                            "bufferedRows",
+                            "openWindows",
+                            "lastMessageAt",
+                            "lastFlushAt",
+                            "lastEventTimestamp",
+                            "lastError"
+                          ],
+                          "properties": {
+                            "connectorId": {
+                              "type": "string"
+                            },
+                            "datasetSlug": {
+                              "type": "string"
+                            },
+                            "topic": {
+                              "type": "string"
+                            },
+                            "groupId": {
+                              "type": "string"
+                            },
+                            "state": {
+                              "type": "string",
+                              "enum": [
+                                "starting",
+                                "running",
+                                "stopped",
+                                "error"
+                              ]
+                            },
+                            "bufferedWindows": {
+                              "type": "integer"
+                            },
+                            "bufferedRows": {
+                              "type": "integer"
+                            },
+                            "openWindows": {
+                              "type": "integer"
+                            },
+                            "lastMessageAt": {
+                              "type": [
+                                "null",
+                                "string"
+                              ],
+                              "format": "date-time"
+                            },
+                            "lastFlushAt": {
+                              "type": [
+                                "null",
+                                "string"
+                              ],
+                              "format": "date-time"
+                            },
+                            "lastEventTimestamp": {
+                              "type": [
+                                "null",
+                                "string"
+                              ],
+                              "format": "date-time"
+                            },
+                            "lastError": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "hotBuffer": {
+                    "type": "object",
+                    "required": [
+                      "enabled",
+                      "state",
+                      "datasets",
+                      "healthy",
+                      "lastRefreshAt",
+                      "lastIngestAt"
+                    ],
+                    "properties": {
+                      "enabled": {
+                        "type": "boolean"
+                      },
+                      "state": {
+                        "type": "string",
+                        "enum": [
+                          "disabled",
+                          "ready",
+                          "unavailable"
+                        ]
+                      },
+                      "datasets": {
+                        "type": "integer"
+                      },
+                      "healthy": {
+                        "type": "boolean"
+                      },
+                      "lastRefreshAt": {
+                        "type": [
+                          "null",
+                          "string"
+                        ],
+                        "format": "date-time"
+                      },
+                      "lastIngestAt": {
+                        "type": [
+                          "null",
+                          "string"
+                        ],
+                        "format": "date-time"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "title": "https://core.apphub/schemas/ReadyResponse.json"
+      },
+      "def-95": {
+        "type": "object",
+        "required": [
+          "status",
+          "features"
+        ],
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "unavailable"
+            ]
+          },
+          "warnings": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "features": {
+            "type": "object",
+            "required": [
+              "streaming"
+            ],
+            "properties": {
+              "streaming": {
+                "type": "object",
+                "required": [
+                  "enabled",
+                  "state",
+                  "reason",
+                  "broker",
+                  "batchers",
+                  "hotBuffer"
+                ],
+                "properties": {
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "state": {
+                    "type": "string",
+                    "enum": [
+                      "disabled",
+                      "ready",
+                      "degraded",
+                      "unconfigured"
+                    ]
+                  },
+                  "reason": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "broker": {
+                    "type": "object",
+                    "required": [
+                      "configured",
+                      "reachable",
+                      "lastCheckedAt",
+                      "error"
+                    ],
+                    "properties": {
+                      "configured": {
+                        "type": "boolean"
+                      },
+                      "reachable": {
+                        "type": [
+                          "null",
+                          "boolean"
+                        ]
+                      },
+                      "lastCheckedAt": {
+                        "type": [
+                          "null",
+                          "string"
+                        ],
+                        "format": "date-time"
+                      },
+                      "error": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      }
+                    }
+                  },
+                  "batchers": {
+                    "type": "object",
+                    "required": [
+                      "configured",
+                      "running",
+                      "failing",
+                      "state",
+                      "connectors"
+                    ],
+                    "properties": {
+                      "configured": {
+                        "type": "integer"
+                      },
+                      "running": {
+                        "type": "integer"
+                      },
+                      "failing": {
+                        "type": "integer"
+                      },
+                      "state": {
+                        "type": "string",
+                        "enum": [
+                          "disabled",
+                          "ready",
+                          "degraded"
+                        ]
+                      },
+                      "connectors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": [
+                            "connectorId",
+                            "datasetSlug",
+                            "topic",
+                            "groupId",
+                            "state",
+                            "bufferedWindows",
+                            "bufferedRows",
+                            "openWindows",
+                            "lastMessageAt",
+                            "lastFlushAt",
+                            "lastEventTimestamp",
+                            "lastError"
+                          ],
+                          "properties": {
+                            "connectorId": {
+                              "type": "string"
+                            },
+                            "datasetSlug": {
+                              "type": "string"
+                            },
+                            "topic": {
+                              "type": "string"
+                            },
+                            "groupId": {
+                              "type": "string"
+                            },
+                            "state": {
+                              "type": "string",
+                              "enum": [
+                                "starting",
+                                "running",
+                                "stopped",
+                                "error"
+                              ]
+                            },
+                            "bufferedWindows": {
+                              "type": "integer"
+                            },
+                            "bufferedRows": {
+                              "type": "integer"
+                            },
+                            "openWindows": {
+                              "type": "integer"
+                            },
+                            "lastMessageAt": {
+                              "type": [
+                                "null",
+                                "string"
+                              ],
+                              "format": "date-time"
+                            },
+                            "lastFlushAt": {
+                              "type": [
+                                "null",
+                                "string"
+                              ],
+                              "format": "date-time"
+                            },
+                            "lastEventTimestamp": {
+                              "type": [
+                                "null",
+                                "string"
+                              ],
+                              "format": "date-time"
+                            },
+                            "lastError": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "hotBuffer": {
+                    "type": "object",
+                    "required": [
+                      "enabled",
+                      "state",
+                      "datasets",
+                      "healthy",
+                      "lastRefreshAt",
+                      "lastIngestAt"
+                    ],
+                    "properties": {
+                      "enabled": {
+                        "type": "boolean"
+                      },
+                      "state": {
+                        "type": "string",
+                        "enum": [
+                          "disabled",
+                          "ready",
+                          "unavailable"
+                        ]
+                      },
+                      "datasets": {
+                        "type": "integer"
+                      },
+                      "healthy": {
+                        "type": "boolean"
+                      },
+                      "lastRefreshAt": {
+                        "type": [
+                          "null",
+                          "string"
+                        ],
+                        "format": "date-time"
+                      },
+                      "lastIngestAt": {
+                        "type": [
+                          "null",
+                          "string"
+                        ],
+                        "format": "date-time"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "title": "https://core.apphub/schemas/ReadyUnavailableResponse.json"
+      },
+      "def-96": {
         "type": "object",
         "required": [
           "error"
@@ -34452,7 +36932,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-88"
+                  "$ref": "#/components/schemas/def-92"
                 }
               }
             }
@@ -34462,7 +36942,38 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-89"
+                  "$ref": "#/components/schemas/def-93"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/readyz": {
+      "get": {
+        "summary": "Readiness probe",
+        "tags": [
+          "System"
+        ],
+        "description": "Aggregates streaming readiness when the feature flag is enabled.",
+        "responses": {
+          "200": {
+            "description": "Core services are ready to receive traffic.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-94"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Streaming components are not ready.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-95"
                 }
               }
             }
@@ -34522,7 +37033,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -34532,7 +37043,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -34542,7 +37053,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -34593,7 +37104,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -34603,7 +37114,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -34613,7 +37124,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -34623,7 +37134,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -34685,7 +37196,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -34695,7 +37206,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -34731,7 +37242,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -34741,7 +37252,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -34751,7 +37262,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -34825,7 +37336,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -34835,7 +37346,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -34845,7 +37356,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -34855,7 +37366,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -34902,7 +37413,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -34912,7 +37423,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -34922,7 +37433,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -34932,7 +37443,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -34942,7 +37453,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35005,7 +37516,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35015,7 +37526,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35025,7 +37536,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35035,7 +37546,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35045,7 +37556,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35076,7 +37587,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35168,7 +37679,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35178,7 +37689,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35188,7 +37699,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35244,7 +37755,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35254,7 +37765,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35264,7 +37775,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35274,7 +37785,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35284,7 +37795,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35294,7 +37805,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35388,7 +37899,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35398,7 +37909,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35408,7 +37919,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35473,7 +37984,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35483,7 +37994,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35493,7 +38004,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35503,7 +38014,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35560,7 +38071,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35570,7 +38081,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35580,7 +38091,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35590,7 +38101,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35705,7 +38216,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35715,7 +38226,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35725,7 +38236,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35735,7 +38246,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35776,7 +38287,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35786,7 +38297,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35796,7 +38307,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35852,7 +38363,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35862,7 +38373,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35872,7 +38383,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35882,7 +38393,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35892,7 +38403,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35902,7 +38413,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35912,7 +38423,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35922,7 +38433,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35978,7 +38489,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35988,7 +38499,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -35998,7 +38509,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -36008,7 +38519,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -36018,7 +38529,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -36028,7 +38539,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -36038,7 +38549,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -36094,7 +38605,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -36104,7 +38615,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -36114,7 +38625,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -36124,7 +38635,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -36134,7 +38645,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -36515,7 +39026,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -36525,7 +39036,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -36535,7 +39046,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -36565,7 +39076,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -36599,7 +39110,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -36609,7 +39120,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -36619,7 +39130,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -36629,7 +39140,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -36639,7 +39150,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -36893,7 +39404,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -36903,7 +39414,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -37228,7 +39739,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -37293,7 +39804,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -37303,7 +39814,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -37313,7 +39824,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -37323,7 +39834,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -37333,7 +39844,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -37397,7 +39908,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -37407,7 +39918,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -37417,7 +39928,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -37427,7 +39938,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -37437,7 +39948,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -37481,7 +39992,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -37534,7 +40045,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -37544,7 +40055,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -37554,7 +40065,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -37564,7 +40075,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -37715,7 +40226,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -37725,7 +40236,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -37735,7 +40246,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -37745,7 +40256,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -37755,7 +40266,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -37765,7 +40276,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -38456,7 +40967,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -38494,7 +41005,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -38536,7 +41047,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -38546,7 +41057,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -38788,7 +41299,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -38798,7 +41309,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -38808,7 +41319,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -38851,7 +41362,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -38861,7 +41372,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -38871,7 +41382,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -38881,7 +41392,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -38928,7 +41439,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -38938,7 +41449,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -38948,7 +41459,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -38958,7 +41469,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39012,7 +41523,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39022,7 +41533,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39032,7 +41543,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39042,7 +41553,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39087,7 +41598,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39097,7 +41608,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39107,7 +41618,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39117,7 +41628,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39164,7 +41675,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39174,7 +41685,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39184,7 +41695,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39194,7 +41705,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39241,7 +41752,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39251,7 +41762,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39261,7 +41772,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39271,7 +41782,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39307,7 +41818,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39317,7 +41828,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39360,7 +41871,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39370,7 +41881,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39380,7 +41891,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39390,7 +41901,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39437,7 +41948,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39447,7 +41958,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39457,7 +41968,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39467,7 +41978,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39521,7 +42032,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39531,7 +42042,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39541,7 +42052,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39551,7 +42062,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39561,7 +42072,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39606,7 +42117,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39616,7 +42127,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39626,7 +42137,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39636,7 +42147,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39683,7 +42194,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39693,7 +42204,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39703,7 +42214,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39713,7 +42224,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39760,7 +42271,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39770,7 +42281,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39780,7 +42291,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }
@@ -39790,7 +42301,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-90"
+                  "$ref": "#/components/schemas/def-96"
                 }
               }
             }

--- a/services/core/openapi.json
+++ b/services/core/openapi.json
@@ -16634,7 +16634,8 @@
           "status": {
             "type": "string",
             "enum": [
-              "unavailable"
+              "unavailable",
+              "degraded"
             ]
           },
           "warnings": {
@@ -17085,7 +17086,8 @@
           "status": {
             "type": "string",
             "enum": [
-              "unavailable"
+              "unavailable",
+              "degraded"
             ]
           },
           "warnings": {
@@ -36102,7 +36104,8 @@
           "status": {
             "type": "string",
             "enum": [
-              "unavailable"
+              "unavailable",
+              "degraded"
             ]
           },
           "warnings": {
@@ -36595,7 +36598,8 @@
           "status": {
             "type": "string",
             "enum": [
-              "unavailable"
+              "unavailable",
+              "degraded"
             ]
           },
           "warnings": {

--- a/services/core/src/openapi/definitions.ts
+++ b/services/core/src/openapi/definitions.ts
@@ -2383,14 +2383,85 @@ const assetMarkStaleRequestSchema: OpenAPIV3.SchemaObject = {
   additionalProperties: false
 };
 
+const streamingBrokerStatusSchema: OpenAPIV3.SchemaObject = {
+  type: 'object',
+  required: ['configured', 'reachable', 'lastCheckedAt', 'error'],
+  properties: {
+    configured: { type: 'boolean' },
+    reachable: { type: 'boolean', nullable: true },
+    lastCheckedAt: nullable(stringSchema('date-time')),
+    error: nullable(stringSchema())
+  }
+};
+
+const streamingBatcherConnectorStatusSchema: OpenAPIV3.SchemaObject = {
+  type: 'object',
+  required: [
+    'connectorId',
+    'datasetSlug',
+    'topic',
+    'groupId',
+    'state',
+    'bufferedWindows',
+    'bufferedRows',
+    'openWindows',
+    'lastMessageAt',
+    'lastFlushAt',
+    'lastEventTimestamp',
+    'lastError'
+  ],
+  properties: {
+    connectorId: stringSchema(),
+    datasetSlug: stringSchema(),
+    topic: stringSchema(),
+    groupId: stringSchema(),
+    state: { type: 'string', enum: ['starting', 'running', 'stopped', 'error'] },
+    bufferedWindows: integerSchema(),
+    bufferedRows: integerSchema(),
+    openWindows: integerSchema(),
+    lastMessageAt: nullable(stringSchema('date-time')),
+    lastFlushAt: nullable(stringSchema('date-time')),
+    lastEventTimestamp: nullable(stringSchema('date-time')),
+    lastError: nullable(stringSchema())
+  }
+};
+
+const streamingBatcherStatusSchema: OpenAPIV3.SchemaObject = {
+  type: 'object',
+  required: ['configured', 'running', 'failing', 'state', 'connectors'],
+  properties: {
+    configured: integerSchema(),
+    running: integerSchema(),
+    failing: integerSchema(),
+    state: { type: 'string', enum: ['disabled', 'ready', 'degraded'] },
+    connectors: {
+      type: 'array',
+      items: streamingBatcherConnectorStatusSchema
+    }
+  }
+};
+
 const streamingStatusSchema: OpenAPIV3.SchemaObject = {
   type: 'object',
-  required: ['enabled', 'state', 'brokerConfigured'],
+  required: ['enabled', 'state', 'reason', 'broker', 'batchers', 'hotBuffer'],
   properties: {
     enabled: { type: 'boolean' },
-    state: { type: 'string', enum: ['disabled', 'ready', 'unconfigured'] },
-    reason: { type: 'string', nullable: true },
-    brokerConfigured: { type: 'boolean' }
+    state: { type: 'string', enum: ['disabled', 'ready', 'degraded', 'unconfigured'] },
+    reason: nullable(stringSchema()),
+    broker: streamingBrokerStatusSchema,
+    batchers: streamingBatcherStatusSchema,
+    hotBuffer: {
+      type: 'object',
+      required: ['enabled', 'state', 'datasets', 'healthy', 'lastRefreshAt', 'lastIngestAt'],
+      properties: {
+        enabled: { type: 'boolean' },
+        state: { type: 'string', enum: ['disabled', 'ready', 'unavailable'] },
+        datasets: integerSchema(),
+        healthy: { type: 'boolean' },
+        lastRefreshAt: nullable(stringSchema('date-time')),
+        lastIngestAt: nullable(stringSchema('date-time'))
+      }
+    }
   }
 };
 
@@ -2415,6 +2486,45 @@ const healthResponseSchema: OpenAPIV3.SchemaObject = {
 };
 
 const healthUnavailableResponseSchema: OpenAPIV3.SchemaObject = {
+  type: 'object',
+  required: ['status', 'features'],
+  properties: {
+    status: { type: 'string', enum: ['unavailable'] },
+    warnings: {
+      type: 'array',
+      items: { type: 'string' }
+    },
+    features: {
+      type: 'object',
+      required: ['streaming'],
+      properties: {
+        streaming: streamingStatusSchema
+      }
+    }
+  }
+};
+
+const readyResponseSchema: OpenAPIV3.SchemaObject = {
+  type: 'object',
+  required: ['status', 'features'],
+  properties: {
+    status: { type: 'string', enum: ['ready'] },
+    warnings: {
+      type: 'array',
+      items: { type: 'string' },
+      default: []
+    },
+    features: {
+      type: 'object',
+      required: ['streaming'],
+      properties: {
+        streaming: streamingStatusSchema
+      }
+    }
+  }
+};
+
+const readyUnavailableResponseSchema: OpenAPIV3.SchemaObject = {
   type: 'object',
   required: ['status', 'features'],
   properties: {
@@ -2531,8 +2641,14 @@ const components: OpenAPIV3.ComponentsObject = {
     WorkflowGraphCacheMeta: workflowGraphCacheMetaSchema,
     WorkflowGraphCacheStats: workflowGraphCacheStatsSchema,
     WorkflowGraphResponse: workflowGraphResponseSchema,
+    StreamingBrokerStatus: streamingBrokerStatusSchema,
+    StreamingBatcherConnectorStatus: streamingBatcherConnectorStatusSchema,
+    StreamingBatcherStatus: streamingBatcherStatusSchema,
+    StreamingStatus: streamingStatusSchema,
     HealthResponse: healthResponseSchema,
     HealthUnavailableResponse: healthUnavailableResponseSchema,
+    ReadyResponse: readyResponseSchema,
+    ReadyUnavailableResponse: readyUnavailableResponseSchema,
     ErrorResponse: errorResponseSchema
   },
   securitySchemes: {

--- a/services/core/src/openapi/definitions.ts
+++ b/services/core/src/openapi/definitions.ts
@@ -2489,7 +2489,7 @@ const healthUnavailableResponseSchema: OpenAPIV3.SchemaObject = {
   type: 'object',
   required: ['status', 'features'],
   properties: {
-    status: { type: 'string', enum: ['unavailable'] },
+    status: { type: 'string', enum: ['unavailable', 'degraded'] },
     warnings: {
       type: 'array',
       items: { type: 'string' }
@@ -2528,7 +2528,7 @@ const readyUnavailableResponseSchema: OpenAPIV3.SchemaObject = {
   type: 'object',
   required: ['status', 'features'],
   properties: {
-    status: { type: 'string', enum: ['unavailable'] },
+    status: { type: 'string', enum: ['unavailable', 'degraded'] },
     warnings: {
       type: 'array',
       items: { type: 'string' }

--- a/services/core/src/openapi/plugin.ts
+++ b/services/core/src/openapi/plugin.ts
@@ -51,6 +51,7 @@ const documentedRoutes = new Set<`${string}:${string}`>([
   'POST:/auth/api-keys',
   'DELETE:/auth/api-keys/:id',
   'GET:/health',
+  'GET:/readyz',
   'GET:/apps',
   'POST:/apps',
   'GET:/apps/:id',

--- a/services/core/src/streaming/status.ts
+++ b/services/core/src/streaming/status.ts
@@ -1,36 +1,156 @@
 import type { FeatureFlags } from '../config/featureFlags';
+import { getServiceBySlug } from '../db';
+import { fetchFromService } from '../clients/serviceClient';
 
-export type StreamingStatus = {
+export type StreamingOverallState = 'disabled' | 'ready' | 'degraded' | 'unconfigured';
+
+export interface StreamingBrokerStatus {
+  configured: boolean;
+  reachable: boolean | null;
+  lastCheckedAt: string | null;
+  error: string | null;
+}
+
+export interface StreamingBatcherConnectorStatus {
+  connectorId: string;
+  datasetSlug: string;
+  topic: string;
+  groupId: string;
+  state: 'starting' | 'running' | 'stopped' | 'error';
+  bufferedWindows: number;
+  bufferedRows: number;
+  openWindows: number;
+  lastMessageAt: string | null;
+  lastFlushAt: string | null;
+  lastEventTimestamp: string | null;
+  lastError: string | null;
+}
+
+export interface StreamingBatcherStatusSummary {
+  configured: number;
+  running: number;
+  failing: number;
+  state: 'disabled' | 'ready' | 'degraded';
+  connectors: StreamingBatcherConnectorStatus[];
+}
+
+export interface StreamingHotBufferStatus {
   enabled: boolean;
-  state: 'disabled' | 'ready' | 'unconfigured';
-  reason: string | null;
-  brokerConfigured: boolean;
-};
+  state: 'disabled' | 'ready' | 'unavailable';
+  datasets: number;
+  healthy: boolean;
+  lastRefreshAt: string | null;
+  lastIngestAt: string | null;
+}
 
-export function evaluateStreamingStatus(flags: FeatureFlags): StreamingStatus {
+export interface StreamingStatus {
+  enabled: boolean;
+  state: StreamingOverallState;
+  reason: string | null;
+  broker: StreamingBrokerStatus;
+  batchers: StreamingBatcherStatusSummary;
+  hotBuffer: StreamingHotBufferStatus;
+}
+
+function createFallbackStatus(
+  options: {
+    enabled: boolean;
+    state: StreamingOverallState;
+    reason: string | null;
+    brokerConfigured: boolean;
+  }
+): StreamingStatus {
+  const { enabled, state, reason, brokerConfigured } = options;
+  const batcherState: StreamingBatcherStatusSummary['state'] = !enabled || !brokerConfigured
+    ? 'disabled'
+    : 'degraded';
+
+  const hotBuffer: StreamingHotBufferStatus = enabled
+    ? {
+        enabled: true,
+        state: 'unavailable',
+        datasets: 0,
+        healthy: false,
+        lastRefreshAt: null,
+        lastIngestAt: null
+      }
+    : {
+        enabled: false,
+        state: 'disabled',
+        datasets: 0,
+        healthy: true,
+        lastRefreshAt: null,
+        lastIngestAt: null
+      };
+
+  return {
+    enabled,
+    state,
+    reason,
+    broker: {
+      configured: brokerConfigured,
+      reachable: brokerConfigured ? null : null,
+      lastCheckedAt: null,
+      error: reason
+    },
+    batchers: {
+      configured: 0,
+      running: 0,
+      failing: 0,
+      state: batcherState,
+      connectors: []
+    },
+    hotBuffer
+  } satisfies StreamingStatus;
+}
+
+export async function evaluateStreamingStatus(flags: FeatureFlags): Promise<StreamingStatus> {
   if (!flags.streaming.enabled) {
-    return {
+    return createFallbackStatus({
       enabled: false,
       state: 'disabled',
       reason: null,
       brokerConfigured: false
-    };
+    });
   }
 
   const brokerUrl = (process.env.APPHUB_STREAM_BROKER_URL ?? '').trim();
-  if (!brokerUrl) {
-    return {
+  const brokerConfigured = brokerUrl.length > 0;
+
+  if (!brokerConfigured) {
+    return createFallbackStatus({
       enabled: true,
       state: 'unconfigured',
       reason: 'APPHUB_STREAM_BROKER_URL is not set',
       brokerConfigured: false
-    };
+    });
   }
 
-  return {
-    enabled: true,
-    state: 'ready',
-    reason: null,
-    brokerConfigured: true
-  };
+  try {
+    const service = await getServiceBySlug('timestore');
+    if (!service) {
+      throw new Error('Timestore service is not registered');
+    }
+
+    const { response } = await fetchFromService(service, '/streaming/status', {
+      headers: {
+        Accept: 'application/json'
+      }
+    });
+
+    if (!response.ok) {
+      throw new Error(`timestore returned HTTP ${response.status}`);
+    }
+
+    const payload = (await response.json()) as StreamingStatus;
+    return payload;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return createFallbackStatus({
+      enabled: true,
+      state: 'degraded',
+      reason: `Failed to fetch streaming status: ${message}`,
+      brokerConfigured: true
+    });
+  }
 }

--- a/services/timestore/openapi.json
+++ b/services/timestore/openapi.json
@@ -99,6 +99,401 @@
           }
         }
       },
+      "StreamingBrokerStatus": {
+        "type": "object",
+        "required": [
+          "configured",
+          "reachable",
+          "lastCheckedAt",
+          "error"
+        ],
+        "properties": {
+          "configured": {
+            "type": "boolean"
+          },
+          "reachable": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "lastCheckedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "error": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "StreamingBatcherConnectorStatus": {
+        "type": "object",
+        "required": [
+          "connectorId",
+          "datasetSlug",
+          "topic",
+          "groupId",
+          "state",
+          "bufferedWindows",
+          "bufferedRows",
+          "openWindows",
+          "lastMessageAt",
+          "lastFlushAt",
+          "lastEventTimestamp",
+          "lastError"
+        ],
+        "properties": {
+          "connectorId": {
+            "type": "string"
+          },
+          "datasetSlug": {
+            "type": "string"
+          },
+          "topic": {
+            "type": "string"
+          },
+          "groupId": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "starting",
+              "running",
+              "stopped",
+              "error"
+            ]
+          },
+          "bufferedWindows": {
+            "type": "integer"
+          },
+          "bufferedRows": {
+            "type": "integer"
+          },
+          "openWindows": {
+            "type": "integer"
+          },
+          "lastMessageAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "lastFlushAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "lastEventTimestamp": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "lastError": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "StreamingBatcherStatus": {
+        "type": "object",
+        "required": [
+          "configured",
+          "running",
+          "failing",
+          "state",
+          "connectors"
+        ],
+        "properties": {
+          "configured": {
+            "type": "integer"
+          },
+          "running": {
+            "type": "integer"
+          },
+          "failing": {
+            "type": "integer"
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "disabled",
+              "ready",
+              "degraded"
+            ]
+          },
+          "connectors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "connectorId",
+                "datasetSlug",
+                "topic",
+                "groupId",
+                "state",
+                "bufferedWindows",
+                "bufferedRows",
+                "openWindows",
+                "lastMessageAt",
+                "lastFlushAt",
+                "lastEventTimestamp",
+                "lastError"
+              ],
+              "properties": {
+                "connectorId": {
+                  "type": "string"
+                },
+                "datasetSlug": {
+                  "type": "string"
+                },
+                "topic": {
+                  "type": "string"
+                },
+                "groupId": {
+                  "type": "string"
+                },
+                "state": {
+                  "type": "string",
+                  "enum": [
+                    "starting",
+                    "running",
+                    "stopped",
+                    "error"
+                  ]
+                },
+                "bufferedWindows": {
+                  "type": "integer"
+                },
+                "bufferedRows": {
+                  "type": "integer"
+                },
+                "openWindows": {
+                  "type": "integer"
+                },
+                "lastMessageAt": {
+                  "type": "string",
+                  "format": "date-time",
+                  "nullable": true
+                },
+                "lastFlushAt": {
+                  "type": "string",
+                  "format": "date-time",
+                  "nullable": true
+                },
+                "lastEventTimestamp": {
+                  "type": "string",
+                  "format": "date-time",
+                  "nullable": true
+                },
+                "lastError": {
+                  "type": "string",
+                  "nullable": true
+                }
+              }
+            }
+          }
+        }
+      },
+      "StreamingStatus": {
+        "type": "object",
+        "required": [
+          "enabled",
+          "state",
+          "reason",
+          "broker",
+          "batchers",
+          "hotBuffer"
+        ],
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "disabled",
+              "ready",
+              "degraded",
+              "unconfigured"
+            ]
+          },
+          "reason": {
+            "type": "string",
+            "nullable": true
+          },
+          "broker": {
+            "type": "object",
+            "required": [
+              "configured",
+              "reachable",
+              "lastCheckedAt",
+              "error"
+            ],
+            "properties": {
+              "configured": {
+                "type": "boolean"
+              },
+              "reachable": {
+                "type": "boolean",
+                "nullable": true
+              },
+              "lastCheckedAt": {
+                "type": "string",
+                "format": "date-time",
+                "nullable": true
+              },
+              "error": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          },
+          "batchers": {
+            "type": "object",
+            "required": [
+              "configured",
+              "running",
+              "failing",
+              "state",
+              "connectors"
+            ],
+            "properties": {
+              "configured": {
+                "type": "integer"
+              },
+              "running": {
+                "type": "integer"
+              },
+              "failing": {
+                "type": "integer"
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "disabled",
+                  "ready",
+                  "degraded"
+                ]
+              },
+              "connectors": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "connectorId",
+                    "datasetSlug",
+                    "topic",
+                    "groupId",
+                    "state",
+                    "bufferedWindows",
+                    "bufferedRows",
+                    "openWindows",
+                    "lastMessageAt",
+                    "lastFlushAt",
+                    "lastEventTimestamp",
+                    "lastError"
+                  ],
+                  "properties": {
+                    "connectorId": {
+                      "type": "string"
+                    },
+                    "datasetSlug": {
+                      "type": "string"
+                    },
+                    "topic": {
+                      "type": "string"
+                    },
+                    "groupId": {
+                      "type": "string"
+                    },
+                    "state": {
+                      "type": "string",
+                      "enum": [
+                        "starting",
+                        "running",
+                        "stopped",
+                        "error"
+                      ]
+                    },
+                    "bufferedWindows": {
+                      "type": "integer"
+                    },
+                    "bufferedRows": {
+                      "type": "integer"
+                    },
+                    "openWindows": {
+                      "type": "integer"
+                    },
+                    "lastMessageAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "lastFlushAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "lastEventTimestamp": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "lastError": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "hotBuffer": {
+            "allOf": [
+              {
+                "type": "object",
+                "required": [
+                  "enabled",
+                  "state",
+                  "datasets",
+                  "healthy",
+                  "lastRefreshAt",
+                  "lastIngestAt"
+                ],
+                "properties": {
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "state": {
+                    "type": "string",
+                    "enum": [
+                      "disabled",
+                      "ready",
+                      "unavailable"
+                    ]
+                  },
+                  "datasets": {
+                    "type": "integer"
+                  },
+                  "healthy": {
+                    "type": "boolean"
+                  },
+                  "lastRefreshAt": {
+                    "type": "string",
+                    "format": "date-time",
+                    "nullable": true
+                  },
+                  "lastIngestAt": {
+                    "type": "string",
+                    "format": "date-time",
+                    "nullable": true
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
       "HealthResponse": {
         "type": "object",
         "required": [
@@ -148,7 +543,10 @@
                 "required": [
                   "enabled",
                   "state",
-                  "brokerConfigured"
+                  "reason",
+                  "broker",
+                  "batchers",
+                  "hotBuffer"
                 ],
                 "properties": {
                   "enabled": {
@@ -159,6 +557,7 @@
                     "enum": [
                       "disabled",
                       "ready",
+                      "degraded",
                       "unconfigured"
                     ]
                   },
@@ -166,8 +565,176 @@
                     "type": "string",
                     "nullable": true
                   },
-                  "brokerConfigured": {
-                    "type": "boolean"
+                  "broker": {
+                    "type": "object",
+                    "required": [
+                      "configured",
+                      "reachable",
+                      "lastCheckedAt",
+                      "error"
+                    ],
+                    "properties": {
+                      "configured": {
+                        "type": "boolean"
+                      },
+                      "reachable": {
+                        "type": "boolean",
+                        "nullable": true
+                      },
+                      "lastCheckedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                      },
+                      "error": {
+                        "type": "string",
+                        "nullable": true
+                      }
+                    }
+                  },
+                  "batchers": {
+                    "type": "object",
+                    "required": [
+                      "configured",
+                      "running",
+                      "failing",
+                      "state",
+                      "connectors"
+                    ],
+                    "properties": {
+                      "configured": {
+                        "type": "integer"
+                      },
+                      "running": {
+                        "type": "integer"
+                      },
+                      "failing": {
+                        "type": "integer"
+                      },
+                      "state": {
+                        "type": "string",
+                        "enum": [
+                          "disabled",
+                          "ready",
+                          "degraded"
+                        ]
+                      },
+                      "connectors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": [
+                            "connectorId",
+                            "datasetSlug",
+                            "topic",
+                            "groupId",
+                            "state",
+                            "bufferedWindows",
+                            "bufferedRows",
+                            "openWindows",
+                            "lastMessageAt",
+                            "lastFlushAt",
+                            "lastEventTimestamp",
+                            "lastError"
+                          ],
+                          "properties": {
+                            "connectorId": {
+                              "type": "string"
+                            },
+                            "datasetSlug": {
+                              "type": "string"
+                            },
+                            "topic": {
+                              "type": "string"
+                            },
+                            "groupId": {
+                              "type": "string"
+                            },
+                            "state": {
+                              "type": "string",
+                              "enum": [
+                                "starting",
+                                "running",
+                                "stopped",
+                                "error"
+                              ]
+                            },
+                            "bufferedWindows": {
+                              "type": "integer"
+                            },
+                            "bufferedRows": {
+                              "type": "integer"
+                            },
+                            "openWindows": {
+                              "type": "integer"
+                            },
+                            "lastMessageAt": {
+                              "type": "string",
+                              "format": "date-time",
+                              "nullable": true
+                            },
+                            "lastFlushAt": {
+                              "type": "string",
+                              "format": "date-time",
+                              "nullable": true
+                            },
+                            "lastEventTimestamp": {
+                              "type": "string",
+                              "format": "date-time",
+                              "nullable": true
+                            },
+                            "lastError": {
+                              "type": "string",
+                              "nullable": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "hotBuffer": {
+                    "allOf": [
+                      {
+                        "type": "object",
+                        "required": [
+                          "enabled",
+                          "state",
+                          "datasets",
+                          "healthy",
+                          "lastRefreshAt",
+                          "lastIngestAt"
+                        ],
+                        "properties": {
+                          "enabled": {
+                            "type": "boolean"
+                          },
+                          "state": {
+                            "type": "string",
+                            "enum": [
+                              "disabled",
+                              "ready",
+                              "unavailable"
+                            ]
+                          },
+                          "datasets": {
+                            "type": "integer"
+                          },
+                          "healthy": {
+                            "type": "boolean"
+                          },
+                          "lastRefreshAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "nullable": true
+                          },
+                          "lastIngestAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "nullable": true
+                          }
+                        }
+                      }
+                    ]
                   }
                 }
               }
@@ -223,7 +790,10 @@
                 "required": [
                   "enabled",
                   "state",
-                  "brokerConfigured"
+                  "reason",
+                  "broker",
+                  "batchers",
+                  "hotBuffer"
                 ],
                 "properties": {
                   "enabled": {
@@ -234,6 +804,7 @@
                     "enum": [
                       "disabled",
                       "ready",
+                      "degraded",
                       "unconfigured"
                     ]
                   },
@@ -241,8 +812,176 @@
                     "type": "string",
                     "nullable": true
                   },
-                  "brokerConfigured": {
-                    "type": "boolean"
+                  "broker": {
+                    "type": "object",
+                    "required": [
+                      "configured",
+                      "reachable",
+                      "lastCheckedAt",
+                      "error"
+                    ],
+                    "properties": {
+                      "configured": {
+                        "type": "boolean"
+                      },
+                      "reachable": {
+                        "type": "boolean",
+                        "nullable": true
+                      },
+                      "lastCheckedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                      },
+                      "error": {
+                        "type": "string",
+                        "nullable": true
+                      }
+                    }
+                  },
+                  "batchers": {
+                    "type": "object",
+                    "required": [
+                      "configured",
+                      "running",
+                      "failing",
+                      "state",
+                      "connectors"
+                    ],
+                    "properties": {
+                      "configured": {
+                        "type": "integer"
+                      },
+                      "running": {
+                        "type": "integer"
+                      },
+                      "failing": {
+                        "type": "integer"
+                      },
+                      "state": {
+                        "type": "string",
+                        "enum": [
+                          "disabled",
+                          "ready",
+                          "degraded"
+                        ]
+                      },
+                      "connectors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": [
+                            "connectorId",
+                            "datasetSlug",
+                            "topic",
+                            "groupId",
+                            "state",
+                            "bufferedWindows",
+                            "bufferedRows",
+                            "openWindows",
+                            "lastMessageAt",
+                            "lastFlushAt",
+                            "lastEventTimestamp",
+                            "lastError"
+                          ],
+                          "properties": {
+                            "connectorId": {
+                              "type": "string"
+                            },
+                            "datasetSlug": {
+                              "type": "string"
+                            },
+                            "topic": {
+                              "type": "string"
+                            },
+                            "groupId": {
+                              "type": "string"
+                            },
+                            "state": {
+                              "type": "string",
+                              "enum": [
+                                "starting",
+                                "running",
+                                "stopped",
+                                "error"
+                              ]
+                            },
+                            "bufferedWindows": {
+                              "type": "integer"
+                            },
+                            "bufferedRows": {
+                              "type": "integer"
+                            },
+                            "openWindows": {
+                              "type": "integer"
+                            },
+                            "lastMessageAt": {
+                              "type": "string",
+                              "format": "date-time",
+                              "nullable": true
+                            },
+                            "lastFlushAt": {
+                              "type": "string",
+                              "format": "date-time",
+                              "nullable": true
+                            },
+                            "lastEventTimestamp": {
+                              "type": "string",
+                              "format": "date-time",
+                              "nullable": true
+                            },
+                            "lastError": {
+                              "type": "string",
+                              "nullable": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "hotBuffer": {
+                    "allOf": [
+                      {
+                        "type": "object",
+                        "required": [
+                          "enabled",
+                          "state",
+                          "datasets",
+                          "healthy",
+                          "lastRefreshAt",
+                          "lastIngestAt"
+                        ],
+                        "properties": {
+                          "enabled": {
+                            "type": "boolean"
+                          },
+                          "state": {
+                            "type": "string",
+                            "enum": [
+                              "disabled",
+                              "ready",
+                              "unavailable"
+                            ]
+                          },
+                          "datasets": {
+                            "type": "integer"
+                          },
+                          "healthy": {
+                            "type": "boolean"
+                          },
+                          "lastRefreshAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "nullable": true
+                          },
+                          "lastIngestAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "nullable": true
+                          }
+                        }
+                      }
+                    ]
                   }
                 }
               }
@@ -275,7 +1014,10 @@
                 "required": [
                   "enabled",
                   "state",
-                  "brokerConfigured"
+                  "reason",
+                  "broker",
+                  "batchers",
+                  "hotBuffer"
                 ],
                 "properties": {
                   "enabled": {
@@ -286,6 +1028,7 @@
                     "enum": [
                       "disabled",
                       "ready",
+                      "degraded",
                       "unconfigured"
                     ]
                   },
@@ -293,8 +1036,176 @@
                     "type": "string",
                     "nullable": true
                   },
-                  "brokerConfigured": {
-                    "type": "boolean"
+                  "broker": {
+                    "type": "object",
+                    "required": [
+                      "configured",
+                      "reachable",
+                      "lastCheckedAt",
+                      "error"
+                    ],
+                    "properties": {
+                      "configured": {
+                        "type": "boolean"
+                      },
+                      "reachable": {
+                        "type": "boolean",
+                        "nullable": true
+                      },
+                      "lastCheckedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                      },
+                      "error": {
+                        "type": "string",
+                        "nullable": true
+                      }
+                    }
+                  },
+                  "batchers": {
+                    "type": "object",
+                    "required": [
+                      "configured",
+                      "running",
+                      "failing",
+                      "state",
+                      "connectors"
+                    ],
+                    "properties": {
+                      "configured": {
+                        "type": "integer"
+                      },
+                      "running": {
+                        "type": "integer"
+                      },
+                      "failing": {
+                        "type": "integer"
+                      },
+                      "state": {
+                        "type": "string",
+                        "enum": [
+                          "disabled",
+                          "ready",
+                          "degraded"
+                        ]
+                      },
+                      "connectors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": [
+                            "connectorId",
+                            "datasetSlug",
+                            "topic",
+                            "groupId",
+                            "state",
+                            "bufferedWindows",
+                            "bufferedRows",
+                            "openWindows",
+                            "lastMessageAt",
+                            "lastFlushAt",
+                            "lastEventTimestamp",
+                            "lastError"
+                          ],
+                          "properties": {
+                            "connectorId": {
+                              "type": "string"
+                            },
+                            "datasetSlug": {
+                              "type": "string"
+                            },
+                            "topic": {
+                              "type": "string"
+                            },
+                            "groupId": {
+                              "type": "string"
+                            },
+                            "state": {
+                              "type": "string",
+                              "enum": [
+                                "starting",
+                                "running",
+                                "stopped",
+                                "error"
+                              ]
+                            },
+                            "bufferedWindows": {
+                              "type": "integer"
+                            },
+                            "bufferedRows": {
+                              "type": "integer"
+                            },
+                            "openWindows": {
+                              "type": "integer"
+                            },
+                            "lastMessageAt": {
+                              "type": "string",
+                              "format": "date-time",
+                              "nullable": true
+                            },
+                            "lastFlushAt": {
+                              "type": "string",
+                              "format": "date-time",
+                              "nullable": true
+                            },
+                            "lastEventTimestamp": {
+                              "type": "string",
+                              "format": "date-time",
+                              "nullable": true
+                            },
+                            "lastError": {
+                              "type": "string",
+                              "nullable": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "hotBuffer": {
+                    "allOf": [
+                      {
+                        "type": "object",
+                        "required": [
+                          "enabled",
+                          "state",
+                          "datasets",
+                          "healthy",
+                          "lastRefreshAt",
+                          "lastIngestAt"
+                        ],
+                        "properties": {
+                          "enabled": {
+                            "type": "boolean"
+                          },
+                          "state": {
+                            "type": "string",
+                            "enum": [
+                              "disabled",
+                              "ready",
+                              "unavailable"
+                            ]
+                          },
+                          "datasets": {
+                            "type": "integer"
+                          },
+                          "healthy": {
+                            "type": "boolean"
+                          },
+                          "lastRefreshAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "nullable": true
+                          },
+                          "lastIngestAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "nullable": true
+                          }
+                        }
+                      }
+                    ]
                   }
                 }
               }
@@ -355,7 +1266,10 @@
                 "required": [
                   "enabled",
                   "state",
-                  "brokerConfigured"
+                  "reason",
+                  "broker",
+                  "batchers",
+                  "hotBuffer"
                 ],
                 "properties": {
                   "enabled": {
@@ -366,6 +1280,7 @@
                     "enum": [
                       "disabled",
                       "ready",
+                      "degraded",
                       "unconfigured"
                     ]
                   },
@@ -373,8 +1288,176 @@
                     "type": "string",
                     "nullable": true
                   },
-                  "brokerConfigured": {
-                    "type": "boolean"
+                  "broker": {
+                    "type": "object",
+                    "required": [
+                      "configured",
+                      "reachable",
+                      "lastCheckedAt",
+                      "error"
+                    ],
+                    "properties": {
+                      "configured": {
+                        "type": "boolean"
+                      },
+                      "reachable": {
+                        "type": "boolean",
+                        "nullable": true
+                      },
+                      "lastCheckedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                      },
+                      "error": {
+                        "type": "string",
+                        "nullable": true
+                      }
+                    }
+                  },
+                  "batchers": {
+                    "type": "object",
+                    "required": [
+                      "configured",
+                      "running",
+                      "failing",
+                      "state",
+                      "connectors"
+                    ],
+                    "properties": {
+                      "configured": {
+                        "type": "integer"
+                      },
+                      "running": {
+                        "type": "integer"
+                      },
+                      "failing": {
+                        "type": "integer"
+                      },
+                      "state": {
+                        "type": "string",
+                        "enum": [
+                          "disabled",
+                          "ready",
+                          "degraded"
+                        ]
+                      },
+                      "connectors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": [
+                            "connectorId",
+                            "datasetSlug",
+                            "topic",
+                            "groupId",
+                            "state",
+                            "bufferedWindows",
+                            "bufferedRows",
+                            "openWindows",
+                            "lastMessageAt",
+                            "lastFlushAt",
+                            "lastEventTimestamp",
+                            "lastError"
+                          ],
+                          "properties": {
+                            "connectorId": {
+                              "type": "string"
+                            },
+                            "datasetSlug": {
+                              "type": "string"
+                            },
+                            "topic": {
+                              "type": "string"
+                            },
+                            "groupId": {
+                              "type": "string"
+                            },
+                            "state": {
+                              "type": "string",
+                              "enum": [
+                                "starting",
+                                "running",
+                                "stopped",
+                                "error"
+                              ]
+                            },
+                            "bufferedWindows": {
+                              "type": "integer"
+                            },
+                            "bufferedRows": {
+                              "type": "integer"
+                            },
+                            "openWindows": {
+                              "type": "integer"
+                            },
+                            "lastMessageAt": {
+                              "type": "string",
+                              "format": "date-time",
+                              "nullable": true
+                            },
+                            "lastFlushAt": {
+                              "type": "string",
+                              "format": "date-time",
+                              "nullable": true
+                            },
+                            "lastEventTimestamp": {
+                              "type": "string",
+                              "format": "date-time",
+                              "nullable": true
+                            },
+                            "lastError": {
+                              "type": "string",
+                              "nullable": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "hotBuffer": {
+                    "allOf": [
+                      {
+                        "type": "object",
+                        "required": [
+                          "enabled",
+                          "state",
+                          "datasets",
+                          "healthy",
+                          "lastRefreshAt",
+                          "lastIngestAt"
+                        ],
+                        "properties": {
+                          "enabled": {
+                            "type": "boolean"
+                          },
+                          "state": {
+                            "type": "string",
+                            "enum": [
+                              "disabled",
+                              "ready",
+                              "unavailable"
+                            ]
+                          },
+                          "datasets": {
+                            "type": "integer"
+                          },
+                          "healthy": {
+                            "type": "boolean"
+                          },
+                          "lastRefreshAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "nullable": true
+                          },
+                          "lastIngestAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "nullable": true
+                          }
+                        }
+                      }
+                    ]
                   }
                 }
               }
@@ -3366,6 +4449,447 @@
       "def-4": {
         "type": "object",
         "required": [
+          "configured",
+          "reachable",
+          "lastCheckedAt",
+          "error"
+        ],
+        "properties": {
+          "configured": {
+            "type": "boolean"
+          },
+          "reachable": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "lastCheckedAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "error": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "title": "https://timestore.apphub/schemas/StreamingBrokerStatus.json"
+      },
+      "def-5": {
+        "type": "object",
+        "required": [
+          "connectorId",
+          "datasetSlug",
+          "topic",
+          "groupId",
+          "state",
+          "bufferedWindows",
+          "bufferedRows",
+          "openWindows",
+          "lastMessageAt",
+          "lastFlushAt",
+          "lastEventTimestamp",
+          "lastError"
+        ],
+        "properties": {
+          "connectorId": {
+            "type": "string"
+          },
+          "datasetSlug": {
+            "type": "string"
+          },
+          "topic": {
+            "type": "string"
+          },
+          "groupId": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "starting",
+              "running",
+              "stopped",
+              "error"
+            ]
+          },
+          "bufferedWindows": {
+            "type": "integer"
+          },
+          "bufferedRows": {
+            "type": "integer"
+          },
+          "openWindows": {
+            "type": "integer"
+          },
+          "lastMessageAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "lastFlushAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "lastEventTimestamp": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "lastError": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "title": "https://timestore.apphub/schemas/StreamingBatcherConnectorStatus.json"
+      },
+      "def-6": {
+        "type": "object",
+        "required": [
+          "configured",
+          "running",
+          "failing",
+          "state",
+          "connectors"
+        ],
+        "properties": {
+          "configured": {
+            "type": "integer"
+          },
+          "running": {
+            "type": "integer"
+          },
+          "failing": {
+            "type": "integer"
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "disabled",
+              "ready",
+              "degraded"
+            ]
+          },
+          "connectors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "connectorId",
+                "datasetSlug",
+                "topic",
+                "groupId",
+                "state",
+                "bufferedWindows",
+                "bufferedRows",
+                "openWindows",
+                "lastMessageAt",
+                "lastFlushAt",
+                "lastEventTimestamp",
+                "lastError"
+              ],
+              "properties": {
+                "connectorId": {
+                  "type": "string"
+                },
+                "datasetSlug": {
+                  "type": "string"
+                },
+                "topic": {
+                  "type": "string"
+                },
+                "groupId": {
+                  "type": "string"
+                },
+                "state": {
+                  "type": "string",
+                  "enum": [
+                    "starting",
+                    "running",
+                    "stopped",
+                    "error"
+                  ]
+                },
+                "bufferedWindows": {
+                  "type": "integer"
+                },
+                "bufferedRows": {
+                  "type": "integer"
+                },
+                "openWindows": {
+                  "type": "integer"
+                },
+                "lastMessageAt": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "format": "date-time"
+                },
+                "lastFlushAt": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "format": "date-time"
+                },
+                "lastEventTimestamp": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "format": "date-time"
+                },
+                "lastError": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "title": "https://timestore.apphub/schemas/StreamingBatcherStatus.json"
+      },
+      "def-7": {
+        "type": "object",
+        "required": [
+          "enabled",
+          "state",
+          "reason",
+          "broker",
+          "batchers",
+          "hotBuffer"
+        ],
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "disabled",
+              "ready",
+              "degraded",
+              "unconfigured"
+            ]
+          },
+          "reason": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "broker": {
+            "type": "object",
+            "required": [
+              "configured",
+              "reachable",
+              "lastCheckedAt",
+              "error"
+            ],
+            "properties": {
+              "configured": {
+                "type": "boolean"
+              },
+              "reachable": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "lastCheckedAt": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "date-time"
+              },
+              "error": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          },
+          "batchers": {
+            "type": "object",
+            "required": [
+              "configured",
+              "running",
+              "failing",
+              "state",
+              "connectors"
+            ],
+            "properties": {
+              "configured": {
+                "type": "integer"
+              },
+              "running": {
+                "type": "integer"
+              },
+              "failing": {
+                "type": "integer"
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "disabled",
+                  "ready",
+                  "degraded"
+                ]
+              },
+              "connectors": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "connectorId",
+                    "datasetSlug",
+                    "topic",
+                    "groupId",
+                    "state",
+                    "bufferedWindows",
+                    "bufferedRows",
+                    "openWindows",
+                    "lastMessageAt",
+                    "lastFlushAt",
+                    "lastEventTimestamp",
+                    "lastError"
+                  ],
+                  "properties": {
+                    "connectorId": {
+                      "type": "string"
+                    },
+                    "datasetSlug": {
+                      "type": "string"
+                    },
+                    "topic": {
+                      "type": "string"
+                    },
+                    "groupId": {
+                      "type": "string"
+                    },
+                    "state": {
+                      "type": "string",
+                      "enum": [
+                        "starting",
+                        "running",
+                        "stopped",
+                        "error"
+                      ]
+                    },
+                    "bufferedWindows": {
+                      "type": "integer"
+                    },
+                    "bufferedRows": {
+                      "type": "integer"
+                    },
+                    "openWindows": {
+                      "type": "integer"
+                    },
+                    "lastMessageAt": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "format": "date-time"
+                    },
+                    "lastFlushAt": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "format": "date-time"
+                    },
+                    "lastEventTimestamp": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "format": "date-time"
+                    },
+                    "lastError": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "hotBuffer": {
+            "allOf": [
+              {
+                "type": "object",
+                "required": [
+                  "enabled",
+                  "state",
+                  "datasets",
+                  "healthy",
+                  "lastRefreshAt",
+                  "lastIngestAt"
+                ],
+                "properties": {
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "state": {
+                    "type": "string",
+                    "enum": [
+                      "disabled",
+                      "ready",
+                      "unavailable"
+                    ]
+                  },
+                  "datasets": {
+                    "type": "integer"
+                  },
+                  "healthy": {
+                    "type": "boolean"
+                  },
+                  "lastRefreshAt": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "format": "date-time"
+                  },
+                  "lastIngestAt": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "format": "date-time"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "title": "https://timestore.apphub/schemas/StreamingStatus.json"
+      },
+      "def-8": {
+        "type": "object",
+        "required": [
           "status",
           "lifecycle",
           "features"
@@ -3414,7 +4938,10 @@
                 "required": [
                   "enabled",
                   "state",
-                  "brokerConfigured"
+                  "reason",
+                  "broker",
+                  "batchers",
+                  "hotBuffer"
                 ],
                 "properties": {
                   "enabled": {
@@ -3425,6 +4952,7 @@
                     "enum": [
                       "disabled",
                       "ready",
+                      "degraded",
                       "unconfigured"
                     ]
                   },
@@ -3434,8 +4962,194 @@
                       "string"
                     ]
                   },
-                  "brokerConfigured": {
-                    "type": "boolean"
+                  "broker": {
+                    "type": "object",
+                    "required": [
+                      "configured",
+                      "reachable",
+                      "lastCheckedAt",
+                      "error"
+                    ],
+                    "properties": {
+                      "configured": {
+                        "type": "boolean"
+                      },
+                      "reachable": {
+                        "type": [
+                          "null",
+                          "boolean"
+                        ]
+                      },
+                      "lastCheckedAt": {
+                        "type": [
+                          "null",
+                          "string"
+                        ],
+                        "format": "date-time"
+                      },
+                      "error": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      }
+                    }
+                  },
+                  "batchers": {
+                    "type": "object",
+                    "required": [
+                      "configured",
+                      "running",
+                      "failing",
+                      "state",
+                      "connectors"
+                    ],
+                    "properties": {
+                      "configured": {
+                        "type": "integer"
+                      },
+                      "running": {
+                        "type": "integer"
+                      },
+                      "failing": {
+                        "type": "integer"
+                      },
+                      "state": {
+                        "type": "string",
+                        "enum": [
+                          "disabled",
+                          "ready",
+                          "degraded"
+                        ]
+                      },
+                      "connectors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": [
+                            "connectorId",
+                            "datasetSlug",
+                            "topic",
+                            "groupId",
+                            "state",
+                            "bufferedWindows",
+                            "bufferedRows",
+                            "openWindows",
+                            "lastMessageAt",
+                            "lastFlushAt",
+                            "lastEventTimestamp",
+                            "lastError"
+                          ],
+                          "properties": {
+                            "connectorId": {
+                              "type": "string"
+                            },
+                            "datasetSlug": {
+                              "type": "string"
+                            },
+                            "topic": {
+                              "type": "string"
+                            },
+                            "groupId": {
+                              "type": "string"
+                            },
+                            "state": {
+                              "type": "string",
+                              "enum": [
+                                "starting",
+                                "running",
+                                "stopped",
+                                "error"
+                              ]
+                            },
+                            "bufferedWindows": {
+                              "type": "integer"
+                            },
+                            "bufferedRows": {
+                              "type": "integer"
+                            },
+                            "openWindows": {
+                              "type": "integer"
+                            },
+                            "lastMessageAt": {
+                              "type": [
+                                "null",
+                                "string"
+                              ],
+                              "format": "date-time"
+                            },
+                            "lastFlushAt": {
+                              "type": [
+                                "null",
+                                "string"
+                              ],
+                              "format": "date-time"
+                            },
+                            "lastEventTimestamp": {
+                              "type": [
+                                "null",
+                                "string"
+                              ],
+                              "format": "date-time"
+                            },
+                            "lastError": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "hotBuffer": {
+                    "allOf": [
+                      {
+                        "type": "object",
+                        "required": [
+                          "enabled",
+                          "state",
+                          "datasets",
+                          "healthy",
+                          "lastRefreshAt",
+                          "lastIngestAt"
+                        ],
+                        "properties": {
+                          "enabled": {
+                            "type": "boolean"
+                          },
+                          "state": {
+                            "type": "string",
+                            "enum": [
+                              "disabled",
+                              "ready",
+                              "unavailable"
+                            ]
+                          },
+                          "datasets": {
+                            "type": "integer"
+                          },
+                          "healthy": {
+                            "type": "boolean"
+                          },
+                          "lastRefreshAt": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "format": "date-time"
+                          },
+                          "lastIngestAt": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "format": "date-time"
+                          }
+                        }
+                      }
+                    ]
                   }
                 }
               }
@@ -3444,7 +5158,7 @@
         },
         "title": "https://timestore.apphub/schemas/HealthResponse.json"
       },
-      "def-5": {
+      "def-9": {
         "type": "object",
         "required": [
           "status",
@@ -3494,7 +5208,10 @@
                 "required": [
                   "enabled",
                   "state",
-                  "brokerConfigured"
+                  "reason",
+                  "broker",
+                  "batchers",
+                  "hotBuffer"
                 ],
                 "properties": {
                   "enabled": {
@@ -3505,6 +5222,7 @@
                     "enum": [
                       "disabled",
                       "ready",
+                      "degraded",
                       "unconfigured"
                     ]
                   },
@@ -3514,8 +5232,194 @@
                       "string"
                     ]
                   },
-                  "brokerConfigured": {
-                    "type": "boolean"
+                  "broker": {
+                    "type": "object",
+                    "required": [
+                      "configured",
+                      "reachable",
+                      "lastCheckedAt",
+                      "error"
+                    ],
+                    "properties": {
+                      "configured": {
+                        "type": "boolean"
+                      },
+                      "reachable": {
+                        "type": [
+                          "null",
+                          "boolean"
+                        ]
+                      },
+                      "lastCheckedAt": {
+                        "type": [
+                          "null",
+                          "string"
+                        ],
+                        "format": "date-time"
+                      },
+                      "error": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      }
+                    }
+                  },
+                  "batchers": {
+                    "type": "object",
+                    "required": [
+                      "configured",
+                      "running",
+                      "failing",
+                      "state",
+                      "connectors"
+                    ],
+                    "properties": {
+                      "configured": {
+                        "type": "integer"
+                      },
+                      "running": {
+                        "type": "integer"
+                      },
+                      "failing": {
+                        "type": "integer"
+                      },
+                      "state": {
+                        "type": "string",
+                        "enum": [
+                          "disabled",
+                          "ready",
+                          "degraded"
+                        ]
+                      },
+                      "connectors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": [
+                            "connectorId",
+                            "datasetSlug",
+                            "topic",
+                            "groupId",
+                            "state",
+                            "bufferedWindows",
+                            "bufferedRows",
+                            "openWindows",
+                            "lastMessageAt",
+                            "lastFlushAt",
+                            "lastEventTimestamp",
+                            "lastError"
+                          ],
+                          "properties": {
+                            "connectorId": {
+                              "type": "string"
+                            },
+                            "datasetSlug": {
+                              "type": "string"
+                            },
+                            "topic": {
+                              "type": "string"
+                            },
+                            "groupId": {
+                              "type": "string"
+                            },
+                            "state": {
+                              "type": "string",
+                              "enum": [
+                                "starting",
+                                "running",
+                                "stopped",
+                                "error"
+                              ]
+                            },
+                            "bufferedWindows": {
+                              "type": "integer"
+                            },
+                            "bufferedRows": {
+                              "type": "integer"
+                            },
+                            "openWindows": {
+                              "type": "integer"
+                            },
+                            "lastMessageAt": {
+                              "type": [
+                                "null",
+                                "string"
+                              ],
+                              "format": "date-time"
+                            },
+                            "lastFlushAt": {
+                              "type": [
+                                "null",
+                                "string"
+                              ],
+                              "format": "date-time"
+                            },
+                            "lastEventTimestamp": {
+                              "type": [
+                                "null",
+                                "string"
+                              ],
+                              "format": "date-time"
+                            },
+                            "lastError": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "hotBuffer": {
+                    "allOf": [
+                      {
+                        "type": "object",
+                        "required": [
+                          "enabled",
+                          "state",
+                          "datasets",
+                          "healthy",
+                          "lastRefreshAt",
+                          "lastIngestAt"
+                        ],
+                        "properties": {
+                          "enabled": {
+                            "type": "boolean"
+                          },
+                          "state": {
+                            "type": "string",
+                            "enum": [
+                              "disabled",
+                              "ready",
+                              "unavailable"
+                            ]
+                          },
+                          "datasets": {
+                            "type": "integer"
+                          },
+                          "healthy": {
+                            "type": "boolean"
+                          },
+                          "lastRefreshAt": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "format": "date-time"
+                          },
+                          "lastIngestAt": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "format": "date-time"
+                          }
+                        }
+                      }
+                    ]
                   }
                 }
               }
@@ -3524,7 +5428,7 @@
         },
         "title": "https://timestore.apphub/schemas/HealthUnavailableResponse.json"
       },
-      "def-6": {
+      "def-10": {
         "type": "object",
         "required": [
           "status",
@@ -3549,7 +5453,10 @@
                 "required": [
                   "enabled",
                   "state",
-                  "brokerConfigured"
+                  "reason",
+                  "broker",
+                  "batchers",
+                  "hotBuffer"
                 ],
                 "properties": {
                   "enabled": {
@@ -3560,6 +5467,7 @@
                     "enum": [
                       "disabled",
                       "ready",
+                      "degraded",
                       "unconfigured"
                     ]
                   },
@@ -3569,8 +5477,194 @@
                       "string"
                     ]
                   },
-                  "brokerConfigured": {
-                    "type": "boolean"
+                  "broker": {
+                    "type": "object",
+                    "required": [
+                      "configured",
+                      "reachable",
+                      "lastCheckedAt",
+                      "error"
+                    ],
+                    "properties": {
+                      "configured": {
+                        "type": "boolean"
+                      },
+                      "reachable": {
+                        "type": [
+                          "null",
+                          "boolean"
+                        ]
+                      },
+                      "lastCheckedAt": {
+                        "type": [
+                          "null",
+                          "string"
+                        ],
+                        "format": "date-time"
+                      },
+                      "error": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      }
+                    }
+                  },
+                  "batchers": {
+                    "type": "object",
+                    "required": [
+                      "configured",
+                      "running",
+                      "failing",
+                      "state",
+                      "connectors"
+                    ],
+                    "properties": {
+                      "configured": {
+                        "type": "integer"
+                      },
+                      "running": {
+                        "type": "integer"
+                      },
+                      "failing": {
+                        "type": "integer"
+                      },
+                      "state": {
+                        "type": "string",
+                        "enum": [
+                          "disabled",
+                          "ready",
+                          "degraded"
+                        ]
+                      },
+                      "connectors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": [
+                            "connectorId",
+                            "datasetSlug",
+                            "topic",
+                            "groupId",
+                            "state",
+                            "bufferedWindows",
+                            "bufferedRows",
+                            "openWindows",
+                            "lastMessageAt",
+                            "lastFlushAt",
+                            "lastEventTimestamp",
+                            "lastError"
+                          ],
+                          "properties": {
+                            "connectorId": {
+                              "type": "string"
+                            },
+                            "datasetSlug": {
+                              "type": "string"
+                            },
+                            "topic": {
+                              "type": "string"
+                            },
+                            "groupId": {
+                              "type": "string"
+                            },
+                            "state": {
+                              "type": "string",
+                              "enum": [
+                                "starting",
+                                "running",
+                                "stopped",
+                                "error"
+                              ]
+                            },
+                            "bufferedWindows": {
+                              "type": "integer"
+                            },
+                            "bufferedRows": {
+                              "type": "integer"
+                            },
+                            "openWindows": {
+                              "type": "integer"
+                            },
+                            "lastMessageAt": {
+                              "type": [
+                                "null",
+                                "string"
+                              ],
+                              "format": "date-time"
+                            },
+                            "lastFlushAt": {
+                              "type": [
+                                "null",
+                                "string"
+                              ],
+                              "format": "date-time"
+                            },
+                            "lastEventTimestamp": {
+                              "type": [
+                                "null",
+                                "string"
+                              ],
+                              "format": "date-time"
+                            },
+                            "lastError": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "hotBuffer": {
+                    "allOf": [
+                      {
+                        "type": "object",
+                        "required": [
+                          "enabled",
+                          "state",
+                          "datasets",
+                          "healthy",
+                          "lastRefreshAt",
+                          "lastIngestAt"
+                        ],
+                        "properties": {
+                          "enabled": {
+                            "type": "boolean"
+                          },
+                          "state": {
+                            "type": "string",
+                            "enum": [
+                              "disabled",
+                              "ready",
+                              "unavailable"
+                            ]
+                          },
+                          "datasets": {
+                            "type": "integer"
+                          },
+                          "healthy": {
+                            "type": "boolean"
+                          },
+                          "lastRefreshAt": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "format": "date-time"
+                          },
+                          "lastIngestAt": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "format": "date-time"
+                          }
+                        }
+                      }
+                    ]
                   }
                 }
               }
@@ -3579,7 +5673,7 @@
         },
         "title": "https://timestore.apphub/schemas/ReadyResponse.json"
       },
-      "def-7": {
+      "def-11": {
         "type": "object",
         "required": [
           "status",
@@ -3634,7 +5728,10 @@
                 "required": [
                   "enabled",
                   "state",
-                  "brokerConfigured"
+                  "reason",
+                  "broker",
+                  "batchers",
+                  "hotBuffer"
                 ],
                 "properties": {
                   "enabled": {
@@ -3645,6 +5742,7 @@
                     "enum": [
                       "disabled",
                       "ready",
+                      "degraded",
                       "unconfigured"
                     ]
                   },
@@ -3654,8 +5752,194 @@
                       "string"
                     ]
                   },
-                  "brokerConfigured": {
-                    "type": "boolean"
+                  "broker": {
+                    "type": "object",
+                    "required": [
+                      "configured",
+                      "reachable",
+                      "lastCheckedAt",
+                      "error"
+                    ],
+                    "properties": {
+                      "configured": {
+                        "type": "boolean"
+                      },
+                      "reachable": {
+                        "type": [
+                          "null",
+                          "boolean"
+                        ]
+                      },
+                      "lastCheckedAt": {
+                        "type": [
+                          "null",
+                          "string"
+                        ],
+                        "format": "date-time"
+                      },
+                      "error": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      }
+                    }
+                  },
+                  "batchers": {
+                    "type": "object",
+                    "required": [
+                      "configured",
+                      "running",
+                      "failing",
+                      "state",
+                      "connectors"
+                    ],
+                    "properties": {
+                      "configured": {
+                        "type": "integer"
+                      },
+                      "running": {
+                        "type": "integer"
+                      },
+                      "failing": {
+                        "type": "integer"
+                      },
+                      "state": {
+                        "type": "string",
+                        "enum": [
+                          "disabled",
+                          "ready",
+                          "degraded"
+                        ]
+                      },
+                      "connectors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": [
+                            "connectorId",
+                            "datasetSlug",
+                            "topic",
+                            "groupId",
+                            "state",
+                            "bufferedWindows",
+                            "bufferedRows",
+                            "openWindows",
+                            "lastMessageAt",
+                            "lastFlushAt",
+                            "lastEventTimestamp",
+                            "lastError"
+                          ],
+                          "properties": {
+                            "connectorId": {
+                              "type": "string"
+                            },
+                            "datasetSlug": {
+                              "type": "string"
+                            },
+                            "topic": {
+                              "type": "string"
+                            },
+                            "groupId": {
+                              "type": "string"
+                            },
+                            "state": {
+                              "type": "string",
+                              "enum": [
+                                "starting",
+                                "running",
+                                "stopped",
+                                "error"
+                              ]
+                            },
+                            "bufferedWindows": {
+                              "type": "integer"
+                            },
+                            "bufferedRows": {
+                              "type": "integer"
+                            },
+                            "openWindows": {
+                              "type": "integer"
+                            },
+                            "lastMessageAt": {
+                              "type": [
+                                "null",
+                                "string"
+                              ],
+                              "format": "date-time"
+                            },
+                            "lastFlushAt": {
+                              "type": [
+                                "null",
+                                "string"
+                              ],
+                              "format": "date-time"
+                            },
+                            "lastEventTimestamp": {
+                              "type": [
+                                "null",
+                                "string"
+                              ],
+                              "format": "date-time"
+                            },
+                            "lastError": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "hotBuffer": {
+                    "allOf": [
+                      {
+                        "type": "object",
+                        "required": [
+                          "enabled",
+                          "state",
+                          "datasets",
+                          "healthy",
+                          "lastRefreshAt",
+                          "lastIngestAt"
+                        ],
+                        "properties": {
+                          "enabled": {
+                            "type": "boolean"
+                          },
+                          "state": {
+                            "type": "string",
+                            "enum": [
+                              "disabled",
+                              "ready",
+                              "unavailable"
+                            ]
+                          },
+                          "datasets": {
+                            "type": "integer"
+                          },
+                          "healthy": {
+                            "type": "boolean"
+                          },
+                          "lastRefreshAt": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "format": "date-time"
+                          },
+                          "lastIngestAt": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "format": "date-time"
+                          }
+                        }
+                      }
+                    ]
                   }
                 }
               }
@@ -3664,7 +5948,7 @@
         },
         "title": "https://timestore.apphub/schemas/ReadyUnavailableResponse.json"
       },
-      "def-8": {
+      "def-12": {
         "type": "object",
         "required": [
           "datasetSlug"
@@ -3678,7 +5962,7 @@
         },
         "title": "https://timestore.apphub/schemas/DatasetSlugParams.json"
       },
-      "def-9": {
+      "def-13": {
         "type": "object",
         "required": [
           "id",
@@ -3700,7 +5984,7 @@
         },
         "title": "https://timestore.apphub/schemas/IngestionActor.json"
       },
-      "def-10": {
+      "def-14": {
         "type": "object",
         "required": [
           "name",
@@ -3725,7 +6009,7 @@
         },
         "title": "https://timestore.apphub/schemas/IngestionFieldDefinition.json"
       },
-      "def-11": {
+      "def-15": {
         "type": "object",
         "required": [
           "fields"
@@ -3785,7 +6069,7 @@
         },
         "title": "https://timestore.apphub/schemas/IngestionSchema.json"
       },
-      "def-12": {
+      "def-16": {
         "type": "object",
         "required": [
           "key",
@@ -3831,7 +6115,7 @@
         },
         "title": "https://timestore.apphub/schemas/IngestionPartition.json"
       },
-      "def-13": {
+      "def-17": {
         "type": "object",
         "required": [
           "schema",
@@ -4039,7 +6323,7 @@
         },
         "title": "https://timestore.apphub/schemas/DatasetIngestionRequest.json"
       },
-      "def-14": {
+      "def-18": {
         "type": "object",
         "required": [
           "id",
@@ -4088,7 +6372,7 @@
         },
         "title": "https://timestore.apphub/schemas/StorageTarget.json"
       },
-      "def-15": {
+      "def-19": {
         "type": "object",
         "required": [
           "id",
@@ -4154,7 +6438,7 @@
         },
         "title": "https://timestore.apphub/schemas/Dataset.json"
       },
-      "def-16": {
+      "def-20": {
         "type": "object",
         "required": [
           "id",
@@ -4364,7 +6648,7 @@
         },
         "title": "https://timestore.apphub/schemas/DatasetManifest.json"
       },
-      "def-17": {
+      "def-21": {
         "type": "object",
         "required": [
           "id",
@@ -4470,7 +6754,7 @@
         },
         "title": "https://timestore.apphub/schemas/DatasetPartition.json"
       },
-      "def-18": {
+      "def-22": {
         "type": "object",
         "required": [
           "mode",
@@ -4810,7 +7094,7 @@
         },
         "title": "https://timestore.apphub/schemas/DatasetIngestionInlineResponse.json"
       },
-      "def-19": {
+      "def-23": {
         "type": "object",
         "required": [
           "mode",
@@ -4830,7 +7114,7 @@
         },
         "title": "https://timestore.apphub/schemas/DatasetIngestionQueuedResponse.json"
       },
-      "def-20": {
+      "def-24": {
         "type": "object",
         "additionalProperties": false,
         "properties": {
@@ -4871,7 +7155,7 @@
         ],
         "title": "https://timestore.apphub/schemas/StringPartitionPredicate.json"
       },
-      "def-21": {
+      "def-25": {
         "type": "object",
         "additionalProperties": false,
         "properties": {
@@ -4924,7 +7208,7 @@
         },
         "title": "https://timestore.apphub/schemas/NumberPartitionPredicate.json"
       },
-      "def-22": {
+      "def-26": {
         "type": "object",
         "additionalProperties": false,
         "properties": {
@@ -4983,7 +7267,7 @@
         },
         "title": "https://timestore.apphub/schemas/TimestampPartitionPredicate.json"
       },
-      "def-23": {
+      "def-27": {
         "type": "object",
         "additionalProperties": false,
         "properties": {
@@ -5012,7 +7296,7 @@
         },
         "title": "https://timestore.apphub/schemas/BooleanColumnPredicate.json"
       },
-      "def-24": {
+      "def-28": {
         "type": "array",
         "minItems": 1,
         "description": "Shorthand for an equality/inclusion check across string values.",
@@ -5021,7 +7305,7 @@
         },
         "title": "https://timestore.apphub/schemas/StringArrayPredicate.json"
       },
-      "def-25": {
+      "def-29": {
         "type": "object",
         "additionalProperties": false,
         "properties": {
@@ -5384,7 +7668,7 @@
         },
         "title": "https://timestore.apphub/schemas/PartitionFilters.json"
       },
-      "def-26": {
+      "def-30": {
         "oneOf": [
           {
             "type": "object",
@@ -5501,7 +7785,7 @@
         ],
         "title": "https://timestore.apphub/schemas/DownsampleAggregation.json"
       },
-      "def-27": {
+      "def-31": {
         "type": "object",
         "additionalProperties": false,
         "required": [
@@ -5648,7 +7932,7 @@
         },
         "title": "https://timestore.apphub/schemas/DownsampleRequest.json"
       },
-      "def-28": {
+      "def-32": {
         "type": "object",
         "required": [
           "timeRange"
@@ -6212,7 +8496,7 @@
         },
         "title": "https://timestore.apphub/schemas/DatasetQueryRequest.json"
       },
-      "def-29": {
+      "def-33": {
         "type": "object",
         "required": [
           "rows",
@@ -6301,7 +8585,7 @@
         },
         "title": "https://timestore.apphub/schemas/DatasetQueryResponse.json"
       },
-      "def-30": {
+      "def-34": {
         "type": "object",
         "required": [
           "sql"
@@ -6351,7 +8635,7 @@
         },
         "title": "https://timestore.apphub/schemas/SqlQueryRequest.json"
       },
-      "def-31": {
+      "def-35": {
         "type": "object",
         "required": [
           "name",
@@ -6379,7 +8663,7 @@
         },
         "title": "https://timestore.apphub/schemas/SqlSchemaColumn.json"
       },
-      "def-32": {
+      "def-36": {
         "type": "object",
         "required": [
           "name",
@@ -6437,7 +8721,7 @@
         },
         "title": "https://timestore.apphub/schemas/SqlSchemaTable.json"
       },
-      "def-33": {
+      "def-37": {
         "type": "object",
         "required": [
           "fetchedAt",
@@ -6518,7 +8802,7 @@
         },
         "title": "https://timestore.apphub/schemas/SqlSchemaResponse.json"
       },
-      "def-34": {
+      "def-38": {
         "type": "object",
         "required": [
           "rowCount",
@@ -6534,7 +8818,7 @@
         },
         "title": "https://timestore.apphub/schemas/SqlReadStatistics.json"
       },
-      "def-35": {
+      "def-39": {
         "type": "object",
         "required": [
           "executionId",
@@ -6644,7 +8928,7 @@
         },
         "title": "https://timestore.apphub/schemas/SqlReadResponse.json"
       },
-      "def-36": {
+      "def-40": {
         "type": "object",
         "additionalProperties": false,
         "properties": {
@@ -6663,7 +8947,7 @@
         },
         "title": "https://timestore.apphub/schemas/SqlSavedQueryStats.json"
       },
-      "def-37": {
+      "def-41": {
         "type": "object",
         "required": [
           "id",
@@ -6723,7 +9007,7 @@
         },
         "title": "https://timestore.apphub/schemas/SqlSavedQuery.json"
       },
-      "def-38": {
+      "def-42": {
         "type": "object",
         "required": [
           "savedQueries"
@@ -6794,7 +9078,7 @@
         },
         "title": "https://timestore.apphub/schemas/SqlSavedQueryListResponse.json"
       },
-      "def-39": {
+      "def-43": {
         "type": "object",
         "required": [
           "savedQuery"
@@ -6862,7 +9146,7 @@
         },
         "title": "https://timestore.apphub/schemas/SqlSavedQueryResponse.json"
       },
-      "def-40": {
+      "def-44": {
         "type": "object",
         "required": [
           "id"
@@ -6875,7 +9159,7 @@
         },
         "title": "https://timestore.apphub/schemas/SqlSavedQueryParams.json"
       },
-      "def-41": {
+      "def-45": {
         "type": "object",
         "required": [
           "statement"
@@ -6916,7 +9200,7 @@
         },
         "title": "https://timestore.apphub/schemas/SqlSavedQueryUpsertRequest.json"
       },
-      "def-42": {
+      "def-46": {
         "type": "object",
         "required": [
           "command",
@@ -6969,7 +9253,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-4"
+                  "$ref": "#/components/schemas/def-8"
                 }
               }
             }
@@ -6979,7 +9263,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-5"
+                  "$ref": "#/components/schemas/def-9"
                 }
               }
             }
@@ -7000,7 +9284,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-6"
+                  "$ref": "#/components/schemas/def-10"
                 }
               }
             }
@@ -7010,7 +9294,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-7"
+                  "$ref": "#/components/schemas/def-11"
                 }
               }
             }
@@ -7029,7 +9313,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/def-13"
+                "$ref": "#/components/schemas/def-17"
               }
             }
           }
@@ -7052,7 +9336,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-19"
+                  "$ref": "#/components/schemas/def-23"
                 }
               }
             }
@@ -7062,7 +9346,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-18"
+                  "$ref": "#/components/schemas/def-22"
                 }
               }
             }
@@ -7072,7 +9356,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-19"
+                  "$ref": "#/components/schemas/def-23"
                 }
               }
             }
@@ -7141,7 +9425,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/def-28"
+                "$ref": "#/components/schemas/def-32"
               }
             }
           }
@@ -7164,7 +9448,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-29"
+                  "$ref": "#/components/schemas/def-33"
                 }
               }
             }
@@ -7235,7 +9519,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-33"
+                  "$ref": "#/components/schemas/def-37"
                 }
               }
             }
@@ -7284,7 +9568,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/def-30"
+                "$ref": "#/components/schemas/def-34"
               }
             }
           }
@@ -7295,7 +9579,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-35"
+                  "$ref": "#/components/schemas/def-39"
                 }
               },
               "text/csv": {
@@ -7377,7 +9661,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-38"
+                  "$ref": "#/components/schemas/def-42"
                 }
               }
             }
@@ -7438,7 +9722,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-39"
+                  "$ref": "#/components/schemas/def-43"
                 }
               }
             }
@@ -7494,7 +9778,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/def-41"
+                "$ref": "#/components/schemas/def-45"
               }
             }
           }
@@ -7516,7 +9800,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-39"
+                  "$ref": "#/components/schemas/def-43"
                 }
               }
             }
@@ -7644,7 +9928,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/def-30"
+                "$ref": "#/components/schemas/def-34"
               }
             }
           }
@@ -7655,7 +9939,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-42"
+                  "$ref": "#/components/schemas/def-46"
                 }
               },
               "text/csv": {

--- a/services/timestore/openapi.json
+++ b/services/timestore/openapi.json
@@ -753,7 +753,8 @@
           "status": {
             "type": "string",
             "enum": [
-              "unavailable"
+              "unavailable",
+              "degraded"
             ],
             "description": "Indicates the service cannot serve traffic."
           },
@@ -5169,7 +5170,8 @@
           "status": {
             "type": "string",
             "enum": [
-              "unavailable"
+              "unavailable",
+              "degraded"
             ],
             "description": "Indicates the service cannot serve traffic."
           },

--- a/services/timestore/src/openapi/definitions.ts
+++ b/services/timestore/src/openapi/definitions.ts
@@ -171,7 +171,7 @@ const healthUnavailableResponseSchema: OpenAPIV3.SchemaObject = {
   properties: {
     status: {
       type: 'string',
-      enum: ['unavailable'],
+      enum: ['unavailable', 'degraded'],
       description: 'Indicates the service cannot serve traffic.'
     },
     lifecycle: lifecycleQueueHealthSchema,

--- a/services/timestore/src/routes/streaming.ts
+++ b/services/timestore/src/routes/streaming.ts
@@ -1,0 +1,31 @@
+import type { FastifyInstance } from 'fastify';
+import { loadServiceConfig } from '../config/serviceConfig';
+import { evaluateStreamingStatus } from '../streaming/status';
+import { schemaRef } from '../openapi/definitions';
+
+export async function registerStreamingRoutes(app: FastifyInstance): Promise<void> {
+  app.get(
+    '/streaming/status',
+    {
+      schema: {
+        tags: ['System'],
+        summary: 'Streaming runtime status',
+        description: 'Reports the current state of streaming brokers, micro-batchers, and the hot buffer.',
+        response: {
+          200: {
+            description: 'Streaming status snapshot.',
+            content: {
+              'application/json': {
+                schema: schemaRef('StreamingStatus')
+              }
+            }
+          }
+        }
+      }
+    },
+    async () => {
+      const config = loadServiceConfig();
+      return evaluateStreamingStatus(config);
+    }
+  );
+}

--- a/services/timestore/src/server.ts
+++ b/services/timestore/src/server.ts
@@ -9,6 +9,7 @@ import { registerIngestionRoutes } from './routes/ingest';
 import { registerQueryRoutes } from './routes/query';
 import { registerAdminRoutes } from './routes/admin';
 import { registerSqlRoutes } from './routes/sql';
+import { registerStreamingRoutes } from './routes/streaming';
 import { ensureDefaultStorageTarget } from './service/bootstrap';
 import { closeLifecycleQueue, verifyLifecycleQueueConnection } from './lifecycle/queue';
 import { timestoreMetricsPlugin } from './observability/metricsPlugin';
@@ -62,6 +63,7 @@ async function start(): Promise<void> {
   await registerOpenApi(app);
 
   await registerHealthRoutes(app);
+  await registerStreamingRoutes(app);
   await registerDatasetRoutes(app, { includeSql: true });
   await app.register(async (instance) => {
     await registerDatasetRoutes(instance, { includeSql: false });

--- a/services/timestore/src/streaming/batchers.ts
+++ b/services/timestore/src/streaming/batchers.ts
@@ -2,22 +2,47 @@ import type { FastifyBaseLogger } from 'fastify';
 import { Kafka, logLevel, type Consumer } from 'kafkajs';
 import type { ServiceConfig, StreamingBatcherConfig } from '../config/serviceConfig';
 import { StreamingBatchProcessor, type FlushReason } from './batchProcessor';
+import {
+  setStreamingBatcherMetrics,
+  type StreamingBatcherMetric,
+  type StreamingBatcherState
+} from '../observability/metrics';
 
 interface StreamingBatcherContext {
   config: StreamingBatcherConfig;
   processor: StreamingBatchProcessor;
   consumer: Consumer;
   logger: FastifyBaseLogger;
+  state: StreamingBatcherState;
+  lastMessageAtMs: number | null;
+  lastError: string | null;
   runPromise?: Promise<void>;
+}
+
+export interface StreamingBatcherRuntimeStatus {
+  connectorId: string;
+  datasetSlug: string;
+  topic: string;
+  groupId: string;
+  state: StreamingBatcherState;
+  lastMessageAtMs: number | null;
+  lastError: string | null;
+  bufferedWindows: number;
+  bufferedRows: number;
+  openWindows: number;
+  lastFlushAtMs: number | null;
+  lastEventTimestampMs: number | null;
 }
 
 class StreamingMicroBatcher {
   private readonly context: StreamingBatcherContext;
+  private readonly metricsCallback: () => void;
 
   constructor(
     kafka: Kafka,
     config: StreamingBatcherConfig,
-    logger: FastifyBaseLogger
+    logger: FastifyBaseLogger,
+    onMetricsUpdate?: () => void
   ) {
     const processorLogger = typeof logger.child === 'function'
       ? logger.child({ connectorId: config.id })
@@ -25,12 +50,15 @@ class StreamingMicroBatcher {
 
     const processor = new StreamingBatchProcessor(config, processorLogger);
     const consumer = kafka.consumer({ groupId: config.groupId });
-
+    this.metricsCallback = typeof onMetricsUpdate === 'function' ? onMetricsUpdate : () => {};
     this.context = {
       config,
       processor,
       consumer,
-      logger: processorLogger
+      logger: processorLogger,
+      state: 'starting',
+      lastMessageAtMs: null,
+      lastError: null
     };
   }
 
@@ -38,6 +66,10 @@ class StreamingMicroBatcher {
     const { consumer, config, processor, logger } = this.context;
     await consumer.connect();
     await consumer.subscribe({ topic: config.topic, fromBeginning: config.startFromEarliest });
+
+    this.context.state = 'running';
+    this.context.lastError = null;
+    this.metricsCallback();
 
     this.context.runPromise = consumer.run({
       eachMessage: async ({ message }) => {
@@ -58,12 +90,17 @@ class StreamingMicroBatcher {
         }
         try {
           await processor.processRecord(payload as Record<string, unknown>);
+          this.context.lastMessageAtMs = Date.now();
+          this.metricsCallback();
         } catch (error) {
           logger.error({ err: error, connectorId: config.id }, 'streaming batch processor failed');
           throw error;
         }
       }
     }).catch((error) => {
+      this.context.state = 'error';
+      this.context.lastError = error instanceof Error ? error.message : String(error);
+      this.metricsCallback();
       logger.error({ err: error, connectorId: config.id }, 'streaming consumer terminated unexpectedly');
     });
 
@@ -86,13 +123,44 @@ class StreamingMicroBatcher {
     } catch (error) {
       logger.warn({ err: error, connectorId: config.id }, 'streaming consumer disconnect failed');
     }
+    this.context.state = 'stopped';
+    this.metricsCallback();
     logger.info({ connectorId: config.id }, 'streaming micro-batcher stopped');
+  }
+
+  getMetric(): StreamingBatcherMetric {
+    const diagnostics = this.context.processor.getDiagnostics();
+    return {
+      datasetSlug: this.context.config.datasetSlug,
+      connectorId: this.context.config.id,
+      buffers: diagnostics.bufferedWindows,
+      state: this.context.state
+    } satisfies StreamingBatcherMetric;
+  }
+
+  getStatus(): StreamingBatcherRuntimeStatus {
+    const diagnostics = this.context.processor.getDiagnostics();
+    return {
+      connectorId: this.context.config.id,
+      datasetSlug: this.context.config.datasetSlug,
+      topic: this.context.config.topic,
+      groupId: this.context.config.groupId,
+      state: this.context.state,
+      lastMessageAtMs: this.context.lastMessageAtMs,
+      lastError: this.context.lastError,
+      bufferedWindows: diagnostics.bufferedWindows,
+      bufferedRows: diagnostics.bufferedRows,
+      openWindows: diagnostics.openWindows,
+      lastFlushAtMs: diagnostics.lastFlushAtMs,
+      lastEventTimestampMs: diagnostics.lastEventTimestampMs
+    } satisfies StreamingBatcherRuntimeStatus;
   }
 }
 
 class StreamingBatcherManager {
   private readonly kafka: Kafka;
   private readonly batchers: StreamingMicroBatcher[] = [];
+  private metricsTimer: NodeJS.Timeout | null = null;
 
   constructor(
     private readonly brokerUrl: string,
@@ -115,18 +183,57 @@ class StreamingBatcherManager {
       const connectorLogger = typeof baseLogger.child === 'function'
         ? baseLogger.child({ connectorId: config.id })
         : baseLogger;
-      const batcher = new StreamingMicroBatcher(this.kafka, config, connectorLogger);
+      const batcher = new StreamingMicroBatcher(this.kafka, config, connectorLogger, () => {
+        this.publishMetrics();
+      });
       await batcher.start();
       this.batchers.push(batcher);
+    }
+
+    this.publishMetrics();
+    if (this.batchers.length === 0) {
+      return;
+    }
+
+    if (this.metricsTimer) {
+      clearInterval(this.metricsTimer);
+    }
+    this.metricsTimer = setInterval(() => {
+      this.publishMetrics();
+    }, 5_000);
+    if (this.metricsTimer && typeof this.metricsTimer.unref === 'function') {
+      this.metricsTimer.unref();
     }
   }
 
   async stop(): Promise<void> {
+    if (this.metricsTimer) {
+      clearInterval(this.metricsTimer);
+      this.metricsTimer = null;
+    }
     const stops = this.batchers.map((batcher) => batcher.stop().catch((error) => {
       this.logger.error({ err: error }, 'failed to stop streaming micro-batcher');
     }));
     await Promise.allSettled(stops);
     this.batchers.length = 0;
+    this.publishMetrics();
+  }
+
+  getMetrics(): StreamingBatcherMetric[] {
+    return this.batchers.map((batcher) => batcher.getMetric());
+  }
+
+  getStatus(): StreamingBatcherRuntimeStatus[] {
+    return this.batchers.map((batcher) => batcher.getStatus());
+  }
+
+  private publishMetrics(): void {
+    try {
+      const metrics = this.getMetrics();
+      setStreamingBatcherMetrics(metrics);
+    } catch (error) {
+      this.logger.debug({ err: error }, 'failed to publish streaming batcher metrics');
+    }
   }
 }
 
@@ -145,6 +252,7 @@ export async function initializeStreamingBatchers(
   const batcherConfigs = params.config.streaming.batchers;
 
   if (!streamingFeatureEnabled) {
+    setStreamingBatcherMetrics([]);
     return;
   }
   if (!brokerUrl) {
@@ -152,9 +260,11 @@ export async function initializeStreamingBatchers(
       ? params.logger.child({ component: 'timestore.streaming.batchers' })
       : params.logger;
     warnLogger.warn('streaming enabled but APPHUB_STREAM_BROKER_URL is not configured; skipping micro-batchers');
+    setStreamingBatcherMetrics([]);
     return;
   }
   if (batcherConfigs.length === 0) {
+    setStreamingBatcherMetrics([]);
     return;
   }
 
@@ -164,11 +274,20 @@ export async function initializeStreamingBatchers(
 
 export async function shutdownStreamingBatchers(): Promise<void> {
   if (!manager) {
+    setStreamingBatcherMetrics([]);
     return;
   }
   const instance = manager;
   manager = null;
   await instance.stop();
+  setStreamingBatcherMetrics([]);
+}
+
+export function getStreamingBatcherStatus(): StreamingBatcherRuntimeStatus[] {
+  if (!manager) {
+    return [];
+  }
+  return manager.getStatus();
 }
 
 export { StreamingBatchProcessor } from './batchProcessor';

--- a/services/timestore/src/streaming/status.ts
+++ b/services/timestore/src/streaming/status.ts
@@ -1,36 +1,184 @@
 import type { ServiceConfig } from '../config/serviceConfig';
+import {
+  getStreamingBatcherStatus,
+  type StreamingBatcherRuntimeStatus
+} from './batchers';
+import { getStreamingHotBufferStatus, type HotBufferStatus } from './hotBuffer';
 
-export type StreamingStatus = {
+export type StreamingOverallState = 'disabled' | 'ready' | 'degraded' | 'unconfigured';
+
+export interface StreamingBrokerStatus {
+  configured: boolean;
+  reachable: boolean | null;
+  lastCheckedAt: string | null;
+  error: string | null;
+}
+
+export interface StreamingBatcherConnectorStatus {
+  connectorId: string;
+  datasetSlug: string;
+  topic: string;
+  groupId: string;
+  state: StreamingBatcherRuntimeStatus['state'];
+  bufferedWindows: number;
+  bufferedRows: number;
+  openWindows: number;
+  lastMessageAt: string | null;
+  lastFlushAt: string | null;
+  lastEventTimestamp: string | null;
+  lastError: string | null;
+}
+
+export interface StreamingBatcherStatusSummary {
+  configured: number;
+  running: number;
+  failing: number;
+  state: 'disabled' | 'ready' | 'degraded';
+  connectors: StreamingBatcherConnectorStatus[];
+}
+
+export interface StreamingStatus {
   enabled: boolean;
-  state: 'disabled' | 'ready' | 'unconfigured';
+  state: StreamingOverallState;
   reason: string | null;
-  brokerConfigured: boolean;
-};
+  broker: StreamingBrokerStatus;
+  batchers: StreamingBatcherStatusSummary;
+  hotBuffer: HotBufferStatus;
+}
 
-export function evaluateStreamingStatus(config: ServiceConfig): StreamingStatus {
-  if (!config.features.streaming.enabled) {
-    return {
-      enabled: false,
-      state: 'disabled',
-      reason: null,
-      brokerConfigured: false
-    };
+function toIso(ms: number | null): string | null {
+  if (!ms) {
+    return null;
   }
+  try {
+    return new Date(ms).toISOString();
+  } catch {
+    return null;
+  }
+}
 
-  const brokerUrl = (process.env.APPHUB_STREAM_BROKER_URL ?? '').trim();
-  if (!brokerUrl) {
-    return {
-      enabled: true,
-      state: 'unconfigured',
-      reason: 'APPHUB_STREAM_BROKER_URL is not set',
-      brokerConfigured: false
-    };
+function buildBatcherSummary(
+  configured: number,
+  runtimeStatus: StreamingBatcherRuntimeStatus[]
+): StreamingBatcherStatusSummary {
+  const connectors: StreamingBatcherConnectorStatus[] = runtimeStatus.map((connector) => ({
+    connectorId: connector.connectorId,
+    datasetSlug: connector.datasetSlug,
+    topic: connector.topic,
+    groupId: connector.groupId,
+    state: connector.state,
+    bufferedWindows: connector.bufferedWindows,
+    bufferedRows: connector.bufferedRows,
+    openWindows: connector.openWindows,
+    lastMessageAt: toIso(connector.lastMessageAtMs),
+    lastFlushAt: toIso(connector.lastFlushAtMs),
+    lastEventTimestamp: toIso(connector.lastEventTimestampMs),
+    lastError: connector.lastError ?? null
+  }));
+
+  const running = runtimeStatus.filter((entry) => entry.state === 'running').length;
+  const failing = runtimeStatus.filter((entry) => entry.state === 'error').length;
+
+  let state: 'disabled' | 'ready' | 'degraded';
+  if (configured === 0) {
+    state = 'disabled';
+  } else if (runtimeStatus.length === 0) {
+    state = 'degraded';
+  } else if (runtimeStatus.every((entry) => entry.state === 'running')) {
+    state = 'ready';
+  } else {
+    state = 'degraded';
   }
 
   return {
-    enabled: true,
-    state: 'ready',
-    reason: null,
-    brokerConfigured: true
-  };
+    configured,
+    running,
+    failing,
+    state,
+    connectors
+  } satisfies StreamingBatcherStatusSummary;
+}
+
+export function evaluateStreamingStatus(config: ServiceConfig): StreamingStatus {
+  const enabled = config.features.streaming.enabled;
+  const brokerUrl = (process.env.APPHUB_STREAM_BROKER_URL ?? '').trim();
+  const brokerConfigured = brokerUrl.length > 0;
+
+  const batcherConfigs = config.streaming.batchers;
+  const runtimeBatchers = getStreamingBatcherStatus();
+  const batchers = buildBatcherSummary(batcherConfigs.length, runtimeBatchers);
+
+  const hotBuffer = getStreamingHotBufferStatus();
+  const hotBufferConfigured = config.streaming.hotBuffer.enabled;
+
+  let overallState: StreamingOverallState = 'disabled';
+  const reasons: string[] = [];
+
+  if (!enabled) {
+    overallState = 'disabled';
+  } else if (!brokerConfigured) {
+    overallState = 'unconfigured';
+    reasons.push('APPHUB_STREAM_BROKER_URL is not set');
+  } else {
+    const batcherHealthy = batchers.state === 'ready' || batchers.state === 'disabled';
+    const hotBufferHealthy = !hotBufferConfigured || hotBuffer.state === 'ready';
+
+    if (batcherHealthy && hotBufferHealthy) {
+      overallState = 'ready';
+    } else {
+      overallState = 'degraded';
+      if (!batcherHealthy) {
+        const configuredTotal = Math.max(batcherConfigs.length, runtimeBatchers.length);
+        reasons.push(
+          configuredTotal > 0
+            ? `Streaming micro-batchers degraded (${batchers.running}/${configuredTotal} running)`
+            : 'Streaming micro-batchers not configured'
+        );
+      }
+      if (!hotBufferHealthy) {
+        reasons.push('Streaming hot buffer unavailable');
+      }
+    }
+  }
+
+  const brokerReachable = (() => {
+    if (!brokerConfigured) {
+      return null;
+    }
+    if (runtimeBatchers.some((entry) => entry.state === 'running')) {
+      return true;
+    }
+    if (runtimeBatchers.some((entry) => entry.state === 'error')) {
+      return false;
+    }
+    return null;
+  })();
+
+  if (brokerConfigured && brokerReachable === false) {
+    reasons.push('Streaming broker unreachable from micro-batchers');
+  }
+
+  const brokerError = brokerConfigured
+    ? brokerReachable === false
+      ? 'broker unreachable'
+      : null
+    : 'broker not configured';
+
+  const brokerStatus: StreamingBrokerStatus = {
+    configured: brokerConfigured,
+    reachable: brokerReachable,
+    lastCheckedAt: hotBuffer.lastRefreshAt ?? hotBuffer.lastIngestAt,
+    error: brokerError
+  } satisfies StreamingBrokerStatus;
+
+  const reason = reasons.length > 0 ? reasons[0] ?? null : null;
+
+  return {
+    enabled,
+    state: overallState,
+    reason,
+    broker: brokerStatus,
+    batchers,
+    hotBuffer
+  } satisfies StreamingStatus;
 }


### PR DESCRIPTION
## Summary
- expose streaming status snapshots and readiness through timestore + core
- wire CLI/status docs/infra so operators get end-to-end visibility and runbooks

## Testing
- npm run lint
- npm run build
- npm run test

Fixes #133