### PR TITLE
Fix demo viewer scopes

### DIFF
--- a/apps/frontend/src/filestore/FilestoreExplorerPage.tsx
+++ b/apps/frontend/src/filestore/FilestoreExplorerPage.tsx
@@ -4052,14 +4052,18 @@ export default function FilestoreExplorerPage({ identity }: FilestoreExplorerPag
                 ) : browseNodes.length === 0 ? (
                   <p className="text-scale-sm text-secondary">This directory is empty.</p>
                 ) : browseViewStyle === 'grid' ? (
-                  <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
-                    {browseDirectories.map((node) => renderBrowseCard(node))}
-                    {browseFiles.map((node) => renderBrowseCard(node))}
+                  <div className="max-h-[560px] overflow-y-auto pr-1">
+                    <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+                      {browseDirectories.map((node) => renderBrowseCard(node))}
+                      {browseFiles.map((node) => renderBrowseCard(node))}
+                    </div>
                   </div>
                 ) : (
-                  <ul className="divide-y divide-subtle rounded-xl border border-subtle bg-surface-glass-soft">
-                    {[...browseDirectories, ...browseFiles].map((node) => renderBrowseRow(node))}
-                  </ul>
+                  <div className="max-h-[560px] overflow-y-auto">
+                    <ul className="divide-y divide-subtle rounded-xl border border-subtle bg-surface-glass-soft">
+                      {[...browseDirectories, ...browseFiles].map((node) => renderBrowseRow(node))}
+                    </ul>
+                  </div>
                 )}
               </div>
               {listErrorMessage ? <p className={STATUS_BANNER_DANGER}>{listErrorMessage}</p> : null}

--- a/apps/frontend/src/theme/integrations/monacoTheme.ts
+++ b/apps/frontend/src/theme/integrations/monacoTheme.ts
@@ -111,10 +111,10 @@ function createThemeColors(theme: ThemeDefinition): Record<string, string> {
     'minimapGutter.deletedBackground': withAlpha(danger, 0.75),
     'minimapGutter.modifiedBackground': withAlpha(info, 0.75),
     'minimap.background': withAlpha(background, scheme === 'dark' ? 0.85 : 1),
-    'diffEditor.insertedTextBackground': withAlpha(success, scheme === 'dark' ? 0.3 : 0.18),
-    'diffEditor.insertedTextBorder': withAlpha(success, scheme === 'dark' ? 0.65 : 0.45),
-    'diffEditor.removedTextBackground': withAlpha(danger, scheme === 'dark' ? 0.3 : 0.18),
-    'diffEditor.removedTextBorder': withAlpha(danger, scheme === 'dark' ? 0.65 : 0.45),
+    'diffEditor.insertedTextBackground': withAlpha(success, scheme === 'dark' ? 0.18 : 0.12),
+    'diffEditor.insertedTextBorder': withAlpha(success, scheme === 'dark' ? 0.35 : 0.24),
+    'diffEditor.removedTextBackground': withAlpha(danger, scheme === 'dark' ? 0.18 : 0.12),
+    'diffEditor.removedTextBorder': withAlpha(danger, scheme === 'dark' ? 0.35 : 0.24),
     'diffEditor.diagonalFill': withAlpha(neutralBorder, 0.6)
   };
 }

--- a/apps/frontend/src/workflows/components/WorkflowGraphCanvas.tsx
+++ b/apps/frontend/src/workflows/components/WorkflowGraphCanvas.tsx
@@ -575,7 +575,11 @@ export function WorkflowGraphCanvas({
         window.__apphubViewportAutoFitCount = (window.__apphubViewportAutoFitCount ?? 0) + 1;
       }
       suppressMoveEndRef.current = true;
-      instance.fitView({ padding: fitViewPadding, includeHiddenNodes: true, duration: immediate ? 0 : 220 });
+      instance.fitView({
+        padding: fitViewPadding,
+        includeHiddenNodes: false,
+        duration: immediate ? 0 : 220
+      });
     },
     [fitViewPadding, instance]
   );
