### PR TITLE
feat(frontend): rename apps surface to builds

### DIFF
--- a/apps/frontend/src/components/Navbar.tsx
+++ b/apps/frontend/src/components/Navbar.tsx
@@ -19,7 +19,7 @@ type IconComponent = (props: IconProps) => JSX.Element;
 const NAV_ICON_MAP: Record<PrimaryNavKey, IconComponent> = {
   overview: OverviewIcon,
   observability: ObservabilityIcon,
-  core: AppsIcon,
+  core: BuildsIcon,
   events: EventsIcon,
   assets: AssetsIcon,
   services: ServicesIcon,
@@ -231,7 +231,7 @@ function EventsIcon({ className }: IconProps) {
   );
 }
 
-function AppsIcon({ className }: IconProps) {
+function BuildsIcon({ className }: IconProps) {
   return (
     <svg
       aria-hidden="true"

--- a/apps/frontend/src/core/CorePage.tsx
+++ b/apps/frontend/src/core/CorePage.tsx
@@ -216,7 +216,7 @@ function CorePage({ searchSeed, onSeedApplied, savedSearchSlug, onSavedSearchApp
       <section className="flex flex-col gap-6">
         {loading && (
           <div className="rounded-2xl border border-subtle bg-surface-muted px-5 py-4 text-scale-sm font-weight-medium text-secondary shadow-sm">
-            <Spinner label="Loading apps…" size="sm" />
+            <Spinner label="Loading builds…" size="sm" />
           </div>
         )}
         {error && !loading && (
@@ -226,7 +226,7 @@ function CorePage({ searchSeed, onSeedApplied, savedSearchSlug, onSavedSearchApp
         )}
         {!loading && !error && apps.length === 0 && (
           <div className="rounded-2xl border border-subtle bg-surface-muted px-5 py-4 text-scale-sm font-weight-medium text-secondary shadow-sm">
-            No apps match your filters yet.
+            No builds match your filters yet.
           </div>
         )}
         <AppList

--- a/apps/frontend/src/core/components/AppDetailsPanel.tsx
+++ b/apps/frontend/src/core/components/AppDetailsPanel.tsx
@@ -157,7 +157,7 @@ function PreviewMedia({ tile }: { tile: AppRecord['previewTiles'][number] }) {
       <img
         className="h-full w-full object-cover"
         src={tile.src}
-        alt={tile.title ?? 'Application preview frame'}
+        alt={tile.title ?? 'Build preview frame'}
         loading="lazy"
       />
     );
@@ -968,7 +968,7 @@ function LaunchSummarySection({
           }}
           disabled={isLaunching || !canLaunch || canStop}
         >
-          {isLaunching ? 'Launching…' : 'Launch app'}
+          {isLaunching ? 'Launching…' : 'Launch build'}
         </button>
         <button
           type="button"
@@ -1520,7 +1520,7 @@ function AppDetailsPanel({
               type="button"
               aria-haspopup="dialog"
               aria-expanded={infoOpen}
-              aria-label={infoOpen ? 'Hide app info' : 'Show app info'}
+              aria-label={infoOpen ? 'Hide build info' : 'Show build info'}
               className="inline-flex items-center justify-center rounded-full border border-subtle bg-surface-glass p-2 text-muted transition-colors hover:border-accent hover:text-accent-strong focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
               onClick={() => setInfoOpen((open) => !open)}
             >

--- a/apps/frontend/src/core/components/AppList.tsx
+++ b/apps/frontend/src/core/components/AppList.tsx
@@ -110,7 +110,7 @@ function AppList({
       <table className="min-w-full divide-y divide-subtle">
         <thead className="bg-surface-muted text-left text-scale-xs font-weight-semibold uppercase tracking-[0.3em] text-muted">
           <tr>
-            <th scope="col" className="px-6 py-4">App</th>
+            <th scope="col" className="px-6 py-4">Build</th>
             <th scope="col" className="px-6 py-4">Ingestion</th>
             <th scope="col" className="px-6 py-4">Latest build</th>
             <th scope="col" className="px-6 py-4">Latest launch</th>
@@ -185,7 +185,7 @@ function AppList({
                   role="button"
                   tabIndex={0}
                   aria-expanded={isSelected}
-                  aria-label={`View details for ${app.name}`}
+                  aria-label={`View build details for ${app.name}`}
                 >
                   <td className="max-w-xs px-6 py-4 align-top">
                     <div className="space-y-2">

--- a/apps/frontend/src/core/components/FullscreenPreview.tsx
+++ b/apps/frontend/src/core/components/FullscreenPreview.tsx
@@ -104,7 +104,7 @@ export function FullscreenOverlay({ preview, onClose }: FullscreenOverlayProps) 
         <div className="relative flex-1 overflow-hidden rounded-3xl border core-fullscreen-frame">
           {content ?? (
             <div className="flex h-full w-full items-center justify-center px-6 text-center text-scale-sm core-fullscreen-message">
-              Preview unavailable. Try opening the app preview in a new tab from the card instead.
+              Preview unavailable. Try opening the build preview in a new tab from the card instead.
             </div>
           )}
         </div>

--- a/apps/frontend/src/import/ImportWorkspace.tsx
+++ b/apps/frontend/src/import/ImportWorkspace.tsx
@@ -14,18 +14,18 @@ import {
   SECONDARY_BUTTON_LARGE
 } from './importTokens';
 
-const STEPS = ['service-manifests', 'apps', 'jobs', 'workflows'] as const;
+const STEPS = ['service-manifests', 'builds', 'jobs', 'workflows'] as const;
 
 const STEP_LABELS: Record<(typeof STEPS)[number], string> = {
   'service-manifests': 'Service manifests',
-  apps: 'Apps',
+  builds: 'Builds',
   jobs: 'Jobs',
   workflows: 'Workflows'
 };
 
 const STEP_DESCRIPTIONS: Record<(typeof STEPS)[number], string> = {
   'service-manifests': 'Register network and service configuration from manifest descriptors.',
-  apps: 'Connect repositories so AppHub can build and launch containers.',
+  builds: 'Connect repositories so AppHub can build and launch containers.',
   jobs: 'Upload or reference job bundles to keep automation assets in sync.',
   workflows: 'Create workflow definitions and validate trigger dependencies.'
 };
@@ -79,7 +79,7 @@ export default function ImportWorkspace({
       <header className="flex flex-col gap-2">
         <h1 className={HEADING_PRIMARY}>Import workspace assets</h1>
         <p className={SUBTEXT}>
-          Seed your AppHub environment with services, apps, job bundles, and workflows. Pick a category below and follow the
+          Seed your AppHub environment with services, builds, job bundles, and workflows. Pick a category below and follow the
           guided form to upload configuration manually.
         </p>
       </header>
@@ -101,7 +101,7 @@ export default function ImportWorkspace({
         {activeStep === 'service-manifests' && (
           <ServiceManifestsTab onImported={onManifestImported} />
         )}
-        {activeStep === 'apps' && <ImportAppsTab onAppRegistered={onAppRegistered} onViewCore={onViewCore} />}
+        {activeStep === 'builds' && <ImportAppsTab onAppRegistered={onAppRegistered} onViewCore={onViewCore} />}
         {activeStep === 'jobs' && <ImportJobBundleTab />}
         {activeStep === 'workflows' && <ImportWorkflowTab />}
       </section>
@@ -110,8 +110,8 @@ export default function ImportWorkspace({
         <button type="button" className={PRIMARY_BUTTON} onClick={() => setActiveStep('service-manifests')}>
           Start with service manifests
         </button>
-        <button type="button" className={SECONDARY_BUTTON_LARGE} onClick={() => setActiveStep('apps')}>
-          Jump to apps
+        <button type="button" className={SECONDARY_BUTTON_LARGE} onClick={() => setActiveStep('builds')}>
+          Jump to builds
         </button>
       </footer>
     </div>

--- a/apps/frontend/src/import/tabs/ImportAppsTab.tsx
+++ b/apps/frontend/src/import/tabs/ImportAppsTab.tsx
@@ -44,7 +44,7 @@ const STATUS_BADGE_MAP: Record<string, string> = {
 
 const resolveStatusBadge = (status: string) => STATUS_BADGE_MAP[status] ?? STATUS_BADGE_NEUTRAL;
 
-const APP_DOC_URL = 'https://github.com/benediktbwimmer/apphub/blob/main/docs/architecture.md#apps';
+const BUILD_DOC_URL = 'https://github.com/benediktbwimmer/apphub/blob/main/docs/architecture.md#apps';
 
 function formatRelativeTime(timestamp: number | null) {
   if (!timestamp) {
@@ -106,8 +106,10 @@ export default function ImportAppsTab({ onAppRegistered, onViewCore }: ImportApp
     const appName = currentApp?.name ?? form.name;
     pushToast({
       tone: 'success',
-      title: 'App registration submitted',
-      description: appName ? `AppHub queued ingestion for ${appName}.` : 'AppHub queued ingestion for the new app.'
+      title: 'Build registration submitted',
+      description: appName
+        ? `AppHub queued ingestion for build ${appName}.`
+        : 'AppHub queued ingestion for the new build.'
     });
     lastSubmissionVersion.current = submissionVersion;
   }, [currentApp?.name, form.name, pushToast, submissionVersion]);
@@ -116,7 +118,7 @@ export default function ImportAppsTab({ onAppRegistered, onViewCore }: ImportApp
     if (!error || errorVersion === lastErrorVersion.current) {
       return;
     }
-    pushToast({ tone: 'error', title: 'App registration failed', description: error });
+    pushToast({ tone: 'error', title: 'Build registration failed', description: error });
     lastErrorVersion.current = errorVersion;
   }, [error, errorVersion, pushToast]);
 
@@ -148,7 +150,7 @@ export default function ImportAppsTab({ onAppRegistered, onViewCore }: ImportApp
           </div>
           <div className="flex flex-wrap gap-2">
             <FormButton size="sm" type="button" variant="secondary" onClick={resetForm}>
-              New app
+              New build
             </FormButton>
             {onViewCore ? (
               <FormButton size="sm" type="button" onClick={() => onViewCore()}>
@@ -183,7 +185,7 @@ export default function ImportAppsTab({ onAppRegistered, onViewCore }: ImportApp
             </ul>
           </div>
         ) : (
-          <p className={STATUS_META}>No ingestion history for this app yet.</p>
+          <p className={STATUS_META}>No ingestion history for this build yet.</p>
         )}
       </div>
     );
@@ -191,19 +193,19 @@ export default function ImportAppsTab({ onAppRegistered, onViewCore }: ImportApp
 
   return (
     <div className="flex flex-col gap-6 lg:grid lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
-      <FormSection as="form" onSubmit={handleSubmit} aria-label="Register application">
+      <FormSection as="form" onSubmit={handleSubmit} aria-label="Register build">
         <div className="flex flex-wrap items-center justify-between gap-2">
-          <h2 className={HEADING_SECONDARY}>Application details</h2>
+          <h2 className={HEADING_SECONDARY}>Build details</h2>
           {draftStatus ? <span className={STATUS_META}>Draft saved {draftStatus}</span> : null}
         </div>
         <div className={`${CARD_SECTION} text-scale-sm`}>
           <p className={BODY_TEXT}>
-            <strong>Apps</strong> represent container workloads that AppHub builds from a Dockerfile. Provide the repository URL
+            <strong>Builds</strong> represent container workloads that AppHub constructs from a Dockerfile. Provide the repository URL
             and the Dockerfile path relative to the repo root. For registering network endpoints or shared manifests, use the
             <strong> Service manifests</strong> tab.
           </p>
-          <a className={LINK_ACCENT} href={APP_DOC_URL} target="_blank" rel="noreferrer">
-            View app onboarding guide
+          <a className={LINK_ACCENT} href={BUILD_DOC_URL} target="_blank" rel="noreferrer">
+            View build onboarding guide
             <span aria-hidden="true">&rarr;</span>
           </a>
         </div>
@@ -223,30 +225,30 @@ export default function ImportAppsTab({ onAppRegistered, onViewCore }: ImportApp
             Local workspace
           </button>
         </div>
-        <FormField label="Application name" htmlFor="app-name">
+        <FormField label="Build name" htmlFor="build-name">
           <input
-            id="app-name"
+            id="build-name"
             className={INPUT}
             value={form.name}
             onChange={(event) => setForm((prev) => ({ ...prev, name: event.target.value }))}
-            placeholder="My Awesome App"
+            placeholder="My Awesome Build"
             required
           />
         </FormField>
-        <FormField label="Description" htmlFor="app-description">
+        <FormField label="Description" htmlFor="build-description">
           <textarea
-            id="app-description"
+            id="build-description"
             className={TEXTAREA}
             value={form.description}
             onChange={(event) => setForm((prev) => ({ ...prev, description: event.target.value }))}
-            placeholder="Describe the application so teammates recognize it in the catalog"
+            placeholder="Describe the build so teammates recognize it in the catalog"
             required
           />
         </FormField>
         <div className="grid gap-4 md:grid-cols-2">
-          <FormField label="Repository URL" htmlFor="app-repo">
+          <FormField label="Repository URL" htmlFor="build-repo">
             <input
-              id="app-repo"
+              id="build-repo"
               className={INPUT}
               value={form.repoUrl}
               onChange={(event) => setForm((prev) => ({ ...prev, repoUrl: event.target.value }))}
@@ -254,9 +256,9 @@ export default function ImportAppsTab({ onAppRegistered, onViewCore }: ImportApp
               required
             />
           </FormField>
-          <FormField label="Dockerfile path" htmlFor="app-dockerfile">
+          <FormField label="Dockerfile path" htmlFor="build-dockerfile">
             <input
-              id="app-dockerfile"
+              id="build-dockerfile"
               className={INPUT}
               value={form.dockerfilePath}
               onChange={(event) => setForm((prev) => ({ ...prev, dockerfilePath: event.target.value }))}
@@ -293,9 +295,9 @@ export default function ImportAppsTab({ onAppRegistered, onViewCore }: ImportApp
             </button>
           </div>
         </div>
-        <FormField label="Metadata strategy" htmlFor="app-metadata">
+        <FormField label="Metadata strategy" htmlFor="build-metadata">
           <select
-            id="app-metadata"
+            id="build-metadata"
             className={INPUT}
             value={form.metadataStrategy}
             onChange={(event) => setForm((prev) => ({ ...prev, metadataStrategy: event.target.value as 'auto' | 'explicit' }))}
@@ -307,7 +309,7 @@ export default function ImportAppsTab({ onAppRegistered, onViewCore }: ImportApp
         {error ? <FormFeedback tone="error">{error}</FormFeedback> : null}
         <FormActions>
           <FormButton type="submit" disabled={submitting || disableSubmit}>
-            {submitting ? 'Submitting...' : 'Register app'}
+            {submitting ? 'Submitting...' : 'Register build'}
           </FormButton>
           <FormButton type="button" variant="secondary" onClick={resetForm}>
             Reset form

--- a/apps/frontend/src/import/tabs/ServiceManifestsTab.tsx
+++ b/apps/frontend/src/import/tabs/ServiceManifestsTab.tsx
@@ -44,7 +44,7 @@ function describePlaceholderUsages(placeholder: ManifestPlaceholder) {
         case 'network-service':
           return `Network ${occurrence.networkId} -> service ${occurrence.serviceSlug} · env ${envKey} (source: ${source})`;
         case 'app-launch':
-          return `App ${occurrence.appId} (network ${occurrence.networkId}) · env ${envKey} (source: ${source})`;
+          return `Build ${occurrence.appId} (network ${occurrence.networkId}) · env ${envKey} (source: ${source})`;
         default:
           return `env ${envKey} (source: ${source})`;
       }
@@ -161,7 +161,7 @@ export default function ServiceManifestsTab({ onImported }: ServiceManifestsTabP
         <div className={`${CARD_SECTION} gap-2`}>
           <p className={BODY_TEXT}>
             Provide either a Git repository or Docker image containing the manifest bundle to register services and networks.
-            When you want AppHub to build a container from source, continue with the <strong>Apps</strong> tab instead.
+            When you want AppHub to build a container from source, continue with the <strong>Builds</strong> tab instead.
           </p>
           <a className={LINK_ACCENT} href={SERVICE_MANIFEST_DOC_URL} target="_blank" rel="noreferrer">
             Learn more about service manifests

--- a/apps/frontend/src/import/useImportApp.ts
+++ b/apps/frontend/src/import/useImportApp.ts
@@ -187,7 +187,7 @@ export function useImportApp(onAppRegistered?: (id: string) => void): UseImportA
     const interval = window.setInterval(async () => {
       try {
       if (!activeToken) {
-        throw new Error('Authentication required to load app status');
+        throw new Error('Authentication required to load build status');
       }
       const payload = await fetchRepository(activeToken, appId, { signal: controller.signal });
       setCurrentApp(payload);

--- a/apps/frontend/src/routes/paths.ts
+++ b/apps/frontend/src/routes/paths.ts
@@ -78,16 +78,16 @@ export type PrimaryNavigationItem = {
 
 export const PRIMARY_NAV_ITEMS: readonly PrimaryNavigationItem[] = [
   { key: 'overview', label: 'Overview', path: ROUTE_PATHS.overview },
-  { key: 'observability', label: 'Observability', path: ROUTE_PATHS.observability },
-  { key: 'core', label: 'Apps', path: ROUTE_PATHS.core },
-  { key: 'events', label: 'Events', path: ROUTE_PATHS.events },
-  { key: 'assets', label: 'Assets', path: ROUTE_PATHS.assets },
-  { key: 'services', label: 'Services', path: ROUTE_PATHS.services },
   { key: 'runs', label: 'Runs', path: ROUTE_PATHS.runs },
-  { key: 'jobs', label: 'Jobs', path: ROUTE_PATHS.jobs },
-  { key: 'workflows', label: 'Workflows', path: ROUTE_PATHS.workflows },
+  { key: 'events', label: 'Events', path: ROUTE_PATHS.events },
+  { key: 'services', label: 'Services', path: ROUTE_PATHS.services },
   { key: 'topology', label: 'Topology', path: ROUTE_PATHS.topology },
+  { key: 'workflows', label: 'Workflows', path: ROUTE_PATHS.workflows },
+  { key: 'jobs', label: 'Jobs', path: ROUTE_PATHS.jobs },
   { key: 'schedules', label: 'Schedules', path: ROUTE_PATHS.schedules },
+  { key: 'assets', label: 'Assets', path: ROUTE_PATHS.assets },
+  { key: 'observability', label: 'Observability', path: ROUTE_PATHS.observability },
+  { key: 'core', label: 'Builds', path: ROUTE_PATHS.core },
   { key: 'settings', label: 'Settings', path: ROUTE_PATHS.settings }
 ] as const;
 

--- a/apps/frontend/src/services/ServiceGallery.tsx
+++ b/apps/frontend/src/services/ServiceGallery.tsx
@@ -105,7 +105,7 @@ function ServicePreviewCard({ service, embedUrl }: ServicePreviewCardProps) {
   const manifest = service.metadata?.manifest ?? null;
   const runtime = service.metadata?.runtime ?? null;
   const moduleConfig = toModuleServiceConfig(service.metadata?.config);
-  const linkedApps = service.metadata?.linkedApps ?? manifest?.apps ?? null;
+  const linkedBuilds = service.metadata?.linkedApps ?? manifest?.apps ?? null;
   const manifestSourceLabel = manifest?.source ?? (manifest?.sources?.[0] ?? 'manifest import');
   const runtimeLabel =
     runtime?.repositoryId ?? moduleConfig?.module?.id ?? runtime?.baseUrl ?? 'not linked';
@@ -178,27 +178,27 @@ function ServicePreviewCard({ service, embedUrl }: ServicePreviewCardProps) {
                 {manifestSourceLabel}
               </dd>
             </div>
-          <div className="flex flex-col gap-1">
-            <dt>Runtime App</dt>
-            <dd className={SERVICE_PREVIEW_DETAIL_VALUE_CLASSES}>{runtimeLabel}</dd>
-          </div>
-          {previewPath ? (
             <div className="flex flex-col gap-1">
-              <dt>Preview Path</dt>
-              <dd className={SERVICE_PREVIEW_DETAIL_VALUE_CLASSES}>{previewPath}</dd>
+              <dt>Runtime Build</dt>
+              <dd className={SERVICE_PREVIEW_DETAIL_VALUE_CLASSES}>{runtimeLabel}</dd>
             </div>
-          ) : null}
-          {moduleTags && moduleTags.length > 0 ? (
+            {previewPath ? (
+              <div className="flex flex-col gap-1">
+                <dt>Preview Path</dt>
+                <dd className={SERVICE_PREVIEW_DETAIL_VALUE_CLASSES}>{previewPath}</dd>
+              </div>
+            ) : null}
+            {moduleTags && moduleTags.length > 0 ? (
+              <div className="flex flex-col gap-1">
+                <dt>Tags</dt>
+                <dd className={SERVICE_PREVIEW_DETAIL_VALUE_CLASSES}>{moduleTags.join(', ')}</dd>
+              </div>
+            ) : null}
             <div className="flex flex-col gap-1">
-              <dt>Tags</dt>
-              <dd className={SERVICE_PREVIEW_DETAIL_VALUE_CLASSES}>{moduleTags.join(', ')}</dd>
-            </div>
-          ) : null}
-          <div className="flex flex-col gap-1">
-            <dt>Linked Apps</dt>
-            <dd className={SERVICE_PREVIEW_DETAIL_VALUE_CLASSES}>
-              {linkedApps && linkedApps.length > 0 ? linkedApps.join(', ') : 'none'}
-            </dd>
+              <dt>Linked Builds</dt>
+              <dd className={SERVICE_PREVIEW_DETAIL_VALUE_CLASSES}>
+                {linkedBuilds && linkedBuilds.length > 0 ? linkedBuilds.join(', ') : 'none'}
+              </dd>
             </div>
           </dl>
           {service.metadata?.notes && <p className={SERVICE_PREVIEW_NOTES_CLASSES}>{service.metadata.notes}</p>}


### PR DESCRIPTION
## Summary
- rename UI copy from apps to builds across nav, import flows, and core catalog surfaces
- swap the overview apps section for an event scheduler snapshot with queue and retry metrics
- refresh services metadata labels and data hooks to align with the builds terminology

## Testing
- npm run lint --workspace @apphub/frontend -- --cache