### PR TITLE
feat: add staging observability metrics

### DIFF
--- a/docs/environment-config.md
+++ b/docs/environment-config.md
@@ -49,6 +49,20 @@ The `getAuthConfig` loader and associated tests (`services/core/tests/authConfig
 
 Metastore-specific tests (`services/metastore/tests/unit/serviceConfig.test.ts`) exercise inline mode toggles, Redis validation, and token parsing via the shared helper.
 
+## Timestore Service
+
+| Variable | Default | Notes |
+| --- | --- | --- |
+| `TIMESTORE_STAGING_DIRECTORY` | `<repo>/services/data/timestore/staging` | Root path for DuckDB staging files; created on boot if missing. |
+| `TIMESTORE_STAGING_MAX_DATASET_BYTES` | `536_870_912` (512 MiB) | Per-dataset guardrail; `0` disables the warning. Pair with `timestore_staging_disk_usage_bytes`. |
+| `TIMESTORE_STAGING_MAX_TOTAL_BYTES` | `0` | Global staging footprint ceiling. `0` leaves the global check disabled. |
+| `TIMESTORE_STAGING_MAX_PENDING` | `64` | In-memory queue depth per dataset before new batches are rejected. |
+| `TIMESTORE_STAGING_FLUSH_MAX_ROWS` | `50_000` | Flush trigger when staged rows exceed the threshold. `0` disables the row-based trigger. |
+| `TIMESTORE_STAGING_FLUSH_MAX_BYTES` | `134_217_728` (128 MiB) | Flush trigger based on DuckDB on-disk size. `0` disables the byte trigger. |
+| `TIMESTORE_STAGING_FLUSH_MAX_AGE_MS` | `60_000` (60s) | Flush trigger when the oldest batch waits longer than the threshold. `0` flushes eagerly whenever staging is non-empty. |
+
+Datasets can override the flush thresholds via metadata (`dataset.metadata.staging.flush`). Operators should document the overrides alongside alert thresholds so dashboards reflect the effective limits.
+
 ## Adding New Configuration
 
 1. Declare expected variables in your service with `z.object({ ... }).passthrough()`.

--- a/docs/runbooks/timestore-staging-operations.md
+++ b/docs/runbooks/timestore-staging-operations.md
@@ -1,0 +1,43 @@
+# Timestore Staging Operations
+
+This runbook covers how to roll out, monitor, and triage the DuckDB-based staging pipeline that now fronts timestore ingestion. The guidance replaces the legacy "direct parquet write" path - only the staging queue should feed partition builds once these steps are complete.
+
+## Enablement Checklist
+
+1. **Provision disk space** - ensure the host (or StatefulSet volume) can accommodate the configured guardrails. Use the defaults (`512 MB` per dataset, optional global ceiling) or set tighter values with `TIMESTORE_STAGING_MAX_DATASET_BYTES` / `TIMESTORE_STAGING_MAX_TOTAL_BYTES`.
+2. **Configure the service** - set the following environment variables in the deployment manifest:
+   - `TIMESTORE_STAGING_DIRECTORY`
+   - `TIMESTORE_STAGING_MAX_DATASET_BYTES`, `TIMESTORE_STAGING_MAX_TOTAL_BYTES`, `TIMESTORE_STAGING_MAX_PENDING`
+   - `TIMESTORE_STAGING_FLUSH_MAX_ROWS`, `TIMESTORE_STAGING_FLUSH_MAX_BYTES`, `TIMESTORE_STAGING_FLUSH_MAX_AGE_MS`
+3. **Capture dataset overrides** - if a dataset needs custom flush behaviour, add `{"staging": {"flush": { ... }}}` to its metadata and document the override in the operations dashboard (so alerts use the correct thresholds).
+4. **Deploy staging-ready workers** - recycle ingestion workers and API pods so they pick up the new configuration and the staged flush pipeline.
+5. **Retire direct writers** - remove any cronjobs or scripts that previously wrote Parquet directly to storage; workers should now enqueue through the staging manager.
+
+## Monitoring & Alerting
+
+Embed the new metrics in the timestore dashboard:
+
+- `timestore_staging_queue_depth{metric="batches"}` - staged backlog. Warn at 20, page at 50.
+- `timestore_staging_queue_depth{metric="rows"}` - helps size flush batches and correlate with compaction cost.
+- `timestore_staging_oldest_age_seconds` - flush lag; alert when the oldest batch waits >120s.
+- `timestore_staging_disk_usage_bytes{component="total"}` - compare to the per-dataset max; alert at 75%/90%.
+- `timestore_staging_flush_duration_seconds` - histogram for success/failure latency. Track p95 for regression detection.
+- `timestore_staging_flush_batches_total` / `timestore_staging_flush_rows_total` - useful for rate panels (successful vs failed flush volume).
+- `timestore_staging_dropped_batches_total` - increments when a dataset exhausts its in-memory queue or size guardrail; triggers should investigate backpressure.
+- `timestore_staging_retried_batches_total` - increments when a flush aborts and batches are returned to staging; page when this grows together with drop counters.
+
+Tie alerts back to the configuration so operators know whether to scale hardware, raise thresholds, or throttle producers.
+
+## Failure Recovery
+
+1. **Flush aborts** - spikes in `timestore_staging_retried_batches_total` mean the flush failed. Inspect the worker logs for DuckDB export errors. The batches remain staged; once the blocker is cleared, the next ingestion job will reattempt.
+2. **Queue saturation** - `timestore_staging_dropped_batches_total{reason="queue_full"}` indicates producers are outpacing the staging manager. Raise `TIMESTORE_STAGING_MAX_PENDING`, spread writes across multiple datasets, or throttle producers.
+3. **Disk pressure** - if `timestore_staging_disk_usage_bytes` approaches the guardrail, drain the queue (manual flush via ingestion API) and increase `TIMESTORE_STAGING_MAX_*` or expand storage.
+4. **Broken thresholds** - when production datasets require different flush cadence, set metadata overrides instead of tuning global defaults, then update dashboards to reflect the new limits.
+
+## Decommission Legacy Parquet Writes
+
+- Remove or disable any worker feature flags that allowed bypassing staging.
+- Delete temporary directories that previously held inline Parquet payloads once the staging directory is stable.
+- Update runbooks and dashboards that referenced the legacy compaction alert pipeline; the new metrics supersede them.
+- Document the migration in the service release notes (see `docs/timestore-staging-release-notes.md`) and link product teams to the new dashboards.

--- a/docs/timestore-staging-release-notes.md
+++ b/docs/timestore-staging-release-notes.md
@@ -1,0 +1,34 @@
+# Timestore Staging Release Notes
+
+## Summary
+
+The ingestion pipeline now stages all writes through DuckDB before partition builds. This release introduces flush orchestration, queue guardrails, and Prometheus instrumentation so operators can monitor backlog, disk usage, and retry rates. Direct Parquet writes are deprecated and will be removed after this rollout.
+
+## What's New
+
+- DuckDB staging queue with per-dataset concurrency limits and size guardrails.
+- Configurable flush thresholds (rows, bytes, age) plus dataset-level overrides.
+- New Prometheus series for staging queue depth, disk usage, flush latency, and drop/retry counters.
+- Runbook (`docs/runbooks/timestore-staging-operations.md`) covering enablement, monitoring, and recovery.
+
+## Upgrade Checklist
+
+1. Roll the new binaries/workers so ingestion jobs use the staging queue.
+2. Set the staging environment variables (`TIMESTORE_STAGING_*`) in deployment manifests; adjust values for production data volumes.
+3. Update dashboards to include the new metrics and wire the recommended alerts (see `docs/timestore-observability.md`).
+4. Validate on a non-production environment:
+   - Run representative ingestion workloads.
+   - Confirm `timestore_staging_queue_depth` settles near zero after drains.
+   - Verify flush latency (`timestore_staging_flush_duration_seconds`) stays within SLOs.
+5. Remove or disable any feature flags or scripts that bypass staging.
+
+## Rollback / Contingency
+
+- If staging introduces regressions, set `TIMESTORE_STAGING_MAX_PENDING` to a higher value and flush manually to buy time.
+- As a last resort, redeploy the previous release and restore the legacy ingestion config (be sure to clear the staging directory to avoid disk pressure when rolling forward again).
+
+## Operator Notes
+
+- Use `timestore_staging_dropped_batches_total` and `timestore_staging_retried_batches_total` to page the on-call when backpressure starts.
+- Guardrails are soft warnings today; exceeding `TIMESTORE_STAGING_MAX_*` logs a warning and increments metrics—plan follow-up work if hard enforcement is required.
+- Document any dataset-level flush overrides so alert thresholds and dashboards stay accurate.

--- a/services/timestore/src/ingestion/flushPlanner.ts
+++ b/services/timestore/src/ingestion/flushPlanner.ts
@@ -1,0 +1,122 @@
+import type { ServiceConfig, StagingFlushConfig } from '../config/serviceConfig';
+import type { DatasetRecord } from '../db/metadata';
+import {
+  DuckDbSpoolManager,
+  type DatasetStagingSummary,
+  type PreparedFlushResult
+} from '../storage/spoolManager';
+
+export interface FlushPreparation {
+  summary: DatasetStagingSummary;
+  thresholds: StagingFlushConfig;
+  result: PreparedFlushResult;
+}
+
+export function resolveFlushThresholds(
+  config: ServiceConfig,
+  dataset: DatasetRecord | null
+): StagingFlushConfig {
+  const global = config.staging.flush;
+  const overrides = extractDatasetOverrides(dataset);
+  return {
+    maxRows: normalizeThreshold(overrides?.maxRows, global.maxRows),
+    maxBytes: normalizeThreshold(overrides?.maxBytes, global.maxBytes),
+    maxAgeMs: normalizeThreshold(overrides?.maxAgeMs, global.maxAgeMs)
+  } satisfies StagingFlushConfig;
+}
+
+export function shouldTriggerFlush(
+  summary: DatasetStagingSummary,
+  thresholds: StagingFlushConfig,
+  nowMs = Date.now()
+): boolean {
+  if (summary.pendingBatchCount === 0) {
+    return false;
+  }
+
+  if (thresholds.maxRows > 0 && summary.pendingRowCount >= thresholds.maxRows) {
+    return true;
+  }
+
+  if (thresholds.maxBytes > 0 && summary.onDiskBytes >= thresholds.maxBytes) {
+    return true;
+  }
+
+  if (thresholds.maxAgeMs > 0 && summary.oldestStagedAt) {
+    const oldest = new Date(summary.oldestStagedAt).getTime();
+    if (Number.isFinite(oldest) && nowMs - oldest >= thresholds.maxAgeMs) {
+      return true;
+    }
+  }
+
+  if (thresholds.maxRows === 0 && thresholds.maxBytes === 0 && thresholds.maxAgeMs === 0) {
+    // All thresholds disabled; fall back to eager flush when anything is staged
+    return true;
+  }
+
+  return false;
+}
+
+export async function maybePrepareDatasetFlush(
+  spoolManager: DuckDbSpoolManager,
+  datasetSlug: string,
+  thresholds: StagingFlushConfig,
+  nowMs = Date.now()
+): Promise<FlushPreparation | null> {
+  const summary = await spoolManager.getDatasetSummary(datasetSlug);
+  if (!shouldTriggerFlush(summary, thresholds, nowMs)) {
+    return null;
+  }
+  const prepared = await spoolManager.prepareFlush(datasetSlug);
+  if (!prepared) {
+    return null;
+  }
+  return {
+    summary,
+    thresholds,
+    result: prepared
+  } satisfies FlushPreparation;
+}
+
+function extractDatasetOverrides(dataset: DatasetRecord | null): Partial<StagingFlushConfig> | null {
+  if (!dataset || !dataset.metadata || typeof dataset.metadata !== 'object') {
+    return null;
+  }
+  const staging = (dataset.metadata as Record<string, unknown>).staging;
+  if (!staging || typeof staging !== 'object') {
+    return null;
+  }
+  const flush = (staging as Record<string, unknown>).flush;
+  if (!flush || typeof flush !== 'object') {
+    return null;
+  }
+  const overrides: Partial<StagingFlushConfig> = {};
+  if (isFiniteNumber((flush as Record<string, unknown>).maxRows)) {
+    overrides.maxRows = Math.max(0, Math.floor(Number((flush as Record<string, unknown>).maxRows)));
+  }
+  if (isFiniteNumber((flush as Record<string, unknown>).maxBytes)) {
+    overrides.maxBytes = Math.max(0, Math.floor(Number((flush as Record<string, unknown>).maxBytes)));
+  }
+  if (isFiniteNumber((flush as Record<string, unknown>).maxAgeMs)) {
+    overrides.maxAgeMs = Math.max(0, Math.floor(Number((flush as Record<string, unknown>).maxAgeMs)));
+  }
+  return Object.keys(overrides).length > 0 ? overrides : null;
+}
+
+function normalizeThreshold(value: number | undefined, fallback: number): number {
+  if (value === undefined || !Number.isFinite(value)) {
+    return fallback >= 0 ? fallback : 0;
+  }
+  return value >= 0 ? value : 0;
+}
+
+function isFiniteNumber(input: unknown): input is number {
+  if (typeof input === 'number') {
+    return Number.isFinite(input);
+  }
+  if (typeof input === 'string' && input.trim().length > 0) {
+    const parsed = Number(input);
+    return Number.isFinite(parsed);
+  }
+  return false;
+}

--- a/services/timestore/src/ingestion/processor.ts
+++ b/services/timestore/src/ingestion/processor.ts
@@ -27,7 +27,7 @@ import { loadServiceConfig } from '../config/serviceConfig';
 import type { FieldDefinition } from '../storage';
 import { ensureDefaultStorageTarget } from '../service/bootstrap';
 import type { IngestionJobPayload, IngestionProcessingResult } from './types';
-import { observeIngestionJob } from '../observability/metrics';
+import { observeIngestionJob, observeStagingFlush, recordStagingRetry } from '../observability/metrics';
 import { publishTimestoreEvent } from '../events/publisher';
 import { endSpan, startSpan } from '../observability/tracing';
 import { invalidateSqlRuntimeCache } from '../sql/runtime';
@@ -35,6 +35,9 @@ import { refreshManifestCache } from '../cache/manifestCache';
 import { deriveManifestShardKey } from '../service/manifestShard';
 import { computePartitionIndexForRows } from '../indexing/partitionIndex';
 import { executePartitionBuild } from './partitionBuilderClient';
+import { getStagingWriteManager } from './stagingManager';
+import { resolveFlushThresholds, maybePrepareDatasetFlush } from './flushPlanner';
+import type { PreparedFlushBatch, StagePartitionRequest } from '../storage/spoolManager';
 import {
   analyzeSchemaCompatibility,
   extractFieldDefinitions,
@@ -62,6 +65,7 @@ export async function processIngestionJob(
   payload: IngestionJobPayload
 ): Promise<IngestionProcessingResult> {
   const config = loadServiceConfig();
+  const stagingManager = getStagingWriteManager(config);
   const datasetSlug = payload.datasetSlug.trim();
   const span = startSpan('timestore.ingest.process', {
     'timestore.dataset_slug': datasetSlug
@@ -70,8 +74,9 @@ export async function processIngestionJob(
   try {
     const storageTarget = await resolveStorageTarget(payload);
 
-    let dataset: DatasetRecord | null = await getDatasetBySlug(datasetSlug);
-    if (!dataset) {
+    const existingDataset = await getDatasetBySlug(datasetSlug);
+    let dataset: DatasetRecord;
+    if (!existingDataset) {
       dataset = await createDataset({
         id: `ds-${randomUUID()}`,
         slug: datasetSlug,
@@ -82,16 +87,19 @@ export async function processIngestionJob(
           createdBy: 'timestore-ingestion'
         }
       });
-    } else if (!dataset.defaultStorageTargetId) {
-      await updateDatasetDefaultStorageTarget(dataset.id, storageTarget.id);
+    } else if (!existingDataset.defaultStorageTargetId) {
+      await updateDatasetDefaultStorageTarget(existingDataset.id, storageTarget.id);
       dataset = {
-        ...dataset,
+        ...existingDataset,
         defaultStorageTargetId: storageTarget.id
       };
+    } else {
+      dataset = existingDataset;
     }
 
     const reuseExistingPartition = async (
-      partition: DatasetPartitionRecord
+      partition: DatasetPartitionRecord,
+      idempotencyKey: string | null | undefined
     ): Promise<IngestionProcessingResult | null> => {
       const manifest = await getManifestById(partition.manifestId);
       if (!manifest) {
@@ -99,11 +107,11 @@ export async function processIngestionJob(
       }
 
       const existingTarget = await getStorageTargetById(partition.storageTargetId);
-      if (payload.idempotencyKey) {
+      if (idempotencyKey) {
         await recordIngestionBatch({
           id: `ing-${randomUUID()}`,
           datasetId: dataset.id,
-          idempotencyKey: payload.idempotencyKey,
+          idempotencyKey,
           manifestId: manifest.id
         });
       }
@@ -113,12 +121,12 @@ export async function processIngestionJob(
         result: 'success',
         durationSeconds: durationSince(start)
       });
-      endSpan(span);
       return {
         dataset,
         manifest,
         storageTarget: existingTarget ?? storageTarget,
-        idempotencyKey: payload.idempotencyKey
+        idempotencyKey: idempotencyKey ?? null,
+        flushPending: false
       };
     };
 
@@ -137,7 +145,8 @@ export async function processIngestionJob(
             dataset,
             manifest,
             storageTarget,
-            idempotencyKey: payload.idempotencyKey
+            idempotencyKey: payload.idempotencyKey,
+            flushPending: false
           };
         }
       }
@@ -178,19 +187,6 @@ export async function processIngestionJob(
     }
 
     const schemaChecksum = createSchemaChecksum(schemaFields);
-    let schemaVersion = await findSchemaVersionByChecksum(dataset.id, schemaChecksum);
-    if (!schemaVersion) {
-      const version = await getNextSchemaVersion(dataset.id);
-      schemaVersion = await createDatasetSchemaVersion({
-        id: `dsv-${randomUUID()}`,
-        datasetId: dataset.id,
-        version,
-        description: `Schema derived from ingestion at ${payload.receivedAt}`,
-        schema: { fields: schemaFields },
-        checksum: schemaChecksum
-      });
-    }
-
     const partitionKey = normalizeStringMap(payload.partition.key) ?? {};
     const partitionAttributes = normalizeStringMap(payload.partition.attributes ?? null);
     const partitionKeyString = buildPartitionKeyString(partitionKey);
@@ -210,234 +206,406 @@ export async function processIngestionJob(
       ingestionSignature
     );
     if (existingPartitionBySignature) {
-      const reused = await reuseExistingPartition(existingPartitionBySignature);
+      const reused = await reuseExistingPartition(existingPartitionBySignature, payload.idempotencyKey ?? null);
       if (reused) {
+        endSpan(span);
         return reused;
       }
     }
 
-    const partitionId = `part-${randomUUID()}`;
     const tableName = payload.tableName ?? 'records';
-    const partitionIndex = computePartitionIndexForRows(
-      payload.rows ?? [],
-      schemaFields,
-      config.partitionIndex
-    );
-    const writeResult = await executePartitionBuild(config, {
+    const stageRequest: StagePartitionRequest = {
       datasetSlug,
-      storageTarget,
-      partitionId,
-      partitionKey: payload.partition.key,
       tableName,
       schema: schemaFields,
       rows: payload.rows,
-      rowCountHint: payload.rows?.length
-    });
-    const partitionInput = {
-      id: partitionId,
-      storageTargetId: storageTarget.id,
-      fileFormat: 'parquet' as const,
-      filePath: writeResult.relativePath,
       partitionKey,
-      startTime,
-      endTime,
-      fileSizeBytes: writeResult.fileSizeBytes,
-      rowCount: writeResult.rowCount,
-      checksum: writeResult.checksum,
-      metadata: {
-        tableName,
-        schemaVersionId: schemaVersion.id,
-        ...(partitionAttributes ? { attributes: partitionAttributes } : {})
+      partitionAttributes: partitionAttributes ?? null,
+      timeRange: {
+        start: payload.partition.timeRange.start,
+        end: payload.partition.timeRange.end
       },
-      columnStatistics: partitionIndex.columnStatistics,
-      columnBloomFilters: partitionIndex.columnBloomFilters,
-      ingestionSignature
-    } satisfies PartitionInput;
-
-    const summaryPatch = {
-      batchRowCount: writeResult.rowCount,
-      tableName,
-      lastPartitionId: partitionId,
-      lastIngestedAt: payload.receivedAt,
-      schemaVersionId: schemaVersion.id
-    } satisfies Record<string, unknown>;
-
-    const metadataPatch: Record<string, unknown> = {
-      tableName,
-      storageTargetId: storageTarget.id,
-      schemaVersionId: schemaVersion.id,
-      ...(partitionAttributes ? { attributes: partitionAttributes } : {})
+      ingestionSignature,
+      receivedAt: payload.receivedAt
     };
 
-    if (compatibility?.status === 'additive' && compatibility.addedFields.length > 0) {
-      metadataPatch.schemaEvolution = {
-        status: 'additive',
-        addedColumns: compatibility.addedFields.map((field) => field.name),
-        requestedBackfill: backfillRequested
-      } satisfies Record<string, unknown>;
+    await stagingManager.enqueue({
+      ...stageRequest,
+      idempotencyKey: payload.idempotencyKey ?? null,
+      schemaDefaults,
+      backfillRequested
+    });
+
+    const spoolManager = stagingManager.getSpoolManager();
+    const flushThresholds = resolveFlushThresholds(config, dataset);
+    const flushPreparation = await maybePrepareDatasetFlush(spoolManager, datasetSlug, flushThresholds);
+
+    if (!flushPreparation) {
+      observeIngestionJob({
+        datasetSlug,
+        result: 'success',
+        durationSeconds: durationSince(start)
+      });
+
+      endSpan(span);
+      return {
+        dataset,
+        manifest: previousManifest ?? baselineManifest ?? null,
+        storageTarget,
+        idempotencyKey: payload.idempotencyKey,
+        flushPending: true
+      } satisfies IngestionProcessingResult;
     }
 
-    let manifest: import('../db/metadata').DatasetManifestWithPartitions;
+    const flushStart = process.hrtime.bigint();
+    const flushBatchCount = flushPreparation.result.batches.length;
+    const flushRowCount = flushPreparation.result.batches.reduce(
+      (total, batch) => total + Math.max(0, Number(batch.rowCount ?? 0)),
+      0
+    );
 
-    const canReuseManifest =
-      Boolean(previousManifest) &&
-      (previousManifest?.schemaVersionId === schemaVersion.id || compatibility?.status === 'additive');
+    const schemaVersionCache = new Map<string, string>();
+    const manifestByShard = new Map<string, import('../db/metadata').DatasetManifestWithPartitions>();
+    let latestManifest: import('../db/metadata').DatasetManifestWithPartitions | null = null;
+    let globalBaselineManifest = baselineManifest ?? null;
 
     try {
-      if (previousManifest && canReuseManifest) {
-        manifest = await appendPartitionsToManifest({
-          datasetId: dataset.id,
-          manifestId: previousManifest.id,
-          partitions: [partitionInput],
-          summaryPatch,
-          metadataPatch,
-          schemaVersionId: schemaVersion.id
-        });
-      } else {
-        const manifestVersion = await getNextManifestVersion(dataset.id);
-        manifest = await createDatasetManifest({
-          id: `dm-${randomUUID()}`,
-          datasetId: dataset.id,
-          version: manifestVersion,
-          status: 'published',
-          manifestShard,
-          schemaVersionId: schemaVersion.id,
-          parentManifestId: previousManifest?.id ?? null,
-          summary: summaryPatch,
-          statistics: {
-            rowCount: writeResult.rowCount,
-            fileSizeBytes: writeResult.fileSizeBytes,
-            startTime: startTime.toISOString(),
-            endTime: endTime.toISOString()
-          },
-          metadata: metadataPatch,
-          createdBy: 'timestore-ingestion',
-          partitions: [partitionInput]
-        });
-      }
-    } catch (error) {
-      if (isIngestionSignatureConflict(error)) {
-        const existingPartition = await findPartitionByIngestionSignature(
-          dataset.id,
-          ingestionSignature
-        );
-        if (existingPartition) {
-          const reused = await reuseExistingPartition(existingPartition);
-          if (reused) {
-            return reused;
-          }
+      for (const batch of flushPreparation.result.batches) {
+        const manifest = await processFlushBatch(batch);
+        if (manifest) {
+          latestManifest = manifest;
+          manifestByShard.set(manifest.manifestShard, manifest);
+          globalBaselineManifest = manifest;
         }
       }
+
+      await spoolManager.finalizeFlush(datasetSlug, flushPreparation.result.flushToken);
+
+      observeStagingFlush({
+        datasetSlug,
+        result: 'success',
+        durationSeconds: durationSince(flushStart),
+        batches: flushBatchCount,
+        rows: flushRowCount
+      });
+
+      observeIngestionJob({
+        datasetSlug,
+        result: 'success',
+        durationSeconds: durationSince(start)
+      });
+
+      endSpan(span);
+      return {
+        dataset,
+        manifest: latestManifest ?? previousManifest ?? baselineManifest ?? null,
+        storageTarget,
+        idempotencyKey: payload.idempotencyKey,
+        flushPending: false
+      } satisfies IngestionProcessingResult;
+    } catch (error) {
+      let retryStats: { batches: number; rows: number } | null = null;
+      try {
+        retryStats = await spoolManager.abortFlush(datasetSlug, flushPreparation.result.flushToken);
+      } catch (abortError) {
+        retryStats = null;
+      }
+
+      observeStagingFlush({
+        datasetSlug,
+        result: 'failure',
+        durationSeconds: durationSince(flushStart),
+        batches: flushBatchCount,
+        rows: flushRowCount
+      });
+
+      recordStagingRetry({
+        datasetSlug,
+        reason: 'flush_abort',
+        batches: retryStats?.batches ?? (flushBatchCount > 0 ? flushBatchCount : 1)
+      });
+
+      observeIngestionJob({
+        datasetSlug,
+        result: 'failure',
+        durationSeconds: durationSince(start)
+      });
+
+      endSpan(span, error);
       throw error;
     }
 
-    if (payload.idempotencyKey) {
-      await recordIngestionBatch({
-        id: `ing-${randomUUID()}`,
-        datasetId: dataset.id,
-        idempotencyKey: payload.idempotencyKey,
-        manifestId: manifest.id
-      });
-    }
+    async function processFlushBatch(batch: PreparedFlushBatch): Promise<import('../db/metadata').DatasetManifestWithPartitions> {
+      const schemaFields = normalizeFieldDefinitions(batch.schema);
+      const partitionKey = batch.partitionKey ?? {};
+      const partitionAttributes = batch.partitionAttributes ?? null;
+      const partitionKeyString = buildPartitionKeyString(partitionKey);
+      const startTime = new Date(batch.timeRange.start);
+      const endTime = new Date(batch.timeRange.end);
 
-    try {
-      const partitionsWithTargets = await getPartitionsWithTargetsForManifest(manifest.id);
-      const { partitions: _cachedPartitions, ...manifestRecord } = manifest;
-      await refreshManifestCache(
-        { id: dataset.id, slug: dataset.slug },
-        manifestRecord,
-        partitionsWithTargets
-      );
-    } catch (err) {
-      console.warn('[timestore] failed to refresh manifest cache after ingestion', err);
-    }
+      if (!Number.isFinite(startTime.getTime()) || !Number.isFinite(endTime.getTime())) {
+        throw new Error('Staged partition includes invalid time range');
+      }
 
-    observeIngestionJob({
-      datasetSlug,
-      result: 'success',
-      durationSeconds: durationSince(start)
-    });
+      const manifestShardKey = deriveManifestShardKey(startTime);
 
-    const addedColumns = compatibility?.addedFields.map((field) => field.name) ?? [];
+      let shardManifest = manifestByShard.get(manifestShardKey);
+      if (!shardManifest) {
+        const fetchedManifest = await getLatestPublishedManifest(dataset.id, { shard: manifestShardKey });
+        if (fetchedManifest) {
+          shardManifest = fetchedManifest;
+          manifestByShard.set(manifestShardKey, fetchedManifest);
+        }
+      }
 
-    try {
-      await publishTimestoreEvent(
-        'timestore.partition.created',
-        {
+      let baselineForCompatibility = shardManifest ?? globalBaselineManifest;
+      if (!baselineForCompatibility) {
+        baselineForCompatibility = await getLatestPublishedManifest(dataset.id);
+        globalBaselineManifest = baselineForCompatibility;
+      }
+
+      let compatibility: SchemaCompatibilityResult | null = null;
+      if (baselineForCompatibility?.schemaVersionId) {
+        const baselineSchemaVersion = await getSchemaVersionById(baselineForCompatibility.schemaVersionId);
+        const baselineFields = baselineSchemaVersion
+          ? extractFieldDefinitions(baselineSchemaVersion.schema)
+          : [];
+        compatibility = analyzeSchemaCompatibility(baselineFields, schemaFields);
+        if (compatibility.status === 'breaking') {
+          throw new SchemaEvolutionError(datasetSlug, compatibility);
+        }
+      }
+
+      const schemaChecksum = createSchemaChecksum(schemaFields);
+      let schemaVersionId = schemaVersionCache.get(schemaChecksum);
+      let schemaVersionRecord = schemaVersionId
+        ? await getSchemaVersionById(schemaVersionId)
+        : await findSchemaVersionByChecksum(dataset.id, schemaChecksum);
+
+      if (!schemaVersionRecord) {
+        const versionNumber = await getNextSchemaVersion(dataset.id);
+        schemaVersionRecord = await createDatasetSchemaVersion({
+          id: `dsv-${randomUUID()}`,
           datasetId: dataset.id,
-          datasetSlug,
-          manifestId: manifest.id,
-          partitionId,
-          partitionKey: partitionKeyString,
-          partitionKeyFields: partitionKey,
-          storageTargetId: storageTarget.id,
-          filePath: writeResult.relativePath,
-          rowCount: writeResult.rowCount,
-          fileSizeBytes: writeResult.fileSizeBytes,
-          checksum: writeResult.checksum ?? null,
-          receivedAt: payload.receivedAt,
-          attributes: partitionAttributes ?? null
+          version: versionNumber,
+          description: `Schema derived from staged ingestion at ${batch.receivedAt}`,
+          schema: { fields: schemaFields },
+          checksum: schemaChecksum
+        });
+      }
+      schemaVersionCache.set(schemaChecksum, schemaVersionRecord.id);
+
+      const partitionIndex = computePartitionIndexForRows(batch.rows, schemaFields, config.partitionIndex);
+
+      const partitionId = `part-${randomUUID()}`;
+      const writeResult = await executePartitionBuild(config, {
+        datasetSlug,
+        storageTarget,
+        partitionId,
+        partitionKey,
+        tableName: batch.tableName,
+        schema: schemaFields,
+        sourceFilePath: batch.parquetFilePath,
+        rowCountHint: batch.rowCount
+      });
+
+      const partitionInput: PartitionInput = {
+        id: partitionId,
+        storageTargetId: storageTarget.id,
+        fileFormat: 'parquet',
+        filePath: writeResult.relativePath,
+        partitionKey,
+        startTime,
+        endTime,
+        fileSizeBytes: writeResult.fileSizeBytes,
+        rowCount: writeResult.rowCount,
+        checksum: writeResult.checksum,
+        metadata: {
+          tableName: batch.tableName,
+          schemaVersionId: schemaVersionRecord.id,
+          ...(partitionAttributes ? { attributes: partitionAttributes } : {})
         },
-        'timestore.ingest'
-      );
-    } catch (err) {
-      console.error('[timestore] failed to publish partition.created event', err);
-    }
+        columnStatistics: partitionIndex.columnStatistics,
+        columnBloomFilters: partitionIndex.columnBloomFilters,
+        ingestionSignature: batch.ingestionSignature
+      };
 
-    if (addedColumns.length > 0) {
+      const summaryPatch = {
+        batchRowCount: writeResult.rowCount,
+        tableName: batch.tableName,
+        lastPartitionId: partitionId,
+        lastIngestedAt: batch.receivedAt,
+        schemaVersionId: schemaVersionRecord.id
+      } satisfies Record<string, unknown>;
+
+      const metadataPatch: Record<string, unknown> = {
+        tableName: batch.tableName,
+        storageTargetId: storageTarget.id,
+        schemaVersionId: schemaVersionRecord.id,
+        ...(partitionAttributes ? { attributes: partitionAttributes } : {})
+      };
+
+      if (compatibility?.status === 'additive' && compatibility.addedFields.length > 0) {
+        metadataPatch.schemaEvolution = {
+          status: 'additive',
+          addedColumns: compatibility.addedFields.map((field) => field.name),
+          requestedBackfill: batch.backfillRequested === true
+        } satisfies Record<string, unknown>;
+      }
+
+      let manifest: import('../db/metadata').DatasetManifestWithPartitions;
+
+      const canReuseManifest =
+        Boolean(shardManifest) &&
+        (shardManifest?.schemaVersionId === schemaVersionRecord.id || compatibility?.status === 'additive');
+
+      try {
+        if (shardManifest && canReuseManifest) {
+          manifest = await appendPartitionsToManifest({
+            datasetId: dataset.id,
+            manifestId: shardManifest.id,
+            partitions: [partitionInput],
+            summaryPatch,
+            metadataPatch,
+            schemaVersionId: schemaVersionRecord.id
+          });
+        } else {
+          const manifestVersion = await getNextManifestVersion(dataset.id);
+          manifest = await createDatasetManifest({
+            id: `dm-${randomUUID()}`,
+            datasetId: dataset.id,
+            version: manifestVersion,
+            status: 'published',
+            manifestShard: manifestShardKey,
+            schemaVersionId: schemaVersionRecord.id,
+            parentManifestId: shardManifest?.id ?? null,
+            summary: summaryPatch,
+            statistics: {
+              rowCount: writeResult.rowCount,
+              fileSizeBytes: writeResult.fileSizeBytes,
+              startTime: startTime.toISOString(),
+              endTime: endTime.toISOString()
+            },
+            metadata: metadataPatch,
+            createdBy: 'timestore-ingestion',
+            partitions: [partitionInput]
+          });
+        }
+      } catch (error) {
+        if (isIngestionSignatureConflict(error)) {
+          const existingPartition = await findPartitionByIngestionSignature(
+            dataset.id,
+            batch.ingestionSignature
+          );
+          if (existingPartition) {
+            const reused = await reuseExistingPartition(existingPartition, batch.idempotencyKey ?? null);
+            if (reused?.manifest) {
+              return reused.manifest;
+            }
+          }
+        }
+        throw error;
+      }
+
+      if (batch.idempotencyKey) {
+        await recordIngestionBatch({
+          id: `ing-${randomUUID()}`,
+          datasetId: dataset.id,
+          idempotencyKey: batch.idempotencyKey,
+          manifestId: manifest.id
+        });
+      }
+
+      try {
+        const partitionsWithTargets = await getPartitionsWithTargetsForManifest(manifest.id);
+        const { partitions: _cachedPartitions, ...manifestRecord } = manifest;
+        await refreshManifestCache(
+          { id: dataset.id, slug: dataset.slug },
+          manifestRecord,
+          partitionsWithTargets
+        );
+      } catch (err) {
+        console.warn('[timestore] failed to refresh manifest cache after ingestion', err);
+      }
+
+      const addedColumns = compatibility?.addedFields.map((field) => field.name) ?? [];
+
       try {
         await publishTimestoreEvent(
-          'timestore.schema.evolved',
+          'timestore.partition.created',
           {
             datasetId: dataset.id,
             datasetSlug,
             manifestId: manifest.id,
-            previousManifestId: previousManifest?.id ?? null,
-            schemaVersionId: schemaVersion.id,
-            addedColumns
+            partitionId,
+            partitionKey: partitionKeyString,
+            partitionKeyFields: partitionKey,
+            storageTargetId: storageTarget.id,
+            filePath: writeResult.relativePath,
+            rowCount: writeResult.rowCount,
+            fileSizeBytes: writeResult.fileSizeBytes,
+            checksum: writeResult.checksum ?? null,
+            receivedAt: batch.receivedAt,
+            attributes: partitionAttributes ?? null
           },
           'timestore.ingest'
         );
       } catch (err) {
-        console.error('[timestore] failed to publish schema.evolved event', err);
+        console.error('[timestore] failed to publish partition.created event', err);
       }
-    }
 
-    if (backfillRequested && addedColumns.length > 0) {
-      try {
-        const defaults = Object.fromEntries(
-          addedColumns.map((column) => [column, schemaDefaults[column] ?? null])
-        );
-        await publishTimestoreEvent(
-          'timestore.schema.backfill.requested',
-          {
-            datasetId: dataset.id,
-            datasetSlug,
-            manifestId: manifest.id,
-            schemaVersionId: schemaVersion.id,
-            addedColumns,
-            defaults
-          },
-          'timestore.ingest'
-        );
-      } catch (err) {
-        console.error('[timestore] failed to publish schema.backfill.requested event', err);
+      if (addedColumns.length > 0) {
+        try {
+          await publishTimestoreEvent(
+            'timestore.schema.evolved',
+            {
+              datasetId: dataset.id,
+              datasetSlug,
+              manifestId: manifest.id,
+              previousManifestId: shardManifest?.id ?? null,
+              schemaVersionId: schemaVersionRecord.id,
+              addedColumns
+            },
+            'timestore.ingest'
+          );
+        } catch (err) {
+          console.error('[timestore] failed to publish schema.evolved event', err);
+        }
       }
+
+      if (batch.backfillRequested && addedColumns.length > 0) {
+        try {
+          const defaultsSource = batch.schemaDefaults ?? {};
+          const defaults = Object.fromEntries(
+            addedColumns.map((column) => [column, (defaultsSource as Record<string, unknown>)[column] ?? null])
+          );
+          await publishTimestoreEvent(
+            'timestore.schema.backfill.requested',
+            {
+              datasetId: dataset.id,
+              datasetSlug,
+              manifestId: manifest.id,
+              schemaVersionId: schemaVersionRecord.id,
+              addedColumns,
+              defaults
+            },
+            'timestore.ingest'
+          );
+        } catch (err) {
+          console.error('[timestore] failed to publish schema.backfill.requested event', err);
+        }
+      }
+
+      invalidateSqlRuntimeCache({
+        datasetId: dataset.id,
+        datasetSlug,
+        reason: 'ingestion'
+      });
+
+      globalBaselineManifest = manifest;
+      manifestByShard.set(manifest.manifestShard, manifest);
+      return manifest;
     }
-
-    invalidateSqlRuntimeCache({
-      datasetId: dataset.id,
-      datasetSlug,
-      reason: 'ingestion'
-    });
-
-    endSpan(span);
-    return {
-      dataset,
-      manifest,
-      storageTarget,
-      idempotencyKey: payload.idempotencyKey
-    };
   } catch (error) {
     observeIngestionJob({
       datasetSlug,

--- a/services/timestore/src/ingestion/stagingManager.ts
+++ b/services/timestore/src/ingestion/stagingManager.ts
@@ -1,0 +1,155 @@
+import type { ServiceConfig } from '../config/serviceConfig';
+import {
+  DuckDbSpoolManager,
+  type StagePartitionRequest,
+  type StagePartitionResult
+} from '../storage/spoolManager';
+import { recordStagingDrop } from '../observability/metrics';
+
+interface StagingManagerOptions {
+  directory: string;
+  maxDatasetBytes: number;
+  maxTotalBytes: number;
+  maxPendingPerDataset: number;
+}
+
+export class StagingQueueFullError extends Error {
+  constructor(datasetSlug: string, capacity: number) {
+    super(`staging queue for dataset '${datasetSlug}' reached capacity (${capacity})`);
+    this.name = 'StagingQueueFullError';
+  }
+}
+
+class DatasetQueue {
+  private readonly pending: Array<{
+    request: StagePartitionRequest;
+    resolve: (value: StagePartitionResult) => void;
+    reject: (error: unknown) => void;
+  }> = [];
+  private processing = false;
+  private inflight = 0;
+
+  constructor(
+    private readonly datasetSlug: string,
+    private readonly spoolManager: DuckDbSpoolManager,
+    private readonly options: { maxPending: number }
+  ) {}
+
+  enqueue(request: StagePartitionRequest): Promise<StagePartitionResult> {
+    if (this.pending.length + this.inflight >= this.options.maxPending) {
+      recordStagingDrop({ datasetSlug: this.datasetSlug, reason: 'queue_full' });
+      return Promise.reject(new StagingQueueFullError(this.datasetSlug, this.options.maxPending));
+    }
+
+    return new Promise<StagePartitionResult>((resolve, reject) => {
+      this.pending.push({ request, resolve, reject });
+      void this.process();
+    });
+  }
+
+  private async process(): Promise<void> {
+    if (this.processing) {
+      return;
+    }
+    this.processing = true;
+    try {
+      while (this.pending.length > 0) {
+        const item = this.pending.shift()!;
+        try {
+          this.inflight += 1;
+          const stageResult = await this.spoolManager.stagePartition(item.request);
+          item.resolve(stageResult);
+        } catch (error) {
+          item.reject(error);
+        } finally {
+          this.inflight -= 1;
+        }
+      }
+    } finally {
+      this.processing = false;
+    }
+  }
+}
+
+class StagingWriteManager {
+  private readonly spoolManager: DuckDbSpoolManager;
+  private readonly queues = new Map<string, DatasetQueue>();
+  private readonly maxPendingPerDataset: number;
+
+  constructor(options: StagingManagerOptions) {
+    this.spoolManager = new DuckDbSpoolManager({
+      directory: options.directory,
+      maxDatasetBytes: options.maxDatasetBytes,
+      maxTotalBytes: options.maxTotalBytes
+    });
+    this.maxPendingPerDataset = options.maxPendingPerDataset;
+  }
+
+  enqueue(request: StagePartitionRequest): Promise<StagePartitionResult> {
+    const queue = this.getOrCreateQueue(request.datasetSlug);
+    return queue.enqueue(request);
+  }
+
+  async close(): Promise<void> {
+    await this.spoolManager.close();
+    this.queues.clear();
+  }
+
+  getSpoolManager(): DuckDbSpoolManager {
+    return this.spoolManager;
+  }
+
+  private getOrCreateQueue(datasetSlug: string): DatasetQueue {
+    let queue = this.queues.get(datasetSlug);
+    if (!queue) {
+      queue = new DatasetQueue(datasetSlug, this.spoolManager, {
+        maxPending: this.maxPendingPerDataset
+      });
+      this.queues.set(datasetSlug, queue);
+    }
+    return queue;
+  }
+}
+
+let activeManager: StagingWriteManager | null = null;
+let activeOptionsSignature: string | null = null;
+
+function buildOptionsSignature(options: StagingManagerOptions): string {
+  return JSON.stringify({
+    directory: options.directory,
+    maxDatasetBytes: options.maxDatasetBytes,
+    maxTotalBytes: options.maxTotalBytes,
+    maxPendingPerDataset: options.maxPendingPerDataset
+  });
+}
+
+function toManagerOptions(config: ServiceConfig): StagingManagerOptions {
+  return {
+    directory: config.staging.directory,
+    maxDatasetBytes: config.staging.maxDatasetBytes,
+    maxTotalBytes: config.staging.maxTotalBytes,
+    maxPendingPerDataset: config.staging.maxPendingPerDataset
+  } satisfies StagingManagerOptions;
+}
+
+export function getStagingWriteManager(config: ServiceConfig): StagingWriteManager {
+  const options = toManagerOptions(config);
+  const signature = buildOptionsSignature(options);
+  if (activeManager && activeOptionsSignature === signature) {
+    return activeManager;
+  }
+  if (activeManager) {
+    void activeManager.close().catch(() => undefined);
+  }
+  activeManager = new StagingWriteManager(options);
+  activeOptionsSignature = signature;
+  return activeManager;
+}
+
+export async function resetStagingWriteManager(): Promise<void> {
+  if (activeManager) {
+    await activeManager.close();
+    activeManager = null;
+    activeOptionsSignature = null;
+  }
+}

--- a/services/timestore/src/observability/metrics.ts
+++ b/services/timestore/src/observability/metrics.ts
@@ -139,6 +139,14 @@ interface MetricsState {
   ingestQueueJobs: Gauge<string> | null;
   ingestJobsTotal: Counter<string> | null;
   ingestJobDurationSeconds: Histogram<string> | null;
+  stagingQueueDepth: Gauge<string> | null;
+  stagingOldestAgeSeconds: Gauge<string> | null;
+  stagingDiskUsageBytes: Gauge<string> | null;
+  stagingFlushDurationSeconds: Histogram<string> | null;
+  stagingFlushBatchesTotal: Counter<string> | null;
+  stagingFlushRowsTotal: Counter<string> | null;
+  stagingDroppedBatchesTotal: Counter<string> | null;
+  stagingRetriedBatchesTotal: Counter<string> | null;
   partitionBuildQueueJobs: Gauge<string> | null;
   partitionBuildJobsTotal: Counter<string> | null;
   partitionBuildJobDurationSeconds: Histogram<string> | null;
@@ -182,6 +190,7 @@ interface MetricsState {
 }
 
 const INGESTION_BUCKETS = [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10];
+const STAGING_FLUSH_BUCKETS = [0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 20, 30, 60];
 const QUERY_BUCKETS = [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5];
 const QUERY_ROWS_BUCKETS = [1, 10, 100, 1_000, 10_000, 100_000];
 const LIFECYCLE_BUCKETS = [0.1, 0.5, 1, 2, 5, 10, 30, 60, 120, 300];
@@ -246,6 +255,79 @@ export function setupMetrics(options: MetricsOptions): MetricsState {
         help: 'Duration of ingestion job processing in seconds',
         labelNames: ['dataset'],
         buckets: INGESTION_BUCKETS,
+        registers: registerMetrics
+      })
+    : null;
+
+  const stagingQueueDepth = enabled
+    ? new Gauge({
+        name: `${prefix}staging_queue_depth`,
+        help: 'Pending staging backlog grouped by dataset and metric',
+        labelNames: ['dataset', 'metric'],
+        registers: registerMetrics
+      })
+    : null;
+
+  const stagingOldestAgeSeconds = enabled
+    ? new Gauge({
+        name: `${prefix}staging_oldest_age_seconds`,
+        help: 'Age in seconds of the oldest staged batch per dataset',
+        labelNames: ['dataset'],
+        registers: registerMetrics
+      })
+    : null;
+
+  const stagingDiskUsageBytes = enabled
+    ? new Gauge({
+        name: `${prefix}staging_disk_usage_bytes`,
+        help: 'Bytes consumed by staging DuckDB files grouped by dataset and component',
+        labelNames: ['dataset', 'component'],
+        registers: registerMetrics
+      })
+    : null;
+
+  const stagingFlushDurationSeconds = enabled
+    ? new Histogram({
+        name: `${prefix}staging_flush_duration_seconds`,
+        help: 'Duration of staging flushes grouped by dataset and result',
+        labelNames: ['dataset', 'result'],
+        buckets: STAGING_FLUSH_BUCKETS,
+        registers: registerMetrics
+      })
+    : null;
+
+  const stagingFlushBatchesTotal = enabled
+    ? new Counter({
+        name: `${prefix}staging_flush_batches_total`,
+        help: 'Batches drained from staging flushes grouped by dataset and result',
+        labelNames: ['dataset', 'result'],
+        registers: registerMetrics
+      })
+    : null;
+
+  const stagingFlushRowsTotal = enabled
+    ? new Counter({
+        name: `${prefix}staging_flush_rows_total`,
+        help: 'Rows drained from staging flushes grouped by dataset and result',
+        labelNames: ['dataset', 'result'],
+        registers: registerMetrics
+      })
+    : null;
+
+  const stagingDroppedBatchesTotal = enabled
+    ? new Counter({
+        name: `${prefix}staging_dropped_batches_total`,
+        help: 'Batches dropped from staging grouped by dataset and reason',
+        labelNames: ['dataset', 'reason'],
+        registers: registerMetrics
+      })
+    : null;
+
+  const stagingRetriedBatchesTotal = enabled
+    ? new Counter({
+        name: `${prefix}staging_retried_batches_total`,
+        help: 'Batches returned to staging for retry grouped by dataset and reason',
+        labelNames: ['dataset', 'reason'],
         registers: registerMetrics
       })
     : null;
@@ -633,6 +715,14 @@ export function setupMetrics(options: MetricsOptions): MetricsState {
     ingestQueueJobs,
     ingestJobsTotal,
     ingestJobDurationSeconds,
+    stagingQueueDepth,
+    stagingOldestAgeSeconds,
+    stagingDiskUsageBytes,
+    stagingFlushDurationSeconds,
+    stagingFlushBatchesTotal,
+    stagingFlushRowsTotal,
+    stagingDroppedBatchesTotal,
+    stagingRetriedBatchesTotal,
     partitionBuildQueueJobs,
     partitionBuildJobsTotal,
     partitionBuildJobDurationSeconds,
@@ -703,6 +793,117 @@ export function updateIngestionQueueDepth(counts: IngestionQueueCounts): void {
     return;
   }
   setGaugeValues(state.ingestQueueJobs, counts);
+}
+
+export interface StagingSummaryMetricsInput {
+  datasetSlug: string;
+  pendingBatchCount: number;
+  pendingRowCount: number;
+  oldestStagedAt?: string | null;
+  databaseSizeBytes: number;
+  walSizeBytes: number;
+  onDiskBytes: number;
+}
+
+export function setStagingSummaryMetrics(input: StagingSummaryMetricsInput): void {
+  const state = metricsState;
+  if (!state?.enabled) {
+    return;
+  }
+
+  const dataset = input.datasetSlug;
+  const batches = Math.max(0, input.pendingBatchCount);
+  const rows = Math.max(0, input.pendingRowCount);
+
+  if (state.stagingQueueDepth) {
+    state.stagingQueueDepth.labels(dataset, 'batches').set(batches);
+    state.stagingQueueDepth.labels(dataset, 'rows').set(rows);
+  }
+
+  if (state.stagingOldestAgeSeconds) {
+    let ageSeconds = 0;
+    if (input.oldestStagedAt) {
+      const oldestTimestamp = new Date(input.oldestStagedAt).getTime();
+      if (Number.isFinite(oldestTimestamp)) {
+        ageSeconds = (Date.now() - oldestTimestamp) / 1_000;
+        if (!Number.isFinite(ageSeconds) || ageSeconds < 0) {
+          ageSeconds = 0;
+        }
+      }
+    }
+    state.stagingOldestAgeSeconds.labels(dataset).set(ageSeconds);
+  }
+
+  if (state.stagingDiskUsageBytes) {
+    state.stagingDiskUsageBytes.labels(dataset, 'database').set(sanitizeMetricValue(input.databaseSizeBytes));
+    state.stagingDiskUsageBytes.labels(dataset, 'wal').set(sanitizeMetricValue(input.walSizeBytes));
+    state.stagingDiskUsageBytes.labels(dataset, 'total').set(sanitizeMetricValue(input.onDiskBytes));
+  }
+}
+
+export type StagingFlushResult = 'success' | 'failure';
+
+export interface StagingFlushMetricsInput {
+  datasetSlug: string;
+  result: StagingFlushResult;
+  durationSeconds: number;
+  batches: number;
+  rows: number;
+}
+
+export function observeStagingFlush(input: StagingFlushMetricsInput): void {
+  const state = metricsState;
+  if (!state?.enabled) {
+    return;
+  }
+
+  const dataset = input.datasetSlug;
+  const result: StagingFlushResult = input.result === 'failure' ? 'failure' : 'success';
+  const duration = sanitizeMetricValue(input.durationSeconds);
+  const batches = Math.max(0, Math.floor(Number.isFinite(input.batches) ? input.batches : 0));
+  const rows = Math.max(0, Math.floor(Number.isFinite(input.rows) ? input.rows : 0));
+
+  if (state.stagingFlushDurationSeconds) {
+    state.stagingFlushDurationSeconds.labels(dataset, result).observe(duration);
+  }
+  if (state.stagingFlushBatchesTotal) {
+    state.stagingFlushBatchesTotal.labels(dataset, result).inc(batches);
+  }
+  if (state.stagingFlushRowsTotal) {
+    state.stagingFlushRowsTotal.labels(dataset, result).inc(rows);
+  }
+}
+
+export type StagingDropReason = 'queue_full' | 'size_limit' | 'flush_abort' | 'unknown';
+
+export interface StagingDropMetricInput {
+  datasetSlug: string;
+  reason: StagingDropReason;
+}
+
+export function recordStagingDrop(input: StagingDropMetricInput): void {
+  const state = metricsState;
+  if (!state?.enabled || !state.stagingDroppedBatchesTotal) {
+    return;
+  }
+  const reason = normalizeReason(input.reason);
+  state.stagingDroppedBatchesTotal.labels(input.datasetSlug, reason).inc();
+}
+
+export interface StagingRetryMetricInput {
+  datasetSlug: string;
+  reason?: 'flush_abort' | 'manual';
+  batches?: number;
+}
+
+export function recordStagingRetry(input: StagingRetryMetricInput): void {
+  const state = metricsState;
+  if (!state?.enabled || !state.stagingRetriedBatchesTotal) {
+    return;
+  }
+  const reason = normalizeReason(input.reason ?? 'flush_abort');
+  const batches = Math.max(1, Math.floor(Number.isFinite(input.batches ?? NaN) ? (input.batches ?? 1) : 1));
+  state.stagingRetriedBatchesTotal.labels(input.datasetSlug, reason).inc(batches);
 }
 
 export function observeIngestionJob(input: IngestionJobMetricsInput): void {
@@ -1063,6 +1264,21 @@ export function metricsEnabled(): boolean {
 
 export function getMetricsRegistry(): Registry | null {
   return metricsState?.registry ?? null;
+}
+
+function sanitizeMetricValue(value: number): number {
+  if (!Number.isFinite(value) || value < 0) {
+    return 0;
+  }
+  return value;
+}
+
+function normalizeReason(reason: string): string {
+  if (!reason) {
+    return 'unknown';
+  }
+  const trimmed = reason.trim();
+  return trimmed.length > 0 ? trimmed.slice(0, 64) : 'unknown';
 }
 
 function setGaugeValues(

--- a/services/timestore/src/storage/spoolManager.ts
+++ b/services/timestore/src/storage/spoolManager.ts
@@ -1,0 +1,1132 @@
+import { randomUUID } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { loadDuckDb, isCloseable } from '@apphub/shared';
+import { setStagingSummaryMetrics } from '../observability/metrics';
+import type { FieldDefinition, FieldType } from './index';
+
+export interface DuckDbSpoolManagerOptions {
+  directory: string;
+  maxDatasetBytes: number;
+  maxTotalBytes: number;
+}
+
+export interface AppendRowsRequest {
+  datasetSlug: string;
+  tableName: string;
+  schema: FieldDefinition[];
+  rows?: Record<string, unknown>[];
+}
+
+export interface DatasetSpoolStats {
+  datasetSlug: string;
+  totalRows: number;
+  tables: Array<{
+    tableName: string;
+    rowCount: number;
+  }>;
+  databaseSizeBytes: number;
+  walSizeBytes: number;
+}
+
+export interface StagePartitionRequest {
+  datasetSlug: string;
+  tableName: string;
+  schema: FieldDefinition[];
+  rows?: Record<string, unknown>[];
+  partitionKey: Record<string, string>;
+  partitionAttributes?: Record<string, string> | null;
+  timeRange: {
+    start: string;
+    end: string;
+  };
+  ingestionSignature: string;
+  receivedAt: string;
+  idempotencyKey?: string | null;
+  schemaDefaults?: Record<string, unknown> | null;
+  backfillRequested?: boolean;
+}
+
+export interface StagePartitionResult {
+  datasetSlug: string;
+  tableName: string;
+  ingestionSignature: string;
+  batchId: string;
+  rowCount: number;
+  alreadyStaged: boolean;
+}
+
+export interface DatasetStagingSummary {
+  datasetSlug: string;
+  pendingBatchCount: number;
+  pendingRowCount: number;
+  oldestStagedAt?: string | null;
+  databaseSizeBytes: number;
+  walSizeBytes: number;
+  onDiskBytes: number;
+}
+
+export interface PreparedFlushBatch {
+  batchId: string;
+  ingestionSignature: string;
+  tableName: string;
+  schema: FieldDefinition[];
+  partitionKey: Record<string, string>;
+  partitionAttributes: Record<string, string> | null;
+  timeRange: {
+    start: string;
+    end: string;
+  };
+  rowCount: number;
+  receivedAt: string;
+  stagedAt: string;
+  idempotencyKey: string | null;
+  schemaDefaults: Record<string, unknown> | null;
+  backfillRequested: boolean;
+  rows: Record<string, unknown>[];
+  parquetFilePath: string;
+}
+
+export interface PreparedFlushResult {
+  datasetSlug: string;
+  flushToken: string;
+  batches: PreparedFlushBatch[];
+  preparedAt: string;
+}
+
+interface DatasetSpoolContext {
+  datasetSlug: string;
+  safeSlug: string;
+  directory: string;
+  databasePath: string;
+  catalogName: string;
+  db: any;
+  connection: any;
+  initialized: boolean;
+  metadataReady: boolean;
+}
+
+const SPOOL_SCHEMA = 'staging';
+const METADATA_TABLE = '__ingestion_batches';
+const INTERNAL_BATCH_ID_COLUMN = '__batch_id';
+const INTERNAL_STAGED_AT_COLUMN = '__staged_at';
+
+export class DuckDbSpoolManager {
+  private readonly rootReady: Promise<void>;
+  private readonly datasetContexts = new Map<string, DatasetSpoolContext>();
+  private readonly datasetLocks = new Map<string, Promise<void>>();
+
+  constructor(private readonly options: DuckDbSpoolManagerOptions) {
+    this.rootReady = fs.mkdir(options.directory, { recursive: true }).then(() => undefined);
+  }
+
+  async ensureDatasetSchema(datasetSlug: string): Promise<void> {
+    await this.runWithDatasetLock(datasetSlug, async () => {
+      const context = await this.getDatasetContext(datasetSlug);
+      if (!context.initialized) {
+        await run(
+          context.connection,
+          `CREATE SCHEMA IF NOT EXISTS ${qualifySchemaName(context.catalogName, SPOOL_SCHEMA)}`
+        );
+        await this.ensureMetadataTable(context);
+        context.initialized = true;
+      }
+    });
+  }
+
+  async appendRows(request: AppendRowsRequest): Promise<number> {
+    const rows = request.rows ?? [];
+    if (rows.length === 0) {
+      await this.ensureDatasetSchema(request.datasetSlug);
+      return 0;
+    }
+
+    return this.runWithDatasetLock(request.datasetSlug, async () => {
+      const context = await this.getDatasetContext(request.datasetSlug);
+      if (!context.initialized) {
+        await run(
+          context.connection,
+          `CREATE SCHEMA IF NOT EXISTS ${qualifySchemaName(context.catalogName, SPOOL_SCHEMA)}`
+        );
+        await this.ensureMetadataTable(context);
+        context.initialized = true;
+      }
+
+      const normalizedTableName = sanitizeTableName(request.tableName);
+      await this.ensureTable(context, normalizedTableName, request.schema);
+
+      await run(context.connection, 'BEGIN TRANSACTION');
+      try {
+        await this.insertRows(context, normalizedTableName, request.schema, rows);
+        await run(context.connection, 'COMMIT');
+      } catch (error) {
+        await run(context.connection, 'ROLLBACK').catch(() => undefined);
+        throw error;
+      }
+
+      await this.evaluateSizeThresholds(request.datasetSlug).catch(() => undefined);
+
+      return rows.length;
+    });
+  }
+
+  async getDatasetStats(datasetSlug: string): Promise<DatasetSpoolStats> {
+    return this.runWithDatasetLock(datasetSlug, async () => {
+      const context = await this.getDatasetContext(datasetSlug);
+      if (!context.initialized) {
+        await run(
+          context.connection,
+          `CREATE SCHEMA IF NOT EXISTS ${qualifySchemaName(context.catalogName, SPOOL_SCHEMA)}`
+        );
+        await this.ensureMetadataTable(context);
+        context.initialized = true;
+      }
+
+      const tableNames = await this.listTables(context);
+      const tables: DatasetSpoolStats['tables'] = [];
+      for (const tableName of tableNames) {
+        const qualified = qualifyTableName(context.catalogName, SPOOL_SCHEMA, tableName);
+        const row = await firstRow(
+          context.connection,
+          `SELECT COUNT(*)::BIGINT AS count FROM ${qualified}`
+        );
+        const rowCount = Number(row?.count ?? 0);
+        tables.push({ tableName, rowCount });
+      }
+
+      const databaseSize = await this.readDatabaseSize(context.connection);
+      const totalRows = tables.reduce((sum, entry) => sum + entry.rowCount, 0);
+
+      return {
+        datasetSlug,
+        totalRows,
+        tables,
+        databaseSizeBytes: databaseSize.databaseSizeBytes,
+        walSizeBytes: databaseSize.walSizeBytes
+      } satisfies DatasetSpoolStats;
+    });
+  }
+
+  async stagePartition(request: StagePartitionRequest): Promise<StagePartitionResult> {
+    return this.runWithDatasetLock(request.datasetSlug, async () => {
+      const context = await this.getDatasetContext(request.datasetSlug);
+      if (!context.initialized) {
+        await run(
+          context.connection,
+          `CREATE SCHEMA IF NOT EXISTS ${qualifySchemaName(context.catalogName, SPOOL_SCHEMA)}`
+        );
+        await this.ensureMetadataTable(context);
+        context.initialized = true;
+      }
+
+      await run(context.connection, 'BEGIN TRANSACTION');
+      try {
+        const metadataTable = qualifyTableName(context.catalogName, SPOOL_SCHEMA, METADATA_TABLE);
+        const existing = await firstRow(
+          context.connection,
+          `SELECT batch_id, row_count FROM ${metadataTable} WHERE ingestion_signature = ?`,
+          request.ingestionSignature
+        );
+        if (existing) {
+          await run(context.connection, 'ROLLBACK').catch(() => undefined);
+          return {
+            datasetSlug: request.datasetSlug,
+            tableName: request.tableName,
+            ingestionSignature: request.ingestionSignature,
+            batchId: String(existing.batch_id ?? ''),
+            rowCount: Number(existing.row_count ?? 0),
+            alreadyStaged: true
+          } satisfies StagePartitionResult;
+        }
+
+        const batchId = randomUUID();
+        const stagedAt = new Date(request.receivedAt);
+        const augmentedSchema = augmentSchema(request.schema);
+        await this.ensureTable(context, request.tableName, augmentedSchema);
+
+        if (request.rows && request.rows.length > 0) {
+          const rowsWithMetadata = request.rows.map((row) => ({
+            ...row,
+            [INTERNAL_BATCH_ID_COLUMN]: batchId,
+            [INTERNAL_STAGED_AT_COLUMN]: stagedAt
+          }));
+          await this.insertRows(context, request.tableName, augmentedSchema, rowsWithMetadata);
+        }
+
+        const metadataSql = `INSERT INTO ${metadataTable} (
+            ingestion_signature,
+            batch_id,
+            table_name,
+            schema_json,
+            partition_key_json,
+            partition_attributes_json,
+            time_range_start,
+            time_range_end,
+            row_count,
+            received_at,
+            staged_at,
+            idempotency_key,
+            schema_defaults_json,
+            schema_backfill_requested
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
+
+        await run(
+          context.connection,
+          metadataSql,
+          request.ingestionSignature,
+          batchId,
+          request.tableName,
+          JSON.stringify(request.schema),
+          JSON.stringify(request.partitionKey),
+          request.partitionAttributes ? JSON.stringify(request.partitionAttributes) : null,
+          new Date(request.timeRange.start),
+          new Date(request.timeRange.end),
+          request.rows ? request.rows.length : 0,
+          stagedAt,
+          stagedAt,
+          request.idempotencyKey ?? null,
+          request.schemaDefaults ? JSON.stringify(request.schemaDefaults) : null,
+          request.backfillRequested === true
+        );
+
+        await run(context.connection, 'COMMIT');
+
+        await this.evaluateSizeThresholds(request.datasetSlug).catch(() => undefined);
+        await this.refreshDatasetSummary(context);
+
+        return {
+          datasetSlug: request.datasetSlug,
+          tableName: request.tableName,
+          ingestionSignature: request.ingestionSignature,
+          batchId,
+          rowCount: request.rows ? request.rows.length : 0,
+          alreadyStaged: false
+        } satisfies StagePartitionResult;
+      } catch (error) {
+        await run(context.connection, 'ROLLBACK').catch(() => undefined);
+        throw error;
+      }
+    });
+  }
+
+  async dropDatasetSchema(datasetSlug: string): Promise<void> {
+    await this.runWithDatasetLock(datasetSlug, async () => {
+      const context = this.datasetContexts.get(datasetSlug);
+      if (context) {
+        await closeConnection(context.connection).catch(() => undefined);
+        if (isCloseable(context.db)) {
+          context.db.close();
+        }
+        this.datasetContexts.delete(datasetSlug);
+      }
+
+      const safeSlug = sanitizeDatasetSlug(datasetSlug);
+      const datasetDir = path.join(this.options.directory, safeSlug);
+      await fs.rm(datasetDir, { recursive: true, force: true });
+      setStagingSummaryMetrics({
+        datasetSlug,
+        pendingBatchCount: 0,
+        pendingRowCount: 0,
+        oldestStagedAt: null,
+        databaseSizeBytes: 0,
+        walSizeBytes: 0,
+        onDiskBytes: 0
+      });
+    });
+  }
+
+  async close(): Promise<void> {
+    const contexts = Array.from(this.datasetContexts.values());
+    this.datasetContexts.clear();
+    await Promise.all(
+      contexts.map(async (context) => {
+        await closeConnection(context.connection).catch(() => undefined);
+        if (isCloseable(context.db)) {
+          context.db.close();
+        }
+      })
+    );
+  }
+
+  private async getDatasetContext(datasetSlug: string): Promise<DatasetSpoolContext> {
+    const existing = this.datasetContexts.get(datasetSlug);
+    if (existing) {
+      return existing;
+    }
+
+    await this.rootReady;
+    const safeSlug = sanitizeDatasetSlug(datasetSlug);
+    const datasetDir = path.join(this.options.directory, safeSlug);
+    await fs.mkdir(datasetDir, { recursive: true });
+    const databasePath = path.join(datasetDir, 'staging.duckdb');
+    const parsedPath = path.parse(databasePath);
+    const catalogName = parsedPath.name;
+
+    const duckdb = loadDuckDb();
+    const db = new duckdb.Database(databasePath);
+    const connection = db.connect();
+
+    const context: DatasetSpoolContext = {
+      datasetSlug,
+      safeSlug,
+      directory: datasetDir,
+      databasePath,
+      catalogName,
+      db,
+      connection,
+      initialized: false,
+      metadataReady: false
+    };
+
+    this.datasetContexts.set(datasetSlug, context);
+    return context;
+  }
+
+  private async ensureTable(
+    context: DatasetSpoolContext,
+    tableName: string,
+    schema: FieldDefinition[]
+  ): Promise<void> {
+    if (schema.length === 0) {
+      throw new Error('Cannot create staging table without at least one column');
+    }
+
+    const qualified = qualifyTableName(context.catalogName, SPOOL_SCHEMA, tableName);
+    const escapedTableForPragma = qualified.replace(/'/g, "''");
+    let metadata: any[] = [];
+    try {
+      metadata = await all(
+        context.connection,
+        `PRAGMA table_info('${escapedTableForPragma}')`
+      );
+    } catch (error) {
+      if (!isMissingTableError(error)) {
+        throw error;
+      }
+      metadata = [];
+    }
+
+    if (metadata.length === 0) {
+      const columnsSql = schema
+        .map((field) => `${quoteIdentifier(field.name)} ${mapDuckDbType(field.type)}`)
+        .join(', ');
+      await run(context.connection, `CREATE TABLE ${qualified} (${columnsSql})`);
+      return;
+    }
+
+    const existingColumns = new Map<string, string>();
+    for (const column of metadata as Array<{ name: string; type: string }>) {
+      existingColumns.set(column.name, column.type?.toUpperCase() ?? '');
+    }
+
+    for (const field of schema) {
+      const expectedType = mapDuckDbType(field.type);
+      const existingType = existingColumns.get(field.name);
+      if (!existingType) {
+        await run(
+          context.connection,
+          `ALTER TABLE ${qualified} ADD COLUMN ${quoteIdentifier(field.name)} ${expectedType}`
+        );
+        continue;
+      }
+
+      if (existingType !== expectedType) {
+        throw new Error(
+          `Field '${field.name}' type mismatch in staging table '${tableName}'. Expected ${expectedType} but found ${existingType}.`
+        );
+      }
+    }
+  }
+
+  private async insertRows(
+    context: DatasetSpoolContext,
+    tableName: string,
+    schema: FieldDefinition[],
+    rows: Record<string, unknown>[]
+  ): Promise<void> {
+    if (rows.length === 0) {
+      return;
+    }
+
+    const qualified = qualifyTableName(context.catalogName, SPOOL_SCHEMA, tableName);
+    const columnNames = schema.map((field) => field.name);
+    const placeholders = columnNames.map(() => '?').join(', ');
+    const insertSql = `INSERT INTO ${qualified} (${columnNames.map(quoteIdentifier).join(', ')}) VALUES (${placeholders})`;
+
+    for (const row of rows) {
+      const values = columnNames.map((column, index) =>
+        coerceValue(row[column], schema[index]?.type ?? 'string')
+      );
+      await run(context.connection, insertSql, ...values);
+    }
+  }
+
+  private async ensureMetadataTable(context: DatasetSpoolContext): Promise<void> {
+    if (context.metadataReady) {
+      return;
+    }
+
+    const metadataTable = qualifyTableName(context.catalogName, SPOOL_SCHEMA, METADATA_TABLE);
+    await run(
+      context.connection,
+      `CREATE TABLE IF NOT EXISTS ${metadataTable} (
+        ingestion_signature VARCHAR PRIMARY KEY,
+        batch_id VARCHAR NOT NULL,
+        table_name VARCHAR NOT NULL,
+        schema_json VARCHAR NOT NULL,
+        partition_key_json VARCHAR NOT NULL,
+        partition_attributes_json VARCHAR,
+        time_range_start TIMESTAMP NOT NULL,
+        time_range_end TIMESTAMP NOT NULL,
+        row_count BIGINT NOT NULL,
+        received_at TIMESTAMP NOT NULL,
+        staged_at TIMESTAMP NOT NULL,
+        idempotency_key VARCHAR,
+        schema_defaults_json VARCHAR,
+        schema_backfill_requested BOOLEAN,
+        flush_token VARCHAR,
+        flush_started_at TIMESTAMP
+      )`
+    );
+
+    await this.ensureMetadataColumns(context);
+    await this.resetIncompleteFlushes(context);
+    context.metadataReady = true;
+  }
+
+  private async ensureMetadataColumns(context: DatasetSpoolContext): Promise<void> {
+    const metadataTable = qualifyTableName(context.catalogName, SPOOL_SCHEMA, METADATA_TABLE);
+    const escaped = metadataTable.replace(/"/g, '""');
+    const existingColumns = await all(
+      context.connection,
+      `PRAGMA table_info('${escaped}')`
+    );
+    const columnNames = new Set(existingColumns.map((column) => String(column.name ?? '')));
+
+    if (!columnNames.has('flush_token')) {
+      await run(context.connection, `ALTER TABLE ${metadataTable} ADD COLUMN flush_token VARCHAR`);
+    }
+    if (!columnNames.has('flush_started_at')) {
+      await run(
+        context.connection,
+        `ALTER TABLE ${metadataTable} ADD COLUMN flush_started_at TIMESTAMP`
+      );
+    }
+    if (!columnNames.has('idempotency_key')) {
+      await run(context.connection, `ALTER TABLE ${metadataTable} ADD COLUMN idempotency_key VARCHAR`);
+    }
+    if (!columnNames.has('schema_defaults_json')) {
+      await run(
+        context.connection,
+        `ALTER TABLE ${metadataTable} ADD COLUMN schema_defaults_json VARCHAR`
+      );
+    }
+    if (!columnNames.has('schema_backfill_requested')) {
+      await run(
+        context.connection,
+        `ALTER TABLE ${metadataTable} ADD COLUMN schema_backfill_requested BOOLEAN`
+      );
+    }
+  }
+
+  private async resetIncompleteFlushes(context: DatasetSpoolContext): Promise<void> {
+    const metadataTable = qualifyTableName(context.catalogName, SPOOL_SCHEMA, METADATA_TABLE);
+    await run(
+      context.connection,
+      `UPDATE ${metadataTable} SET flush_token = NULL, flush_started_at = NULL WHERE flush_token IS NOT NULL`
+    );
+  }
+
+  private async listTables(context: DatasetSpoolContext): Promise<string[]> {
+    const rows = await all(
+      context.connection,
+      `SELECT table_name
+         FROM information_schema.tables
+        WHERE table_catalog = ?
+          AND table_schema = ?
+          AND table_type = 'BASE TABLE'
+        ORDER BY table_name`,
+      context.catalogName,
+      SPOOL_SCHEMA
+    );
+    return rows
+      .map((row) => String(row.table_name))
+      .filter((name) => name !== METADATA_TABLE);
+  }
+
+  private async readDatabaseSize(connection: any): Promise<{
+    databaseSizeBytes: number;
+    walSizeBytes: number;
+  }> {
+    const row = await firstRow(connection, 'SELECT * FROM pragma_database_size()');
+    const databaseSizeBytes = parseSizeString(typeof row?.database_size === 'string' ? row.database_size : null);
+    const walSizeBytes = parseSizeString(typeof row?.wal_size === 'string' ? row.wal_size : null);
+    return { databaseSizeBytes, walSizeBytes };
+  }
+
+  private async evaluateSizeThresholds(datasetSlug: string): Promise<void> {
+    const datasetSize = await this.computeDatasetBytes(datasetSlug);
+    if (this.options.maxDatasetBytes > 0 && datasetSize > this.options.maxDatasetBytes) {
+      console.warn(
+        `[timestore] staging dataset '${datasetSlug}' exceeded maxDatasetBytes (${datasetSize} > ${this.options.maxDatasetBytes})`
+      );
+    }
+
+    if (this.options.maxTotalBytes > 0) {
+      const totalSize = await this.computeTotalBytes();
+      if (totalSize > this.options.maxTotalBytes) {
+        console.warn(
+          `[timestore] total staging footprint exceeded maxTotalBytes (${totalSize} > ${this.options.maxTotalBytes})`
+        );
+      }
+    }
+  }
+
+  private async computeDatasetBytes(datasetSlug: string): Promise<number> {
+    const safeSlug = sanitizeDatasetSlug(datasetSlug);
+    const datasetDir = path.join(this.options.directory, safeSlug);
+    const files = ['staging.duckdb', 'staging.duckdb.wal'];
+    let total = 0;
+    for (const file of files) {
+      const filePath = path.join(datasetDir, file);
+      try {
+        const stats = await fs.stat(filePath);
+        total += stats.size;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+          throw error;
+        }
+      }
+    }
+    return total;
+  }
+
+  private async computeTotalBytes(): Promise<number> {
+    const entries = await fs.readdir(this.options.directory, { withFileTypes: true });
+    let total = 0;
+    for (const entry of entries) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+      const datasetSlug = entry.name;
+      total += await this.computeDatasetBytes(datasetSlug);
+    }
+    return total;
+  }
+
+  async getDatasetSummary(datasetSlug: string): Promise<DatasetStagingSummary> {
+    return this.runWithDatasetLock(datasetSlug, async () => {
+      const context = await this.getDatasetContext(datasetSlug);
+      return this.buildDatasetSummary(context);
+    });
+  }
+
+  private async buildDatasetSummary(context: DatasetSpoolContext): Promise<DatasetStagingSummary> {
+    await this.ensureMetadataTable(context);
+    const metadataTable = qualifyTableName(context.catalogName, SPOOL_SCHEMA, METADATA_TABLE);
+    const summaryRow = await firstRow(
+      context.connection,
+      `SELECT
+          COUNT(*)::BIGINT AS batch_count,
+          COALESCE(SUM(row_count), 0)::BIGINT AS row_count,
+          MIN(staged_at) AS oldest_staged_at
+        FROM ${metadataTable}
+       WHERE flush_token IS NULL`
+    );
+
+    const pendingBatchCount = Number(summaryRow?.batch_count ?? 0n);
+    const pendingRowCount = Number(summaryRow?.row_count ?? 0n);
+    const oldestStagedAt = summaryRow?.oldest_staged_at
+      ? new Date(summaryRow.oldest_staged_at).toISOString()
+      : null;
+
+    const { databaseSizeBytes, walSizeBytes } = await this.readDatabaseSize(context.connection);
+    const onDiskBytes = await this.computeDatasetBytes(context.datasetSlug);
+
+    const summary: DatasetStagingSummary = {
+      datasetSlug: context.datasetSlug,
+      pendingBatchCount,
+      pendingRowCount,
+      oldestStagedAt,
+      databaseSizeBytes,
+      walSizeBytes,
+      onDiskBytes
+    };
+
+    setStagingSummaryMetrics(summary);
+    return summary;
+  }
+
+  private async refreshDatasetSummary(context: DatasetSpoolContext): Promise<void> {
+    try {
+      await this.buildDatasetSummary(context);
+    } catch (error) {
+      console.warn('[timestore] failed to refresh staging summary metrics', error);
+    }
+  }
+
+  async prepareFlush(datasetSlug: string): Promise<PreparedFlushResult | null> {
+    return this.runWithDatasetLock(datasetSlug, async () => {
+      const context = await this.getDatasetContext(datasetSlug);
+      await this.ensureMetadataTable(context);
+      const metadataTable = qualifyTableName(context.catalogName, SPOOL_SCHEMA, METADATA_TABLE);
+
+      const pendingBatches = await all(
+        context.connection,
+        `SELECT
+            ingestion_signature,
+            batch_id,
+            table_name,
+            schema_json,
+            partition_key_json,
+            partition_attributes_json,
+            time_range_start,
+            time_range_end,
+            row_count,
+            received_at,
+            staged_at,
+            idempotency_key,
+            schema_defaults_json,
+            schema_backfill_requested
+          FROM ${metadataTable}
+         WHERE flush_token IS NULL
+         ORDER BY staged_at ASC`
+      );
+
+      if (pendingBatches.length === 0) {
+        return null;
+      }
+
+      const flushToken = randomUUID();
+      const now = new Date();
+
+      await run(context.connection, 'BEGIN TRANSACTION');
+      try {
+        for (const batch of pendingBatches) {
+          await run(
+            context.connection,
+            `UPDATE ${metadataTable}
+                SET flush_token = ?, flush_started_at = ?
+              WHERE batch_id = ? AND flush_token IS NULL`,
+            flushToken,
+            now,
+            batch.batch_id
+          );
+        }
+        await run(context.connection, 'COMMIT');
+      } catch (error) {
+        await run(context.connection, 'ROLLBACK').catch(() => undefined);
+        throw error;
+      }
+
+      await this.refreshDatasetSummary(context);
+
+      const flushDir = await this.ensureFlushDirectory(context, flushToken);
+      const batches: PreparedFlushBatch[] = [];
+
+      try {
+        for (const batch of pendingBatches) {
+          const schema = parseJson<FieldDefinition[]>(batch.schema_json, []);
+          const partitionKey = parseJson<Record<string, string>>(batch.partition_key_json, {});
+          const partitionAttributes = batch.partition_attributes_json
+            ? parseJson<Record<string, string> | null>(batch.partition_attributes_json, null)
+            : null;
+          const schemaDefaults = batch.schema_defaults_json
+            ? parseJson<Record<string, unknown> | null>(batch.schema_defaults_json, null)
+            : null;
+          const backfillRequested = Boolean(batch.schema_backfill_requested);
+
+          const tableName = String(batch.table_name ?? '');
+          const parquetFilePath = path.join(
+            flushDir,
+            `${sanitizeTableName(tableName)}-${String(batch.batch_id ?? '')}.parquet`
+          );
+          await fs.rm(parquetFilePath, { force: true });
+          await this.exportBatchToParquet(context, tableName, schema, String(batch.batch_id ?? ''), parquetFilePath);
+          const rows = await this.readBatchRows(context, tableName, schema, String(batch.batch_id ?? ''));
+
+          batches.push({
+            batchId: String(batch.batch_id ?? ''),
+            ingestionSignature: String(batch.ingestion_signature ?? ''),
+            tableName,
+            schema,
+            partitionKey,
+            partitionAttributes,
+            timeRange: {
+              start: new Date(batch.time_range_start).toISOString(),
+              end: new Date(batch.time_range_end).toISOString()
+            },
+            rowCount: Number(batch.row_count ?? 0),
+            receivedAt: new Date(batch.received_at).toISOString(),
+            stagedAt: new Date(batch.staged_at).toISOString(),
+            idempotencyKey: batch.idempotency_key ? String(batch.idempotency_key) : null,
+            schemaDefaults,
+            backfillRequested,
+            rows,
+            parquetFilePath
+          });
+        }
+      } catch (error) {
+        await this.abortFlushInternal(context, flushToken).catch(() => undefined);
+        throw error;
+      }
+
+      return {
+        datasetSlug,
+        flushToken,
+        batches,
+        preparedAt: now.toISOString()
+      } satisfies PreparedFlushResult;
+    });
+  }
+
+  async finalizeFlush(datasetSlug: string, flushToken: string): Promise<void> {
+    await this.runWithDatasetLock(datasetSlug, async () => {
+      const context = await this.getDatasetContext(datasetSlug);
+      await this.ensureMetadataTable(context);
+      const metadataTable = qualifyTableName(context.catalogName, SPOOL_SCHEMA, METADATA_TABLE);
+
+      const batches = await all(
+        context.connection,
+        `SELECT batch_id, table_name
+           FROM ${metadataTable}
+          WHERE flush_token = ?`,
+        flushToken
+      );
+
+      if (batches.length > 0) {
+        await run(context.connection, 'BEGIN TRANSACTION');
+        try {
+          for (const batch of batches) {
+            const tableName = String(batch.table_name ?? '');
+            const batchId = String(batch.batch_id ?? '');
+            const qualifiedTable = qualifyTableName(context.catalogName, SPOOL_SCHEMA, tableName);
+            await run(
+              context.connection,
+              `DELETE FROM ${qualifiedTable} WHERE ${quoteIdentifier(INTERNAL_BATCH_ID_COLUMN)} = ?`,
+              batchId
+            );
+            await run(
+              context.connection,
+              `DELETE FROM ${metadataTable} WHERE batch_id = ?`,
+              batchId
+            );
+          }
+          await run(context.connection, 'COMMIT');
+        } catch (error) {
+          await run(context.connection, 'ROLLBACK').catch(() => undefined);
+          throw error;
+        }
+      }
+
+      await this.cleanupFlushDirectory(context, flushToken);
+      await this.refreshDatasetSummary(context);
+    });
+  }
+
+  async abortFlush(datasetSlug: string, flushToken: string): Promise<{ batches: number; rows: number }> {
+    return this.runWithDatasetLock(datasetSlug, async () => {
+      const context = await this.getDatasetContext(datasetSlug);
+      await this.ensureMetadataTable(context);
+      return this.abortFlushInternal(context, flushToken);
+    });
+  }
+
+  private async abortFlushInternal(
+    context: DatasetSpoolContext,
+    flushToken: string
+  ): Promise<{ batches: number; rows: number }> {
+    const metadataTable = qualifyTableName(context.catalogName, SPOOL_SCHEMA, METADATA_TABLE);
+    const stats = await firstRow(
+      context.connection,
+      `SELECT
+          COUNT(*)::BIGINT AS batch_count,
+          COALESCE(SUM(row_count), 0)::BIGINT AS row_count
+        FROM ${metadataTable}
+       WHERE flush_token = ?`,
+      flushToken
+    );
+    const batches = Number(stats?.batch_count ?? 0n);
+    const rows = Number(stats?.row_count ?? 0n);
+    await run(
+      context.connection,
+      `UPDATE ${metadataTable} SET flush_token = NULL, flush_started_at = NULL WHERE flush_token = ?`,
+      flushToken
+    );
+    await this.cleanupFlushDirectory(context, flushToken);
+    await this.refreshDatasetSummary(context);
+    return { batches, rows };
+  }
+
+  private getFlushDirectory(context: DatasetSpoolContext, flushToken: string): string {
+    return path.join(context.directory, 'flush', flushToken);
+  }
+
+  private async ensureFlushDirectory(
+    context: DatasetSpoolContext,
+    flushToken: string
+  ): Promise<string> {
+    const flushDir = this.getFlushDirectory(context, flushToken);
+    await fs.mkdir(flushDir, { recursive: true });
+    return flushDir;
+  }
+
+  private async cleanupFlushDirectory(
+    context: DatasetSpoolContext,
+    flushToken: string
+  ): Promise<void> {
+    const flushDir = this.getFlushDirectory(context, flushToken);
+    await fs.rm(flushDir, { recursive: true, force: true });
+  }
+
+  private async readBatchRows(
+    context: DatasetSpoolContext,
+    tableName: string,
+    schema: FieldDefinition[],
+    batchId: string
+  ): Promise<Record<string, unknown>[]> {
+    if (schema.length === 0) {
+      return [];
+    }
+    const qualifiedTable = qualifyTableName(context.catalogName, SPOOL_SCHEMA, tableName);
+    const columnList = schema.map((field) => quoteIdentifier(field.name)).join(', ');
+    const rows = await all(
+      context.connection,
+      `SELECT ${columnList}
+         FROM ${qualifiedTable}
+        WHERE ${quoteIdentifier(INTERNAL_BATCH_ID_COLUMN)} = ?
+        ORDER BY ${quoteIdentifier(INTERNAL_STAGED_AT_COLUMN)}`,
+      batchId
+    );
+    return rows.map((row) => {
+      const output: Record<string, unknown> = {};
+      for (const field of schema) {
+        output[field.name] = (row as Record<string, unknown>)[field.name];
+      }
+      return output;
+    });
+  }
+
+  private async exportBatchToParquet(
+    context: DatasetSpoolContext,
+    tableName: string,
+    schema: FieldDefinition[],
+    batchId: string,
+    destinationPath: string
+  ): Promise<void> {
+    if (schema.length === 0) {
+      throw new Error(`Cannot export staging batch '${batchId}' for table '${tableName}' without schema columns`);
+    }
+    const qualifiedTable = qualifyTableName(context.catalogName, SPOOL_SCHEMA, tableName);
+    const columnList = schema.map((field) => quoteIdentifier(field.name)).join(', ');
+    const escapedPath = destinationPath.replace(/'/g, "''");
+    await run(
+      context.connection,
+      `COPY (
+        SELECT ${columnList}
+          FROM ${qualifiedTable}
+         WHERE ${quoteIdentifier(INTERNAL_BATCH_ID_COLUMN)} = ?
+      ) TO '${escapedPath}' (FORMAT PARQUET)`,
+      batchId
+    );
+  }
+
+  private async runWithDatasetLock<T>(datasetSlug: string, fn: () => Promise<T>): Promise<T> {
+    const existing = this.datasetLocks.get(datasetSlug) ?? Promise.resolve();
+    let release: () => void = () => undefined;
+    const current = existing.then(
+      () => new Promise<void>((resolve) => {
+        release = resolve;
+      })
+    );
+    this.datasetLocks.set(datasetSlug, current);
+    try {
+      await existing;
+      const result = await fn();
+      release();
+      if (this.datasetLocks.get(datasetSlug) === current) {
+        this.datasetLocks.delete(datasetSlug);
+      }
+      return result;
+    } catch (error) {
+      release();
+      if (this.datasetLocks.get(datasetSlug) === current) {
+        this.datasetLocks.delete(datasetSlug);
+      }
+      throw error;
+    }
+  }
+}
+
+function sanitizeDatasetSlug(datasetSlug: string): string {
+  const trimmed = datasetSlug.trim();
+  if (trimmed.length === 0) {
+    throw new Error('datasetSlug must not be empty');
+  }
+  const normalized = trimmed.replace(/[^a-zA-Z0-9_.-]/g, '_');
+  return normalized.length > 0 ? normalized : 'dataset';
+}
+
+function sanitizeTableName(tableName: string): string {
+  const trimmed = tableName.trim();
+  if (!trimmed) {
+    throw new Error('tableName must not be empty');
+  }
+  return trimmed.replace(/[^a-zA-Z0-9_]/g, '_');
+}
+
+function quoteIdentifier(identifier: string): string {
+  const safe = identifier.replace(/"/g, '""');
+  return `"${safe}"`;
+}
+
+function qualifySchemaName(catalog: string, schema: string): string {
+  return `${quoteIdentifier(catalog)}.${quoteIdentifier(schema)}`;
+}
+
+function qualifyTableName(catalog: string, schema: string, table: string): string {
+  return `${qualifySchemaName(catalog, schema)}.${quoteIdentifier(table)}`;
+}
+
+function augmentSchema(schema: FieldDefinition[]): FieldDefinition[] {
+  const names = new Set(schema.map((field) => field.name));
+  const augmented: FieldDefinition[] = [...schema];
+  if (!names.has(INTERNAL_BATCH_ID_COLUMN)) {
+    augmented.push({ name: INTERNAL_BATCH_ID_COLUMN, type: 'string' });
+  }
+  if (!names.has(INTERNAL_STAGED_AT_COLUMN)) {
+    augmented.push({ name: INTERNAL_STAGED_AT_COLUMN, type: 'timestamp' });
+  }
+  return augmented;
+}
+
+function parseJson<T>(value: unknown, fallback: T): T {
+  if (typeof value !== 'string') {
+    return fallback;
+  }
+  try {
+    return JSON.parse(value) as T;
+  } catch (error) {
+    console.warn('[timestore] failed to parse staging metadata json', error);
+    return fallback;
+  }
+}
+
+function mapDuckDbType(type: FieldType): string {
+  switch (type) {
+    case 'timestamp':
+      return 'TIMESTAMP';
+    case 'double':
+      return 'DOUBLE';
+    case 'integer':
+      return 'BIGINT';
+    case 'boolean':
+      return 'BOOLEAN';
+    case 'string':
+    default:
+      return 'VARCHAR';
+  }
+}
+
+function coerceValue(value: unknown, type: FieldType): unknown {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  switch (type) {
+    case 'timestamp':
+      if (value instanceof Date) {
+        return value.toISOString();
+      }
+      return new Date(String(value)).toISOString();
+    case 'double':
+      return Number(value);
+    case 'integer':
+      return Number.parseInt(String(value), 10);
+    case 'boolean':
+      return typeof value === 'boolean' ? value : String(value).toLowerCase() === 'true';
+    case 'string':
+    default:
+      return String(value);
+  }
+}
+
+function run(connection: any, sql: string, ...params: unknown[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    connection.run(sql, ...params, (err: Error | null) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+function all(connection: any, sql: string, ...params: unknown[]): Promise<any[]> {
+  return new Promise((resolve, reject) => {
+    connection.all(sql, ...params, (err: Error | null, rows?: any[]) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(rows ?? []);
+      }
+    });
+  });
+}
+
+function firstRow(connection: any, sql: string, ...params: unknown[]): Promise<any | null> {
+  return new Promise((resolve, reject) => {
+    connection.all(sql, ...params, (err: Error | null, rows?: any[]) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(rows && rows.length > 0 ? rows[0] : null);
+      }
+    });
+  });
+}
+
+function closeConnection(connection: any): Promise<void> {
+  return new Promise((resolve, reject) => {
+    connection.close((err: Error | null) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+const SIZE_MULTIPLIERS: Record<string, number> = {
+  byte: 1,
+  bytes: 1,
+  kib: 1024,
+  mib: 1024 * 1024,
+  gib: 1024 * 1024 * 1024,
+  tib: 1024 * 1024 * 1024 * 1024,
+  pib: 1024 * 1024 * 1024 * 1024 * 1024
+};
+
+function parseSizeString(value: string | null | undefined): number {
+  if (!value) {
+    return 0;
+  }
+  const trimmed = value.trim();
+  const match = /^([0-9]+(?:\.[0-9]+)?)\s*(bytes?|KiB|MiB|GiB|TiB|PiB)$/i.exec(trimmed);
+  if (!match) {
+    return 0;
+  }
+  const amount = Number.parseFloat(match[1]);
+  const unit = match[2].toLowerCase();
+  const multiplier = SIZE_MULTIPLIERS[unit] ?? 1;
+  return Math.round(amount * multiplier);
+}
+
+function isMissingTableError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  return /does not exist/i.test(error.message ?? '');
+}

--- a/services/timestore/tests/spoolManager.test.ts
+++ b/services/timestore/tests/spoolManager.test.ts
@@ -1,0 +1,190 @@
+/// <reference path="../src/types/embeddedPostgres.d.ts" />
+
+import './testEnv';
+
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import * as duckdb from 'duckdb';
+import { DuckDbSpoolManager } from '../src/storage/spoolManager';
+import type { FieldDefinition } from '../src/storage';
+
+describe('DuckDbSpoolManager', () => {
+  let rootDir: string;
+  let manager: DuckDbSpoolManager;
+
+  const schema: FieldDefinition[] = [
+    { name: 'recordedAt', type: 'timestamp' },
+    { name: 'value', type: 'double' },
+    { name: 'label', type: 'string' }
+  ];
+
+  beforeEach(async () => {
+    rootDir = await mkdtemp(path.join(tmpdir(), 'timestore-spool-'));
+    manager = new DuckDbSpoolManager({
+      directory: rootDir,
+      maxDatasetBytes: 10 * 1024 * 1024,
+      maxTotalBytes: 20 * 1024 * 1024
+    });
+  });
+
+  afterEach(async () => {
+    await manager.close();
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  test('creates staging tables and appends rows', async () => {
+    const datasetSlug = 'metrics.latency';
+    const rows = [
+      { recordedAt: new Date('2024-01-01T00:00:00Z'), value: 12.34, label: 'api' },
+      { recordedAt: new Date('2024-01-01T00:05:00Z'), value: 9.87, label: 'api' }
+    ];
+
+    const appended = await manager.appendRows({
+      datasetSlug,
+      tableName: 'records',
+      schema,
+      rows
+    });
+
+    assert.equal(appended, rows.length, 'should report the number of staged rows');
+
+    const stats = await manager.getDatasetStats(datasetSlug);
+    assert.equal(stats.totalRows, rows.length, 'should track total staged rows');
+    const tableStats = stats.tables.find((entry) => entry.tableName === 'records');
+    assert.ok(tableStats, 'should expose table statistics');
+    assert.equal(tableStats?.rowCount, rows.length);
+    assert.ok(stats.databaseSizeBytes >= 0);
+    assert.ok(stats.walSizeBytes >= 0);
+  });
+
+  test('recovers staged rows after a restart', async () => {
+    const datasetSlug = 'metrics.throughput';
+
+    await manager.appendRows({
+      datasetSlug,
+      tableName: 'records',
+      schema,
+      rows: [
+        { recordedAt: new Date('2024-02-01T00:00:00Z'), value: 100, label: 'worker-a' }
+      ]
+    });
+
+    await manager.close();
+
+    manager = new DuckDbSpoolManager({
+      directory: rootDir,
+      maxDatasetBytes: 10 * 1024 * 1024,
+      maxTotalBytes: 20 * 1024 * 1024
+    });
+
+    const statsAfterRestart = await manager.getDatasetStats(datasetSlug);
+    const initialTable = statsAfterRestart.tables.find((entry) => entry.tableName === 'records');
+    assert.equal(initialTable?.rowCount ?? 0, 1, 'should retain staged rows after restart');
+
+    await manager.appendRows({
+      datasetSlug,
+      tableName: 'records',
+      schema,
+      rows: [
+        { recordedAt: new Date('2024-02-01T00:10:00Z'), value: 104, label: 'worker-b' }
+      ]
+    });
+
+    const finalStats = await manager.getDatasetStats(datasetSlug);
+    const finalTable = finalStats.tables.find((entry) => entry.tableName === 'records');
+    assert.equal(finalTable?.rowCount ?? 0, 2, 'should continue staging rows after recovery');
+  });
+
+  test('stagePartition records metadata and enforces idempotency', async () => {
+    const datasetSlug = 'metrics.latency';
+    const tableName = 'records';
+    const ingestionSignature = 'sig-123';
+    const rows = [
+      { recordedAt: new Date('2024-03-01T00:00:00Z'), value: 42.5, label: 'api' },
+      { recordedAt: new Date('2024-03-01T00:05:00Z'), value: 43.1, label: 'api' }
+    ];
+
+    const result = await manager.stagePartition({
+      datasetSlug,
+      tableName,
+      schema,
+      rows,
+      partitionKey: { window: '2024-03-01T00:00:00Z', chunk: '0' },
+      partitionAttributes: { source: 'test' },
+      timeRange: {
+        start: '2024-03-01T00:00:00Z',
+        end: '2024-03-01T00:10:00Z'
+      },
+      ingestionSignature,
+      receivedAt: '2024-03-01T00:10:00Z'
+    });
+
+    assert.equal(result.alreadyStaged, false);
+    assert.equal(result.rowCount, rows.length);
+    assert.ok(result.batchId);
+
+    const sanitizedSlug = datasetSlug.replace(/[^a-zA-Z0-9_.-]/g, '_') || 'dataset';
+    const databasePath = path.join(rootDir, sanitizedSlug, 'staging.duckdb');
+    const database = new duckdb.Database(databasePath);
+    const connection = database.connect();
+
+    const metadataRows: Array<{ ingestion_signature: string; row_count: bigint }> = await new Promise(
+      (resolve, reject) => {
+        connection.all(
+          'SELECT ingestion_signature, row_count FROM "staging"."staging"."__ingestion_batches"',
+          (err: Error | null, rowsResult?: unknown[]) => {
+            if (err) {
+              reject(err);
+              return;
+            }
+            resolve((rowsResult ?? []) as Array<{ ingestion_signature: string; row_count: bigint }>);
+          }
+        );
+      }
+    );
+
+    assert.equal(metadataRows.length, 1);
+    assert.equal(metadataRows[0]?.ingestion_signature, ingestionSignature);
+    assert.equal(Number(metadataRows[0]?.row_count ?? 0n), rows.length);
+
+    await new Promise<void>((resolve, reject) => {
+      connection.close((err: Error | null) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+    await new Promise<void>((resolve, reject) => {
+      database.close((err: Error | null) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+
+    const duplicate = await manager.stagePartition({
+      datasetSlug,
+      tableName,
+      schema,
+      rows,
+      partitionKey: { window: '2024-03-01T00:00:00Z', chunk: '0' },
+      partitionAttributes: { source: 'test' },
+      timeRange: {
+        start: '2024-03-01T00:00:00Z',
+        end: '2024-03-01T00:10:00Z'
+      },
+      ingestionSignature,
+      receivedAt: '2024-03-01T00:10:00Z'
+    });
+
+    assert.equal(duplicate.alreadyStaged, true);
+    assert.equal(duplicate.rowCount, rows.length);
+  });
+});

--- a/services/timestore/tests/stagingManager.test.ts
+++ b/services/timestore/tests/stagingManager.test.ts
@@ -1,0 +1,80 @@
+/// <reference path="../src/types/embeddedPostgres.d.ts" />
+
+import './testEnv';
+
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, beforeEach, test } from 'node:test';
+import { loadServiceConfig, resetCachedServiceConfig } from '../src/config/serviceConfig';
+import {
+  getStagingWriteManager,
+  resetStagingWriteManager,
+  StagingQueueFullError
+} from '../src/ingestion/stagingManager';
+import type { StagePartitionRequest } from '../src/storage/spoolManager';
+
+let stagingDir: string;
+
+beforeEach(async () => {
+  stagingDir = await mkdtemp(path.join(tmpdir(), 'timestore-staging-'));
+  process.env.TIMESTORE_STAGING_DIRECTORY = stagingDir;
+  process.env.TIMESTORE_STAGING_MAX_PENDING = '1';
+  await resetCachedServiceConfig();
+});
+
+afterEach(async () => {
+  await resetStagingWriteManager();
+  await resetCachedServiceConfig();
+  delete process.env.TIMESTORE_STAGING_DIRECTORY;
+  delete process.env.TIMESTORE_STAGING_MAX_PENDING;
+  await rm(stagingDir, { recursive: true, force: true });
+});
+
+test('staging manager enqueues sequential writes and enforces capacity', async () => {
+  const config = loadServiceConfig();
+  const manager = getStagingWriteManager(config);
+
+  const baseRequest: StagePartitionRequest = {
+    datasetSlug: 'queue-test',
+    tableName: 'records',
+    schema: [
+      { name: 'recordedAt', type: 'timestamp' },
+      { name: 'value', type: 'double' }
+    ],
+    rows: [
+      { recordedAt: new Date('2024-04-01T00:00:00Z'), value: 1.23 },
+      { recordedAt: new Date('2024-04-01T00:01:00Z'), value: 1.24 }
+    ],
+    partitionKey: { window: '2024-04-01T00:00:00Z' },
+    partitionAttributes: null,
+    timeRange: {
+      start: '2024-04-01T00:00:00Z',
+      end: '2024-04-01T00:05:00Z'
+    },
+    ingestionSignature: 'sig-primary',
+    receivedAt: '2024-04-01T00:05:00Z'
+  };
+
+  const firstPromise = manager.enqueue(baseRequest);
+
+  await assert.rejects(
+    manager.enqueue({ ...baseRequest, ingestionSignature: 'sig-secondary' }),
+    (error: unknown) => {
+      assert.ok(error instanceof StagingQueueFullError);
+      assert.match(error.message, /reached capacity/i);
+      return true;
+    }
+  );
+
+  const firstResult = await firstPromise;
+  assert.equal(firstResult.alreadyStaged, false);
+
+  const secondResult = await manager.enqueue({
+    ...baseRequest,
+    ingestionSignature: 'sig-secondary',
+    rows: [{ recordedAt: new Date('2024-04-01T00:02:00Z'), value: 1.25 }]
+  });
+  assert.equal(secondResult.alreadyStaged, false);
+});

--- a/services/timestore/tests/utils/embeddedPostgres.ts
+++ b/services/timestore/tests/utils/embeddedPostgres.ts
@@ -1,0 +1,38 @@
+import EmbeddedPostgres from 'embedded-postgres';
+
+const activeInstances = new Set<EmbeddedPostgres>();
+
+type EmbeddedPostgresOptions = ConstructorParameters<typeof EmbeddedPostgres>[0];
+
+export function createEmbeddedPostgres(options?: EmbeddedPostgresOptions): EmbeddedPostgres {
+  if (options && typeof options === 'object') {
+    const info = {
+      databaseDir: (options as { databaseDir?: string }).databaseDir,
+      port: (options as { port?: number }).port
+    };
+    console.info('[timestore:test] starting embedded Postgres', info);
+  }
+  const instance = new EmbeddedPostgres(options as EmbeddedPostgresOptions);
+  activeInstances.add(instance);
+  return instance;
+}
+
+export async function stopEmbeddedPostgres(instance: EmbeddedPostgres | null | undefined): Promise<void> {
+  if (!instance) {
+    return;
+  }
+  try {
+    await instance.stop();
+  } catch (error) {
+    console.warn('[timestore:test] failed to stop embedded Postgres', error);
+  } finally {
+    activeInstances.delete(instance);
+  }
+}
+
+export async function stopAllEmbeddedPostgres(): Promise<void> {
+  const instances = Array.from(activeInstances);
+  for (const instance of instances) {
+    await stopEmbeddedPostgres(instance);
+  }
+}

--- a/services/timestore/tests/utils/processProbes.ts
+++ b/services/timestore/tests/utils/processProbes.ts
@@ -1,0 +1,37 @@
+import { exec } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execAsync = promisify(exec);
+
+export async function killPort(port: number): Promise<void> {
+  try {
+    if (process.platform === 'win32') {
+      return;
+    }
+    const { stdout } = await execAsync(`lsof -i :${port} -t || true`);
+    const pids = stdout
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+    for (const pid of pids) {
+      try {
+        process.kill(Number(pid), 'SIGKILL');
+      } catch {
+        // ignore
+      }
+    }
+  } catch (error) {
+    console.warn('[timestore:testEnv] failed to kill port', { port, error });
+  }
+}
+
+export function listActiveChildProcesses(): NodeJS.ChildProcess[] {
+  const handles = (process as unknown as { _getActiveHandles?: () => unknown[] })._getActiveHandles?.() ?? [];
+  const children: NodeJS.ChildProcess[] = [];
+  for (const handle of handles) {
+    if ((handle as { constructor?: { name?: string } }).constructor?.name === 'ChildProcess') {
+      children.push(handle as NodeJS.ChildProcess);
+    }
+  }
+  return children;
+}


### PR DESCRIPTION
## Summary
- Expose staging queue depth, disk usage, flush duration/volume, and drop/retry counters via Prometheus
- Wire the new metrics through the staging manager, DuckDB spool lifecycle, and ingestion flush path
- Document configuration knobs, dashboards, and rollout steps for the staging pipeline (runbook + release notes)

Fixes #165

## Testing
- npm run lint --workspace @apphub/timestore
- npm run test --workspace @apphub/timestore *(fails: embedded Postgres init script exits with code 1; data dir already exists)*