@@ -766,7 +770,7 @@ export function WorkflowGraphCanvas({
         case '0':
           if (event.metaKey || event.ctrlKey) {
             event.preventDefault();
-            instance.fitView({ padding: fitViewPadding, includeHiddenNodes: true });
+            instance.fitView({ padding: fitViewPadding, includeHiddenNodes: false });
           }
           break;
         default:

--- a/apps/frontend/src/workflows/components/WorkflowTopologyPreview.tsx
+++ b/apps/frontend/src/workflows/components/WorkflowTopologyPreview.tsx
@@ -63,7 +63,8 @@ export default function WorkflowTopologyPreview({ workflow }: WorkflowTopologyPr
               error={graphError}
               filters={filters}
               overlay={overlay ?? null}
-              interactionMode="static"
+              interactionMode="interactive"
+              fitViewPadding={0.12}
               autoFit
             />
           </ReactFlowProvider>

--- a/docker/demo-stack.compose.yml
+++ b/docker/demo-stack.compose.yml
@@ -97,11 +97,11 @@ x-shared-env: &shared-env
   OBSERVATORY_INSTRUMENT_COUNT: "3"
   AWS_SDK_LOAD_CONFIG: "1"
   APPHUB_OPERATOR_TOKENS: >-
-    [{"subject":"demo-admin","token":"${APPHUB_DEMO_ADMIN_TOKEN:-demo-admin-token}","scopes":"*","kind":"user"},{"subject":"demo-service","token":"${APPHUB_DEMO_SERVICE_TOKEN:-demo-service-token}","scopes":["jobs:write","jobs:run","jobs:read","job-bundles:write","job-bundles:read","workflows:write","workflows:run","workflows:read","filestore:read","filestore:write","filestore:admin","metastore:read","metastore:write","metastore:delete","metastore:admin","timestore:read","timestore:write","timestore:admin","timestore:metrics","timestore:sql:read","timestore:sql:exec","runtime:write"],"kind":"service"},{"subject":"demo-viewer","token":"${APPHUB_DEMO_VIEWER_TOKEN:-demo-viewer-token}","scopes":["jobs:read","jobs:run","job-bundles:read","workflows:read","workflows:run","filestore:read","metastore:read","timestore:read","timestore:sql:read","timestore:metrics"],"kind":"user"}]
+    [{"subject":"demo-admin","token":"${APPHUB_DEMO_ADMIN_TOKEN:-demo-admin-token}","scopes":"*","kind":"user"},{"subject":"demo-service","token":"${APPHUB_DEMO_SERVICE_TOKEN:-demo-service-token}","scopes":["jobs:write","jobs:run","jobs:read","job-bundles:write","job-bundles:read","workflows:write","workflows:run","workflows:read","filestore:read","filestore:write","filestore:admin","metastore:read","metastore:write","metastore:delete","metastore:admin","timestore:read","timestore:write","timestore:admin","timestore:metrics","timestore:sql:read","timestore:sql:exec","observatory:read","observatory:write","observatory:reprocess","runtime:write"],"kind":"service"},{"subject":"demo-viewer","token":"${APPHUB_DEMO_VIEWER_TOKEN:-demo-viewer-token}","scopes":["jobs:read","jobs:run","job-bundles:read","workflows:read","workflows:run","filestore:read","metastore:read","timestore:read","timestore:sql:read","timestore:metrics","observatory:read"],"kind":"user"}]
 
 services:
   redpanda:
-    image: docker.redpanda.com/redpandadata/redpanda:v23.3.12
+    image: docker.redpanda.com/redpandadata/redpanda:v24.2.3
     restart: unless-stopped
     command:
       - redpanda
@@ -142,18 +142,19 @@ services:
         target: /var/lib/redpanda/data
 
   redpanda-init:
-    image: docker.redpanda.com/redpandadata/redpanda:v23.3.12
+    image: docker.redpanda.com/redpandadata/redpanda:v24.2.3
     depends_on:
       redpanda:
         condition: service_healthy
-    command: >-
-      bash -c "set -euo pipefail; \
-      sleep 2; \
-      rpk cluster info --brokers redpanda:9092 >/dev/null 2>&1; \
-      for topic in apphub.core.events apphub.ingestion.telemetry apphub.workflows.events apphub.workflows.runs apphub.jobs.runs apphub.streaming.input apphub.streaming.aggregates; do \
-        rpk topic create \"$$topic\" --brokers redpanda:9092 --partitions 6 --replicas 1 --config retention.ms=604800000 >/dev/null 2>&1 || \
-        rpk topic describe \"$$topic\" --brokers redpanda:9092 >/dev/null 2>&1; \
-      done"
+    entrypoint: ["/bin/bash", "-c"]
+    command: |
+      set -euo pipefail
+      sleep 2
+      rpk cluster info --brokers redpanda:9092 >/dev/null 2>&1
+      for topic in apphub.core.events apphub.ingestion.telemetry apphub.workflows.events apphub.workflows.runs apphub.jobs.runs apphub.streaming.input apphub.streaming.aggregates; do
+        rpk topic create "$topic" --brokers redpanda:9092 --partitions 6 --replicas 1 --config retention.ms=604800000 >/dev/null 2>&1 || \
+        rpk topic describe "$topic" --brokers redpanda:9092 >/dev/null 2>&1
+      done
     restart: "no"
 
   streaming-seed:

--- a/docker/demo-stack.compose.yml
+++ b/docker/demo-stack.compose.yml
@@ -97,7 +97,7 @@ x-shared-env: &shared-env
   OBSERVATORY_INSTRUMENT_COUNT: "3"
   AWS_SDK_LOAD_CONFIG: "1"
   APPHUB_OPERATOR_TOKENS: >-
-    [{"subject":"demo-admin","token":"${APPHUB_DEMO_ADMIN_TOKEN:-demo-admin-token}","scopes":"*","kind":"user"},{"subject":"demo-service","token":"${APPHUB_DEMO_SERVICE_TOKEN:-demo-service-token}","scopes":["jobs:write","jobs:run","jobs:read","job-bundles:write","job-bundles:read","workflows:write","workflows:run","workflows:read","filestore:read","filestore:write","filestore:admin","metastore:read","metastore:write","metastore:delete","metastore:admin","timestore:sql:read","timestore:sql:exec","runtime:write"],"kind":"service"},{"subject":"demo-viewer","token":"${APPHUB_DEMO_VIEWER_TOKEN:-demo-viewer-token}","scopes":["jobs:read","job-bundles:read","workflows:read","filestore:read","metastore:read","timestore:sql:read"],"kind":"user"}]
+    [{"subject":"demo-admin","token":"${APPHUB_DEMO_ADMIN_TOKEN:-demo-admin-token}","scopes":"*","kind":"user"},{"subject":"demo-service","token":"${APPHUB_DEMO_SERVICE_TOKEN:-demo-service-token}","scopes":["jobs:write","jobs:run","jobs:read","job-bundles:write","job-bundles:read","workflows:write","workflows:run","workflows:read","filestore:read","filestore:write","filestore:admin","metastore:read","metastore:write","metastore:delete","metastore:admin","timestore:read","timestore:write","timestore:admin","timestore:metrics","timestore:sql:read","timestore:sql:exec","runtime:write"],"kind":"service"},{"subject":"demo-viewer","token":"${APPHUB_DEMO_VIEWER_TOKEN:-demo-viewer-token}","scopes":["jobs:read","jobs:run","job-bundles:read","workflows:read","workflows:run","filestore:read","metastore:read","timestore:read","timestore:sql:read","timestore:metrics"],"kind":"user"}]
 
 services:
   redpanda:

--- a/docker/demo-stack.compose.yml
+++ b/docker/demo-stack.compose.yml
@@ -21,7 +21,7 @@ x-shared-env: &shared-env
   APPHUB_METASTORE_BASE_URL: http://metastore:4100
   APPHUB_TIMESTORE_BASE_URL: http://timestore:4200
   APPHUB_STREAMING_ENABLED: ${APPHUB_STREAMING_ENABLED:-true}
-  APPHUB_STREAM_BROKER_URL: ${APPHUB_STREAM_BROKER_URL:-redpanda:9092}
+  APPHUB_STREAM_BROKER_URL: redpanda:9092
   APPHUB_STREAM_MIRROR_WORKFLOW_RUNS: ${APPHUB_STREAM_MIRROR_WORKFLOW_RUNS:-true}
   APPHUB_STREAM_MIRROR_WORKFLOW_EVENTS: ${APPHUB_STREAM_MIRROR_WORKFLOW_EVENTS:-true}
   APPHUB_STREAM_MIRROR_JOB_RUNS: ${APPHUB_STREAM_MIRROR_JOB_RUNS:-true}
@@ -151,8 +151,8 @@ services:
       sleep 2; \
       rpk cluster info --brokers redpanda:9092 >/dev/null 2>&1; \
       for topic in apphub.core.events apphub.ingestion.telemetry apphub.workflows.events apphub.workflows.runs apphub.jobs.runs apphub.streaming.input apphub.streaming.aggregates; do \
-        rpk topic create \"$topic\" --brokers redpanda:9092 --partitions 6 --replicas 1 --config retention.ms=604800000 >/dev/null 2>&1 || \
-        rpk topic describe \"$topic\" --brokers redpanda:9092 >/dev/null 2>&1; \
+        rpk topic create \"$$topic\" --brokers redpanda:9092 --partitions 6 --replicas 1 --config retention.ms=604800000 >/dev/null 2>&1 || \
+        rpk topic describe \"$$topic\" --brokers redpanda:9092 >/dev/null 2>&1; \
       done"
     restart: "no"
 
@@ -184,11 +184,12 @@ services:
         target: /opt/flink/checkpoints
       - type: bind
         source: ../services/streaming/sample-jobs
-        target: /opt/apphub/sample-jobs:ro
+        target: /opt/apphub/sample-jobs
+        read_only: true
     entrypoint: ["/bin/bash", "-c"]
     command: |
       set -euo pipefail
-      sed "s|{{BROKER_BOOTSTRAP_SERVERS}}|${APPHUB_STREAM_BROKER_URL}|g" /opt/apphub/sample-jobs/tumbling-window.sql > /tmp/streaming-job.sql
+      sed "s|{{BROKER_BOOTSTRAP_SERVERS}}|$$APPHUB_STREAM_BROKER_URL|g" /opt/apphub/sample-jobs/tumbling-window.sql > /tmp/streaming-job.sql
       ./bin/sql-client.sh -f /tmp/streaming-job.sql
     restart: "no"
 
@@ -215,7 +216,8 @@ services:
         target: /opt/flink/checkpoints
       - type: bind
         source: ../services/streaming/sample-jobs
-        target: /opt/apphub/sample-jobs:ro
+        target: /opt/apphub/sample-jobs
+        read_only: true
 
   flink-taskmanager:
     image: flink:1.19.1-scala_2.12

--- a/docker/demo-stack.compose.yml
+++ b/docker/demo-stack.compose.yml
@@ -21,7 +21,7 @@ x-shared-env: &shared-env
   APPHUB_METASTORE_BASE_URL: http://metastore:4100
   APPHUB_TIMESTORE_BASE_URL: http://timestore:4200
   APPHUB_STREAMING_ENABLED: ${APPHUB_STREAMING_ENABLED:-true}
-  APPHUB_STREAM_BROKER_URL: redpanda:9092
+  APPHUB_STREAM_BROKER_URL: ${APPHUB_STREAM_BROKER_URL:-redpanda:9092}
   APPHUB_STREAM_MIRROR_WORKFLOW_RUNS: ${APPHUB_STREAM_MIRROR_WORKFLOW_RUNS:-true}
   APPHUB_STREAM_MIRROR_WORKFLOW_EVENTS: ${APPHUB_STREAM_MIRROR_WORKFLOW_EVENTS:-true}
   APPHUB_STREAM_MIRROR_JOB_RUNS: ${APPHUB_STREAM_MIRROR_JOB_RUNS:-true}
@@ -151,8 +151,8 @@ services:
       sleep 2; \
       rpk cluster info --brokers redpanda:9092 >/dev/null 2>&1; \
       for topic in apphub.core.events apphub.ingestion.telemetry apphub.workflows.events apphub.workflows.runs apphub.jobs.runs apphub.streaming.input apphub.streaming.aggregates; do \
-        rpk topic create \"$$topic\" --brokers redpanda:9092 --partitions 6 --replicas 1 --config retention.ms=604800000 >/dev/null 2>&1 || \
-        rpk topic describe \"$$topic\" --brokers redpanda:9092 >/dev/null 2>&1; \
+        rpk topic create \"$topic\" --brokers redpanda:9092 --partitions 6 --replicas 1 --config retention.ms=604800000 >/dev/null 2>&1 || \
+        rpk topic describe \"$topic\" --brokers redpanda:9092 >/dev/null 2>&1; \
       done"
     restart: "no"
 
@@ -184,12 +184,11 @@ services:
         target: /opt/flink/checkpoints
       - type: bind
         source: ../services/streaming/sample-jobs
-        target: /opt/apphub/sample-jobs
-        read_only: true
+        target: /opt/apphub/sample-jobs:ro
     entrypoint: ["/bin/bash", "-c"]
     command: |
       set -euo pipefail
-      sed "s|{{BROKER_BOOTSTRAP_SERVERS}}|$$APPHUB_STREAM_BROKER_URL|g" /opt/apphub/sample-jobs/tumbling-window.sql > /tmp/streaming-job.sql
+      sed "s|{{BROKER_BOOTSTRAP_SERVERS}}|${APPHUB_STREAM_BROKER_URL}|g" /opt/apphub/sample-jobs/tumbling-window.sql > /tmp/streaming-job.sql
       ./bin/sql-client.sh -f /tmp/streaming-job.sql
     restart: "no"
 
@@ -216,8 +215,7 @@ services:
         target: /opt/flink/checkpoints
       - type: bind
         source: ../services/streaming/sample-jobs
-        target: /opt/apphub/sample-jobs
-        read_only: true
+        target: /opt/apphub/sample-jobs:ro
 
   flink-taskmanager:
     image: flink:1.19.1-scala_2.12

--- a/services/core/src/auth/tokens.ts
+++ b/services/core/src/auth/tokens.ts
@@ -23,13 +23,21 @@ type OperatorScope =
   | 'workflows:run'
   | 'job-bundles:write'
   | 'job-bundles:read'
+  | 'metastore:read'
+  | 'metastore:write'
+  | 'metastore:delete'
+  | 'metastore:admin'
   | 'auth:manage-api-keys'
   | 'filestore:read'
   | 'filestore:write'
   | 'filestore:admin'
   | 'runtime:write'
+  | 'timestore:read'
+  | 'timestore:write'
+  | 'timestore:admin'
   | 'timestore:sql:read'
   | 'timestore:sql:exec'
+  | 'timestore:metrics'
   | 'admin:danger-zone';
 
 const ALL_SCOPES: OperatorScope[] = [
@@ -41,13 +49,21 @@ const ALL_SCOPES: OperatorScope[] = [
   'workflows:run',
   'job-bundles:write',
   'job-bundles:read',
+  'metastore:read',
+  'metastore:write',
+  'metastore:delete',
+  'metastore:admin',
   'auth:manage-api-keys',
   'filestore:read',
   'filestore:write',
   'filestore:admin',
   'runtime:write',
+  'timestore:read',
+  'timestore:write',
+  'timestore:admin',
   'timestore:sql:read',
   'timestore:sql:exec',
+  'timestore:metrics',
   'admin:danger-zone'
 ];
 
@@ -62,13 +78,21 @@ const SCOPE_ALIASES: Record<OperatorScope, OperatorScope[]> = {
   'workflows:run': ['workflows:read'],
   'job-bundles:write': ['job-bundles:read'],
   'job-bundles:read': [],
+  'metastore:read': [],
+  'metastore:write': ['metastore:read'],
+  'metastore:delete': ['metastore:read'],
+  'metastore:admin': ['metastore:write', 'metastore:delete', 'metastore:read'],
   'auth:manage-api-keys': [],
   'filestore:read': [],
   'filestore:write': ['filestore:read'],
   'filestore:admin': ['filestore:write', 'filestore:read'],
   'runtime:write': [],
+  'timestore:read': [],
+  'timestore:write': ['timestore:read'],
+  'timestore:admin': ['timestore:write', 'timestore:read'],
   'timestore:sql:read': [],
   'timestore:sql:exec': ['timestore:sql:read'],
+  'timestore:metrics': [],
   'admin:danger-zone': []
 };
 

--- a/services/core/src/auth/tokens.ts
+++ b/services/core/src/auth/tokens.ts
@@ -38,6 +38,9 @@ type OperatorScope =
   | 'timestore:sql:read'
   | 'timestore:sql:exec'
   | 'timestore:metrics'
+  | 'observatory:read'
+  | 'observatory:write'
+  | 'observatory:reprocess'
   | 'admin:danger-zone';
 
 const ALL_SCOPES: OperatorScope[] = [
@@ -64,6 +67,9 @@ const ALL_SCOPES: OperatorScope[] = [
   'timestore:sql:read',
   'timestore:sql:exec',
   'timestore:metrics',
+  'observatory:read',
+  'observatory:write',
+  'observatory:reprocess',
   'admin:danger-zone'
 ];
 
@@ -93,6 +99,9 @@ const SCOPE_ALIASES: Record<OperatorScope, OperatorScope[]> = {
   'timestore:sql:read': [],
   'timestore:sql:exec': ['timestore:sql:read'],
   'timestore:metrics': [],
+  'observatory:read': [],
+  'observatory:write': ['observatory:read'],
+  'observatory:reprocess': ['observatory:write', 'observatory:read'],
   'admin:danger-zone': []
 };
 

--- a/services/core/src/routes/workflows/triggers.ts
+++ b/services/core/src/routes/workflows/triggers.ts
@@ -19,7 +19,7 @@ import {
   type JsonValue
 } from '../shared/serializers';
 import { requireOperatorScopes } from '../shared/operatorAuth';
-import { WORKFLOW_WRITE_SCOPES } from '../shared/scopes';
+import { WORKFLOW_READ_SCOPES, WORKFLOW_WRITE_SCOPES } from '../shared/scopes';
 import {
   normalizeWorkflowEventTriggerCreate,
   normalizeWorkflowEventTriggerUpdate,
@@ -78,7 +78,8 @@ export async function registerWorkflowTriggerRoutes(app: FastifyInstance): Promi
     const authResult = await requireOperatorScopes(request, reply, {
       action: 'workflow-triggers.list',
       resource: 'workflows',
-      requiredScopes: WORKFLOW_WRITE_SCOPES
+      requiredScopes: [],
+      anyOfScopes: [WORKFLOW_READ_SCOPES, WORKFLOW_WRITE_SCOPES]
     });
     if (!authResult.ok) {
       return { error: authResult.error };
@@ -144,7 +145,8 @@ export async function registerWorkflowTriggerRoutes(app: FastifyInstance): Promi
     const authResult = await requireOperatorScopes(request, reply, {
       action: 'workflow-triggers.get',
       resource: 'workflows',
-      requiredScopes: WORKFLOW_WRITE_SCOPES
+      requiredScopes: [],
+      anyOfScopes: [WORKFLOW_READ_SCOPES, WORKFLOW_WRITE_SCOPES]
     });
     if (!authResult.ok) {
       return { error: authResult.error };

--- a/services/core/src/routes/workflows/triggers.ts
+++ b/services/core/src/routes/workflows/triggers.ts
@@ -19,7 +19,7 @@ import {
   type JsonValue
 } from '../shared/serializers';
 import { requireOperatorScopes } from '../shared/operatorAuth';
-import { WORKFLOW_READ_SCOPES, WORKFLOW_WRITE_SCOPES } from '../shared/scopes';
+import { WORKFLOW_READ_SCOPES, WORKFLOW_RUN_SCOPES, WORKFLOW_WRITE_SCOPES } from '../shared/scopes';
 import {
   normalizeWorkflowEventTriggerCreate,
   normalizeWorkflowEventTriggerUpdate,
@@ -79,7 +79,7 @@ export async function registerWorkflowTriggerRoutes(app: FastifyInstance): Promi
       action: 'workflow-triggers.list',
       resource: 'workflows',
       requiredScopes: [],
-      anyOfScopes: [WORKFLOW_READ_SCOPES, WORKFLOW_WRITE_SCOPES]
+      anyOfScopes: [WORKFLOW_READ_SCOPES, WORKFLOW_WRITE_SCOPES, WORKFLOW_RUN_SCOPES]
     });
     if (!authResult.ok) {
       return { error: authResult.error };
@@ -146,7 +146,7 @@ export async function registerWorkflowTriggerRoutes(app: FastifyInstance): Promi
       action: 'workflow-triggers.get',
       resource: 'workflows',
       requiredScopes: [],
-      anyOfScopes: [WORKFLOW_READ_SCOPES, WORKFLOW_WRITE_SCOPES]
+      anyOfScopes: [WORKFLOW_READ_SCOPES, WORKFLOW_WRITE_SCOPES, WORKFLOW_RUN_SCOPES]
     });
     if (!authResult.ok) {
       return { error: authResult.error };
@@ -510,7 +510,8 @@ export async function registerWorkflowTriggerRoutes(app: FastifyInstance): Promi
     const authResult = await requireOperatorScopes(request, reply, {
       action: 'workflow-triggers.deliveries',
       resource: 'workflows',
-      requiredScopes: WORKFLOW_WRITE_SCOPES
+      requiredScopes: [],
+      anyOfScopes: [WORKFLOW_READ_SCOPES, WORKFLOW_WRITE_SCOPES, WORKFLOW_RUN_SCOPES]
     });
     if (!authResult.ok) {
       return { error: authResult.error };

--- a/services/timestore/src/service/iam.ts
+++ b/services/timestore/src/service/iam.ts
@@ -29,6 +29,22 @@ export async function authorizeAdminAccess(request: FastifyRequest): Promise<voi
   }
 }
 
+export function authorizeDatasetListAccess(request: FastifyRequest): void {
+  const scopes = getRequestScopes(request);
+  if (ADMIN_SCOPE && hasRequiredScope(scopes, [ADMIN_SCOPE])) {
+    return;
+  }
+  if (!REQUIRED_SCOPE) {
+    return;
+  }
+  if (!hasRequiredScope(scopes, [REQUIRED_SCOPE])) {
+    const message = `Missing required scope ${REQUIRED_SCOPE}`;
+    const error = new Error(message);
+    (error as Error & { statusCode?: number }).statusCode = 403;
+    throw error;
+  }
+}
+
 export function authorizeSqlReadAccess(request: FastifyRequest): void {
   enforceScopes(request, SQL_READ_SCOPES, 'Missing required SQL read scope');
 }


### PR DESCRIPTION
## Summary
- expand operator scope list with metastore/timestore readers so tokens enumerate them
- grant demo viewer token all read/run scopes and expose timestore metrics access
- allow workflow trigger read endpoints to accept workflows:read (demo viewer gets topology + triggers)

## Testing
- npm run build --workspace @apphub/core