### PR TITLE
feat: refresh observatory burst pipeline

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -17,6 +17,7 @@
     "@apphub/module-registry": "0.1.0",
     "@apphub/module-sdk": "0.1.0",
     "commander": "^11.1.0",
+    "@aws-sdk/client-s3": "^3.896.0",
     "yaml": "^2.8.1"
   },
   "devDependencies": {

--- a/apps/cli/src/lib/moduleDeploy/deploy.ts
+++ b/apps/cli/src/lib/moduleDeploy/deploy.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { access, readFile } from 'node:fs/promises';
+import { access, readFile, writeFile } from 'node:fs/promises';
 import { serializeModuleDefinition, type ModuleManifest } from '@apphub/module-sdk';
 import { loadModuleDefinition } from '../module';
 import type { ModuleDeploymentLogger } from './types';
@@ -14,6 +14,7 @@ import { syncServices } from './services';
 import { syncJobs } from './jobs';
 import { syncWorkflows } from './workflows';
 import { createCoreRequest } from './request';
+import { prepareModuleArtifact, type ModuleArtifactDescriptor } from './storage';
 
 export interface DeployModuleOptions {
   modulePath: string;
@@ -27,12 +28,19 @@ export interface DeployModuleOptions {
 export async function deployModule(options: DeployModuleOptions): Promise<DeployModuleResult> {
   const modulePath = path.resolve(options.modulePath);
   const distPath = path.resolve(options.distPath ?? path.join(modulePath, 'dist'));
-  const moduleEntryPath = path.join(distPath, 'module.js');
 
-  await assertFileExists(moduleEntryPath);
+  primeScratchPrefixes(options.env);
+  options.logger.debug?.('Configured scratch prefixes', {
+    prefixes: process.env.APPHUB_SCRATCH_PREFIXES
+  });
 
-  const moduleDefinition = await loadModuleDefinition(modulePath, path.relative(modulePath, moduleEntryPath));
-  const manifest = serializeModuleDefinition(moduleDefinition);
+  const { entryPath: moduleEntryPath, relativeEntry } = await resolveModuleEntryPath({
+    modulePath,
+    distPath
+  });
+
+  let moduleDefinition = await loadModuleDefinition(modulePath, relativeEntry);
+  let manifest = serializeModuleDefinition(moduleDefinition);
 
   const request = createCoreRequest({ baseUrl: options.coreUrl, token: options.coreToken });
 
@@ -48,9 +56,17 @@ export async function deployModule(options: DeployModuleOptions): Promise<Deploy
     });
   }
 
+  const artifact = await prepareModuleArtifact({
+    moduleId: manifest.metadata.name,
+    moduleVersion: manifest.metadata.version,
+    moduleEntryPath,
+    env: options.env,
+    logger: options.logger
+  });
+
   await publishModuleArtifactBundle({
     manifest,
-    moduleEntryPath,
+    artifact,
     request,
     logger: options.logger
   });
@@ -66,7 +82,23 @@ export async function deployModule(options: DeployModuleOptions): Promise<Deploy
 
     if (backendId && prepared.filestore.backendMountId !== backendId) {
       prepared.filestore.backendMountId = backendId;
+      if (prepared.configPath) {
+        await updateObservatoryConfigBackendId({
+          configPath: prepared.configPath,
+          backendId,
+          env: options.env,
+          logger: options.logger
+        });
+      }
+      if (moduleDefinition.settings?.defaults && typeof moduleDefinition.settings.defaults === 'object') {
+        const defaults = moduleDefinition.settings.defaults as Record<string, any>;
+        if (defaults.filestore && typeof defaults.filestore === 'object') {
+          defaults.filestore.backendId = backendId;
+      }
     }
+  }
+
+  manifest = serializeModuleDefinition(moduleDefinition);
 
     if (prepared.filestore.prefixes.length > 0) {
       filestorePrefixesEnsured = await ensureFilestorePrefixes({
@@ -129,45 +161,148 @@ export async function deployModule(options: DeployModuleOptions): Promise<Deploy
   } satisfies DeployModuleResult;
 }
 
+function primeScratchPrefixes(env: NodeJS.ProcessEnv): void {
+  const prefixes = new Set<string>();
+
+  const add = (value: string | undefined) => {
+    if (!value) {
+      return;
+    }
+    const trimmed = value.trim();
+    if (trimmed.length === 0) {
+      return;
+    }
+    prefixes.add(path.resolve(trimmed));
+  };
+
+  const existing = process.env.APPHUB_SCRATCH_PREFIXES ?? env.APPHUB_SCRATCH_PREFIXES;
+  if (existing) {
+    for (const candidate of existing.split(':')) {
+      add(candidate);
+    }
+  }
+
+  add(env.APPHUB_SCRATCH_ROOT);
+  add(env.APPHUB_RUNTIME_SCRATCH_ROOT);
+  add(process.env.APPHUB_SCRATCH_ROOT);
+  add(process.env.APPHUB_RUNTIME_SCRATCH_ROOT);
+  const configPath = env.OBSERVATORY_CONFIG_PATH ?? process.env.OBSERVATORY_CONFIG_PATH;
+  if (configPath) {
+    add(path.dirname(configPath));
+  }
+  add('/tmp/apphub');
+
+  if (prefixes.size > 0) {
+    process.env.APPHUB_SCRATCH_PREFIXES = Array.from(prefixes).join(':');
+  }
+}
+
 async function publishModuleArtifactBundle(options: {
   manifest: ModuleManifest;
-  moduleEntryPath: string;
+  artifact: ModuleArtifactDescriptor;
   request: ReturnType<typeof createCoreRequest>;
   logger: ModuleDeploymentLogger;
 }): Promise<void> {
-  const artifactBuffer = await readFile(options.moduleEntryPath);
-  const filename = path.basename(options.moduleEntryPath);
+  const basePayload = {
+    moduleId: options.manifest.metadata.name,
+    moduleVersion: options.manifest.metadata.version,
+    displayName: options.manifest.metadata.displayName ?? null,
+    description: options.manifest.metadata.description ?? null,
+    keywords: options.manifest.metadata.keywords ?? [],
+    manifest: options.manifest
+  } satisfies Record<string, unknown>;
+
+  const artifactPayload =
+    options.artifact.storage === 's3'
+      ? {
+          storage: 's3' as const,
+          bucket: options.artifact.bucket,
+          key: options.artifact.key,
+          contentType: options.artifact.contentType,
+          size: options.artifact.size,
+          checksum: options.artifact.checksum
+        }
+      : {
+          storage: 'inline' as const,
+          filename: options.artifact.filename,
+          contentType: options.artifact.contentType,
+          data: options.artifact.data,
+          size: options.artifact.size,
+          checksum: options.artifact.checksum
+        };
 
   await options.request({
     method: 'POST',
     path: '/module-runtime/artifacts',
     body: {
-      moduleId: options.manifest.metadata.name,
-      moduleVersion: options.manifest.metadata.version,
-      displayName: options.manifest.metadata.displayName ?? null,
-      description: options.manifest.metadata.description ?? null,
-      keywords: options.manifest.metadata.keywords ?? [],
-      manifest: options.manifest,
-      artifact: {
-        filename,
-        contentType: 'application/javascript',
-        data: artifactBuffer.toString('base64')
-      }
+      ...basePayload,
+      artifact: artifactPayload
     }
   });
 
   options.logger.info('Published module artifact', {
     moduleId: options.manifest.metadata.name,
-    moduleVersion: options.manifest.metadata.version
+    moduleVersion: options.manifest.metadata.version,
+    storage: options.artifact.storage
   });
 }
 
-async function assertFileExists(filePath: string): Promise<void> {
+async function updateObservatoryConfigBackendId(options: {
+  configPath: string;
+  backendId: number;
+  env: NodeJS.ProcessEnv;
+  logger: ModuleDeploymentLogger;
+}): Promise<void> {
   try {
-    await access(filePath);
+    const raw = await readFile(options.configPath, 'utf8');
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    if (!parsed || typeof parsed !== 'object') {
+      throw new Error('config is not a JSON object');
+    }
+    const filestore = (parsed.filestore ?? {}) as Record<string, unknown>;
+    filestore.backendMountId = options.backendId;
+    parsed.filestore = filestore;
+    await writeFile(options.configPath, `${JSON.stringify(parsed, null, 2)}\n`, 'utf8');
+
+    const runtimeRoot = options.env.APPHUB_RUNTIME_SCRATCH_ROOT?.trim();
+    if (runtimeRoot) {
+      const mirrorPath = path.join(runtimeRoot, 'observatory', 'config', 'observatory-config.json');
+      try {
+        await writeFile(mirrorPath, `${JSON.stringify(parsed, null, 2)}\n`, 'utf8');
+      } catch (error) {
+        options.logger.warn?.('Failed to mirror observatory config to runtime scratch root', {
+          path: mirrorPath,
+          error
+        });
+      }
+    }
   } catch (error) {
-    throw new Error(`Required file not found: ${filePath}`);
+    options.logger.warn?.('Failed to update observatory config with backend mount id', {
+      configPath: options.configPath,
+      backendId: options.backendId,
+      error
+    });
   }
+}
+
+async function resolveModuleEntryPath(options: {
+  modulePath: string;
+  distPath: string;
+}): Promise<{ entryPath: string; relativeEntry: string }> {
+  const candidates = ['module.artifact.js', 'module.js'];
+  for (const candidate of candidates) {
+    const candidatePath = path.join(options.distPath, candidate);
+    if (await fileExists(candidatePath)) {
+      return {
+        entryPath: candidatePath,
+        relativeEntry: path.relative(options.modulePath, candidatePath)
+      };
+    }
+  }
+
+  throw new Error(
+    `Unable to locate module entry file in ${options.distPath}. Expected one of ${candidates.join(', ')}`
+  );
 }
 
 async function loadDeploymentAdapter(

--- a/apps/cli/src/lib/moduleDeploy/storage.ts
+++ b/apps/cli/src/lib/moduleDeploy/storage.ts
@@ -1,0 +1,290 @@
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import {
+  S3Client,
+  PutObjectCommand,
+  CreateBucketCommand,
+  type BucketLocationConstraint
+} from '@aws-sdk/client-s3';
+import type { ModuleDeploymentLogger } from './types';
+
+export type ArtifactStorageBackend = 'inline' | 's3';
+
+export type InlineArtifactDescriptor = {
+  storage: 'inline';
+  filename: string;
+  contentType: string;
+  data: string;
+  size: number;
+  checksum: string;
+};
+
+export type S3ArtifactDescriptor = {
+  storage: 's3';
+  bucket: string;
+  key: string;
+  contentType: string;
+  size: number;
+  checksum: string;
+};
+
+export type ModuleArtifactDescriptor = InlineArtifactDescriptor | S3ArtifactDescriptor;
+
+export interface PrepareArtifactOptions {
+  moduleId: string;
+  moduleVersion: string;
+  moduleEntryPath: string;
+  env: NodeJS.ProcessEnv;
+  logger: ModuleDeploymentLogger;
+}
+
+export async function prepareModuleArtifact(
+  options: PrepareArtifactOptions
+): Promise<ModuleArtifactDescriptor> {
+  const backend = resolveStorageBackend(options.env);
+  if (backend === 's3') {
+    return uploadArtifactToS3(options);
+  }
+
+  options.logger.warn(
+    'Module artifact S3 storage not configured; falling back to inline upload (may hit payload limits)'
+  );
+  return encodeInlineArtifact(options);
+}
+
+function resolveStorageBackend(env: NodeJS.ProcessEnv): ArtifactStorageBackend {
+  const explicit = env.APPHUB_MODULE_ARTIFACT_STORAGE_BACKEND?.trim().toLowerCase();
+  if (explicit === 's3') {
+    return 's3';
+  }
+  if (explicit === 'inline' || explicit === 'filesystem') {
+    return 'inline';
+  }
+  const bundleBackend = env.APPHUB_BUNDLE_STORAGE_BACKEND?.trim().toLowerCase();
+  if (bundleBackend === 's3') {
+    return 's3';
+  }
+  return 'inline';
+}
+
+async function encodeInlineArtifact(options: PrepareArtifactOptions): Promise<InlineArtifactDescriptor> {
+  const data = await readFile(options.moduleEntryPath);
+  const checksum = sha256(data);
+  const contentType = 'application/javascript';
+  const filename = path.basename(options.moduleEntryPath);
+  return {
+    storage: 'inline',
+    filename,
+    contentType,
+    data: data.toString('base64'),
+    size: data.byteLength,
+    checksum
+  } satisfies InlineArtifactDescriptor;
+}
+
+async function uploadArtifactToS3(options: PrepareArtifactOptions): Promise<S3ArtifactDescriptor> {
+  const config = resolveS3Config(options.env);
+  if (!config) {
+    throw new Error(
+      'Module artifact storage is set to s3, but APPHUB_MODULE_ARTIFACT_BUCKET or APPHUB_BUNDLE_STORAGE_BUCKET is not configured'
+    );
+  }
+
+  const buffer = await readFile(options.moduleEntryPath);
+  const checksum = sha256(buffer);
+
+  const key = buildS3Key({
+    moduleId: options.moduleId,
+    moduleVersion: options.moduleVersion,
+    filename: path.basename(options.moduleEntryPath),
+    prefix: config.prefix
+  });
+
+  const client = createS3Client(config);
+  await ensureBucketExists(client, config);
+  await client.send(
+    new PutObjectCommand({
+      Bucket: config.bucket,
+      Key: key,
+      Body: buffer,
+      ContentType: 'application/javascript',
+      ContentLength: buffer.byteLength,
+      ChecksumSHA256: Buffer.from(checksum, 'hex').toString('base64')
+    })
+  );
+
+  options.logger.info('Uploaded module artifact to object storage', {
+    bucket: config.bucket,
+    key,
+    size: buffer.byteLength
+  });
+
+  return {
+    storage: 's3',
+    bucket: config.bucket,
+    key,
+    contentType: 'application/javascript',
+    size: buffer.byteLength,
+    checksum
+  } satisfies S3ArtifactDescriptor;
+}
+
+function sha256(buffer: Buffer): string {
+  return createHash('sha256').update(buffer).digest('hex');
+}
+
+function buildS3Key(params: {
+  moduleId: string;
+  moduleVersion: string;
+  filename: string;
+  prefix?: string;
+}): string {
+  const safeModule = sanitizeSegment(params.moduleId);
+  const safeVersion = sanitizeSegment(params.moduleVersion);
+  const safeFilename = sanitizeFilename(params.filename);
+  const segments = [params.prefix, safeModule, safeVersion, safeFilename].filter(
+    (segment): segment is string => Boolean(segment && segment.length)
+  );
+  return segments.join('/');
+}
+
+function sanitizeSegment(value: string): string {
+  return value
+    .trim()
+    .replace(/[^a-zA-Z0-9._-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^[-.]+|[-.]+$/g, '')
+    .toLowerCase();
+}
+
+function sanitizeFilename(value: string): string {
+  const base = path.basename(value || 'module.js');
+  if (!base) {
+    return 'module.js';
+  }
+  return base.replace(/[^a-zA-Z0-9._-]+/g, '-');
+}
+
+type S3Config = {
+  bucket: string;
+  region: string;
+  endpoint?: string;
+  forcePathStyle: boolean;
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  sessionToken?: string;
+  prefix?: string;
+};
+
+function resolveS3Config(env: NodeJS.ProcessEnv): S3Config | null {
+  const bucket =
+    env.APPHUB_MODULE_ARTIFACT_BUCKET?.trim() ||
+    env.APPHUB_MODULE_ARTIFACT_S3_BUCKET?.trim() ||
+    env.APPHUB_BUNDLE_STORAGE_BUCKET?.trim() ||
+    env.APPHUB_JOB_BUNDLE_S3_BUCKET?.trim() ||
+    '';
+
+  if (!bucket) {
+    return null;
+  }
+
+  const region =
+    env.APPHUB_MODULE_ARTIFACT_REGION?.trim() ||
+    env.APPHUB_MODULE_ARTIFACT_S3_REGION?.trim() ||
+    env.APPHUB_BUNDLE_STORAGE_REGION?.trim() ||
+    env.AWS_REGION?.trim() ||
+    'us-east-1';
+
+  const endpoint =
+    env.APPHUB_MODULE_ARTIFACT_ENDPOINT?.trim() ||
+    env.APPHUB_MODULE_ARTIFACT_S3_ENDPOINT?.trim() ||
+    env.APPHUB_BUNDLE_STORAGE_ENDPOINT?.trim() ||
+    env.APPHUB_JOB_BUNDLE_S3_ENDPOINT?.trim();
+
+  const forcePathStyleRaw =
+    env.APPHUB_MODULE_ARTIFACT_FORCE_PATH_STYLE ??
+    env.APPHUB_MODULE_ARTIFACT_S3_FORCE_PATH_STYLE ??
+    env.APPHUB_BUNDLE_STORAGE_FORCE_PATH_STYLE ??
+    env.APPHUB_JOB_BUNDLE_S3_FORCE_PATH_STYLE ??
+    'false';
+
+  const accessKeyId =
+    env.APPHUB_MODULE_ARTIFACT_ACCESS_KEY_ID ??
+    env.APPHUB_MODULE_ARTIFACT_S3_ACCESS_KEY_ID ??
+    env.APPHUB_BUNDLE_STORAGE_ACCESS_KEY_ID ??
+    env.APPHUB_JOB_BUNDLE_S3_ACCESS_KEY_ID ??
+    env.AWS_ACCESS_KEY_ID ??
+    undefined;
+
+  const secretAccessKey =
+    env.APPHUB_MODULE_ARTIFACT_SECRET_ACCESS_KEY ??
+    env.APPHUB_MODULE_ARTIFACT_S3_SECRET_ACCESS_KEY ??
+    env.APPHUB_BUNDLE_STORAGE_SECRET_ACCESS_KEY ??
+    env.APPHUB_JOB_BUNDLE_S3_SECRET_ACCESS_KEY ??
+    env.AWS_SECRET_ACCESS_KEY ??
+    undefined;
+
+  const sessionToken =
+    env.APPHUB_MODULE_ARTIFACT_SESSION_TOKEN ??
+    env.APPHUB_MODULE_ARTIFACT_S3_SESSION_TOKEN ??
+    env.APPHUB_BUNDLE_STORAGE_SESSION_TOKEN ??
+    env.APPHUB_JOB_BUNDLE_S3_SESSION_TOKEN ??
+    env.AWS_SESSION_TOKEN ??
+    undefined;
+
+  const prefix =
+    env.APPHUB_MODULE_ARTIFACT_PREFIX?.trim() ||
+    env.APPHUB_MODULE_ARTIFACT_S3_PREFIX?.trim() ||
+    env.APPHUB_BUNDLE_STORAGE_PREFIX?.trim() ||
+    env.APPHUB_JOB_BUNDLE_S3_PREFIX?.trim() ||
+    'modules';
+
+  return {
+    bucket,
+    region,
+    endpoint,
+    forcePathStyle: String(forcePathStyleRaw).toLowerCase() === 'true',
+    accessKeyId,
+    secretAccessKey,
+    sessionToken,
+    prefix: prefix.replace(/^\/+/, '').replace(/\/+$/, '')
+  } satisfies S3Config;
+}
+
+function createS3Client(config: S3Config): S3Client {
+  const clientConfig: ConstructorParameters<typeof S3Client>[0] = {
+    region: config.region,
+    forcePathStyle: config.forcePathStyle
+  };
+  if (config.endpoint) {
+    clientConfig.endpoint = config.endpoint;
+  }
+  if (config.accessKeyId && config.secretAccessKey) {
+    clientConfig.credentials = {
+      accessKeyId: config.accessKeyId,
+      secretAccessKey: config.secretAccessKey,
+      sessionToken: config.sessionToken
+    };
+  }
+  return new S3Client(clientConfig);
+}
+
+async function ensureBucketExists(client: S3Client, config: S3Config): Promise<void> {
+  try {
+    const input: ConstructorParameters<typeof CreateBucketCommand>[0] = { Bucket: config.bucket };
+    const normalizedRegion = config.region?.toLowerCase() ?? 'us-east-1';
+    if (normalizedRegion && normalizedRegion !== 'us-east-1' && config.region) {
+      input.CreateBucketConfiguration = {
+        LocationConstraint: config.region as BucketLocationConstraint
+      };
+    }
+    await client.send(new CreateBucketCommand(input));
+  } catch (error) {
+    const code = (error as { name?: string; Code?: string }).name ?? (error as { Code?: string }).Code;
+    if (code === 'BucketAlreadyOwnedByYou' || code === 'BucketAlreadyExists') {
+      return;
+    }
+    throw error;
+  }
+}

--- a/docker/observatory-e2e.compose.yml
+++ b/docker/observatory-e2e.compose.yml
@@ -46,6 +46,7 @@ x-shared-env: &shared-env
   APPHUB_JOB_BUNDLE_S3_FORCE_PATH_STYLE: "true"
   APPHUB_JOB_BUNDLE_S3_ACCESS_KEY_ID: apphub
   APPHUB_JOB_BUNDLE_S3_SECRET_ACCESS_KEY: apphub123
+  OBSERVATORY_CONFIG_PATH: /tmp/apphub-observatory/scratch/config/observatory-config.json
   TIMESTORE_STORAGE_DRIVER: s3
   TIMESTORE_S3_BUCKET: apphub-timestore
   TIMESTORE_S3_ENDPOINT: http://minio:9000
@@ -91,10 +92,12 @@ x-core-service: &core-service
   volumes:
     - ${APPHUB_E2E_REPO_ROOT}:${APPHUB_E2E_REPO_ROOT}:ro
     - module-artifacts:/tmp/apphub
+    - module-config:/tmp/apphub-observatory/scratch
 
 x-runtime-volume: &runtime-volume
   - ${APPHUB_E2E_REPO_ROOT}:${APPHUB_E2E_REPO_ROOT}:ro
   - module-artifacts:/tmp/apphub
+  - module-config:/tmp/apphub-observatory/scratch
 
 services:
   postgres:
@@ -254,4 +257,6 @@ services:
 volumes:
   minio-data:
   module-artifacts:
+    driver: local
+  module-config:
     driver: local

--- a/modules/environmental-observatory/module.ts
+++ b/modules/environmental-observatory/module.ts
@@ -2,7 +2,7 @@ import { defineModule, namedCapabilities, secretsRef, settingsRef } from '@apphu
 import type { ObservatoryModuleSecrets, ObservatoryModuleSettings } from './src/runtime/settings';
 import { defaultObservatorySettings, defaultObservatorySecrets } from './src/runtime/settings';
 import { dataGeneratorJob } from './src/jobs/dataGenerator';
-import { inboxNormalizerJob } from './src/jobs/inboxNormalizer';
+import { minutePreprocessorJob } from './src/jobs/minutePreprocessor';
 import { timestoreLoaderJob } from './src/jobs/timestoreLoader';
 import { visualizationRunnerJob } from './src/jobs/visualizationRunner';
 import { dashboardAggregatorJob } from './src/jobs/dashboardAggregator';
@@ -10,12 +10,14 @@ import { reportPublisherJob } from './src/jobs/reportPublisher';
 import { calibrationImporterJob } from './src/jobs/calibrationImporter';
 import { calibrationPlannerJob } from './src/jobs/calibrationPlanner';
 import { calibrationReprocessorJob } from './src/jobs/calibrationReprocessor';
+import { burstFinalizerJob } from './src/jobs/burstFinalizer';
 import { dashboardService, adminService } from './src/services';
 import {
   minuteDataGeneratorWorkflow,
   minuteIngestWorkflow,
   dailyPublicationWorkflow,
   dashboardAggregateWorkflow,
+  burstFinalizeWorkflow,
   calibrationImportWorkflow,
   calibrationReprocessWorkflow
 } from './src/workflows';
@@ -23,7 +25,7 @@ import {
 export default defineModule<ObservatoryModuleSettings, ObservatoryModuleSecrets>({
   metadata: {
     name: 'environmental-observatory',
-    version: '0.1.5',
+    version: '0.1.6',
     displayName: 'Environmental Observatory',
     description:
       'Reference implementation of the environmental observatory scenario using the AppHub module runtime.'
@@ -82,11 +84,12 @@ export default defineModule<ObservatoryModuleSettings, ObservatoryModuleSecrets>
   },
   targets: [
     dataGeneratorJob,
-    inboxNormalizerJob,
+    minutePreprocessorJob,
     timestoreLoaderJob,
     visualizationRunnerJob,
     dashboardAggregatorJob,
     reportPublisherJob,
+    burstFinalizerJob,
     calibrationImporterJob,
     calibrationPlannerJob,
     calibrationReprocessorJob,
@@ -96,6 +99,7 @@ export default defineModule<ObservatoryModuleSettings, ObservatoryModuleSecrets>
     minuteIngestWorkflow,
     dailyPublicationWorkflow,
     dashboardAggregateWorkflow,
+    burstFinalizeWorkflow,
     calibrationImportWorkflow,
     calibrationReprocessWorkflow
   ]

--- a/modules/environmental-observatory/package.json
+++ b/modules/environmental-observatory/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "lint": "tsc -b --pretty false",
-    "build": "tsc -b",
+    "build": "tsc -b && node ./scripts/bundle-module.cjs",
     "clean": "rm -rf dist"
   },
   "dependencies": {

--- a/modules/environmental-observatory/scripts/bundle-module.cjs
+++ b/modules/environmental-observatory/scripts/bundle-module.cjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+const path = require('node:path');
+const fs = require('node:fs/promises');
+const { build } = require('esbuild');
+
+async function main() {
+  const moduleRoot = path.resolve(__dirname, '..');
+  const distDir = path.join(moduleRoot, 'dist');
+  const entryPath = path.join(distDir, 'module.js');
+  const artifactPath = path.join(distDir, 'module.artifact.js');
+
+  await ensureFile(entryPath, 'Module entrypoint not found. Did you run "tsc -b" first?');
+
+  await build({
+    entryPoints: [entryPath],
+    outfile: artifactPath,
+    bundle: true,
+    platform: 'node',
+    format: 'cjs',
+    target: ['node18'],
+    logLevel: 'silent',
+    sourcemap: false,
+    minify: true,
+    external: ['@apphub/module-sdk', '@apphub/module-registry', '@apphub/filestore-client', 'undici']
+  });
+}
+
+async function ensureFile(filePath, message) {
+  try {
+    await fs.access(filePath);
+  } catch (error) {
+    const err = new Error(message);
+    err.cause = error;
+    throw err;
+  }
+}
+
+main().catch((error) => {
+  console.error('[bundle-module]', error);
+  process.exitCode = 1;
+});

--- a/modules/environmental-observatory/src/deployment/config.ts
+++ b/modules/environmental-observatory/src/deployment/config.ts
@@ -1,5 +1,6 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
+import { enforceScratchOnlyWrites } from '@apphub/module-sdk';
 import {
   createEventDrivenObservatoryConfig,
   type EventDrivenObservatoryConfig
@@ -94,6 +95,51 @@ export async function materializeObservatoryConfig(
 
   await mkdir(path.dirname(outputPath), { recursive: true });
   await writeFile(outputPath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
+
+  const runtimeScratchRoots = new Set<string>();
+  const runtimeScratchCandidates = [
+    env.APPHUB_RUNTIME_SCRATCH_ROOT?.trim(),
+    env.APPHUB_SCRATCH_ROOT?.trim()
+  ];
+
+  for (const candidate of runtimeScratchCandidates) {
+    if (!candidate) {
+      continue;
+    }
+    runtimeScratchRoots.add(path.resolve(candidate));
+  }
+
+  runtimeScratchRoots.add('/tmp/apphub');
+
+  const mirrorTargets = new Set<string>();
+  const explicitConfigPath = env.OBSERVATORY_CONFIG_PATH?.trim();
+  if (explicitConfigPath) {
+    mirrorTargets.add(path.resolve(explicitConfigPath));
+  }
+
+  for (const root of runtimeScratchRoots) {
+    mirrorTargets.add(path.resolve(path.join(root, 'observatory', 'config', 'observatory-config.json')));
+    mirrorTargets.add(path.resolve(path.join(root, 'config', 'observatory-config.json')));
+  }
+
+  mirrorTargets.add(path.resolve('/tmp/apphub/config/observatory-config.json'));
+
+  enforceScratchOnlyWrites({
+    allowedPrefixes: Array.from(mirrorTargets).map((target) => path.dirname(target))
+  });
+
+  for (const targetPath of mirrorTargets) {
+    if (path.resolve(targetPath) === path.resolve(outputPath)) {
+      continue;
+    }
+    try {
+      await mkdir(path.dirname(targetPath), { recursive: true });
+      await writeFile(targetPath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
+      logger.debug?.('Observatory config mirrored', { path: targetPath });
+    } catch (error) {
+      logger.debug?.('Skipping observatory config mirror', { path: targetPath, error });
+    }
+  }
 
   logger.debug?.('Observatory config materialized', { outputPath });
 

--- a/modules/environmental-observatory/src/deployment/configBuilder.ts
+++ b/modules/environmental-observatory/src/deployment/configBuilder.ts
@@ -61,6 +61,8 @@ export type ObservatoryConfig = {
     dashboard?: {
       overviewPrefix?: string;
       lookbackMinutes?: number;
+      burstQuietMillis?: number;
+      snapshotFreshnessMillis?: number;
     };
   };
 };
@@ -371,7 +373,10 @@ export function createEventDrivenObservatoryConfig(
       },
       dashboard: {
         overviewPrefix: optionalString(getVar('OBSERVATORY_DASHBOARD_OVERVIEW_PREFIX')),
-        lookbackMinutes: optionalNumber(getVar('OBSERVATORY_DASHBOARD_LOOKBACK_MINUTES')) ?? 720
+        lookbackMinutes: optionalNumber(getVar('OBSERVATORY_DASHBOARD_LOOKBACK_MINUTES')) ?? 720,
+        burstQuietMillis: optionalNumber(getVar('OBSERVATORY_DASHBOARD_BURST_QUIET_MS')) ?? 5_000,
+        snapshotFreshnessMillis:
+          optionalNumber(getVar('OBSERVATORY_DASHBOARD_SNAPSHOT_FRESHNESS_MS')) ?? 60_000
       }
     }
   };

--- a/modules/environmental-observatory/src/jobs/burstFinalizer.ts
+++ b/modules/environmental-observatory/src/jobs/burstFinalizer.ts
@@ -1,0 +1,127 @@
+import { z } from 'zod';
+import {
+  createJobHandler,
+  inheritModuleSecrets,
+  inheritModuleSettings,
+  selectEventBus,
+  type JobContext
+} from '@apphub/module-sdk';
+
+import { createObservatoryEventPublisher, publishAssetMaterialized } from '../runtime/events';
+import type { ObservatoryModuleSecrets, ObservatoryModuleSettings } from '../runtime/settings';
+
+const parametersSchema = z
+  .object({
+    partitionKey: z.string().min(1, 'partitionKey is required'),
+    producedAt: z.string().optional(),
+    expiresAt: z.string().optional(),
+    reason: z.string().optional()
+  })
+  .strip();
+
+export type BurstFinalizerParameters = z.infer<typeof parametersSchema>;
+
+export type BurstFinalizerResult = {
+  partitionKey: string;
+  burst: {
+    partitionKey: string;
+    finishedAt: string;
+    producedAt: string | null;
+    expiresAt: string | null;
+    reason: string | null;
+  };
+  assets: Array<{
+    assetId: string;
+    partitionKey: string;
+    producedAt: string;
+    payload: BurstFinalizerResult['burst'];
+  }>;
+};
+
+type BurstFinalizerContext = JobContext<
+  ObservatoryModuleSettings,
+  ObservatoryModuleSecrets,
+  BurstFinalizerParameters
+>;
+
+export const burstFinalizerJob = createJobHandler<
+  ObservatoryModuleSettings,
+  ObservatoryModuleSecrets,
+  BurstFinalizerResult,
+  BurstFinalizerParameters,
+  ['events.default']
+>({
+  name: 'observatory-burst-finalizer',
+  settings: inheritModuleSettings(),
+  secrets: inheritModuleSecrets(),
+  requires: ['events.default'] as const,
+  parameters: {
+    resolve: (raw) => parametersSchema.parse(raw ?? {})
+  },
+  handler: async (context: BurstFinalizerContext): Promise<BurstFinalizerResult> => {
+    const partitionKey = context.parameters.partitionKey.trim();
+    if (!partitionKey) {
+      throw new Error('partitionKey parameter is required');
+    }
+
+    const eventsCapability = selectEventBus(context.capabilities, 'default');
+    if (!eventsCapability) {
+      throw new Error('Event bus capability is required for burst finalization');
+    }
+
+    const finishedAt = new Date().toISOString();
+    const burst = {
+      partitionKey,
+      finishedAt,
+      producedAt: context.parameters.producedAt ?? null,
+      expiresAt: context.parameters.expiresAt ?? null,
+      reason: context.parameters.reason ?? null
+    } satisfies BurstFinalizerResult['burst'];
+
+    const publisher = createObservatoryEventPublisher({
+      capability: eventsCapability,
+      source: context.settings.events.source || 'observatory.burst-finalizer'
+    });
+
+    try {
+      await publishAssetMaterialized(publisher, {
+        assetId: 'observatory.burst.ready',
+        partitionKey,
+        producedAt: finishedAt,
+        metadata: {
+          producedAt: burst.producedAt,
+          expiresAt: burst.expiresAt,
+          reason: burst.reason
+        }
+      });
+
+      await publisher.publish({
+        type: 'observatory.burst.finished',
+        occurredAt: finishedAt,
+        payload: burst
+      });
+    } finally {
+      await publisher.close().catch(() => undefined);
+    }
+
+    context.logger.info('Burst finalized after quiet window', {
+      partitionKey,
+      producedAt: burst.producedAt,
+      expiresAt: burst.expiresAt,
+      finishedAt
+    });
+
+    return {
+      partitionKey,
+      burst,
+      assets: [
+        {
+          assetId: 'observatory.burst.ready',
+          partitionKey,
+          producedAt: finishedAt,
+          payload: burst
+        }
+      ]
+    } satisfies BurstFinalizerResult;
+  }
+});

--- a/modules/environmental-observatory/src/jobs/calibrationImporter.ts
+++ b/modules/environmental-observatory/src/jobs/calibrationImporter.ts
@@ -21,7 +21,7 @@ import {
   deriveMetastoreKey,
   normalizeCalibrationRecord
 } from '../runtime/calibrations';
-import { createObservatoryEventPublisher, toJsonRecord } from '../runtime/events';
+import { createObservatoryEventPublisher, publishAssetMaterialized, toJsonRecord } from '../runtime/events';
 import type { ObservatoryModuleSecrets, ObservatoryModuleSettings } from '../runtime/settings';
 
 const parametersSchema = z
@@ -179,6 +179,19 @@ export const calibrationImporterJob = createJobHandler<
     const generatedAt = new Date().toISOString();
 
     try {
+      await publishAssetMaterialized(publisher, {
+        assetId: 'observatory.calibration.instrument',
+        partitionKey: normalized.calibrationId,
+        producedAt: generatedAt,
+        metadata: {
+          instrumentId: normalized.instrumentId,
+          effectiveAt: normalized.effectiveAt,
+          metastoreNamespace: context.settings.calibrations.namespace,
+          metastoreRecordKey: metastoreKey,
+          metastoreVersion
+        }
+      });
+
       await publisher.publish({
         type: 'observatory.calibration.updated',
         occurredAt: generatedAt,

--- a/modules/environmental-observatory/src/jobs/dataGenerator.ts
+++ b/modules/environmental-observatory/src/jobs/dataGenerator.ts
@@ -203,18 +203,6 @@ async function handler(context: GeneratorContext): Promise<GeneratorJobResult> {
     moduleSettings.filestore.inboxPrefix,
     principal
   );
-  await ensureFilestoreHierarchy(
-    filestore,
-    backendMountId,
-    moduleSettings.filestore.stagingPrefix,
-    principal
-  );
-  await ensureFilestoreHierarchy(
-    filestore,
-    backendMountId,
-    moduleSettings.filestore.archivePrefix,
-    principal
-  );
 
   const seed = moduleSettings.generator.seed;
   const rng = createRandom(seed);

--- a/modules/environmental-observatory/src/runtime/config.ts
+++ b/modules/environmental-observatory/src/runtime/config.ts
@@ -60,6 +60,8 @@ export type ObservatoryWorkflowGeneratorConfig = {
 export type ObservatoryWorkflowDashboardConfig = {
   overviewDirName?: string;
   lookbackMinutes?: number;
+  burstQuietMillis?: number;
+  snapshotFreshnessMillis?: number;
 };
 
 export type ObservatoryWorkflowConfig = {

--- a/modules/environmental-observatory/src/runtime/settings.ts
+++ b/modules/environmental-observatory/src/runtime/settings.ts
@@ -41,6 +41,8 @@ export interface EventSettings {
 
 export interface DashboardSettings {
   lookbackMinutes: number;
+  burstQuietMs: number;
+  snapshotFreshnessMs: number;
 }
 
 export interface CoreSettings {
@@ -62,7 +64,7 @@ export interface IngestSettings {
 
 export interface PrincipalSettings {
   dataGenerator: string;
-  inboxNormalizer: string;
+  minutePreprocessor: string;
   timestoreLoader: string;
   visualizationRunner: string;
   dashboardAggregator: string;
@@ -117,9 +119,9 @@ const FALLBACK_OBSERVATORY_SETTINGS: ObservatoryModuleSettings = {
     baseUrl: 'http://127.0.0.1:4300',
     backendKey: 'observatory-event-driven-s3',
     backendId: 1,
-    inboxPrefix: 'datasets/observatory/inbox',
-    stagingPrefix: 'datasets/observatory/staging',
-    archivePrefix: 'datasets/observatory/archive',
+    inboxPrefix: 'datasets/observatory/raw',
+    stagingPrefix: 'datasets/observatory/raw',
+    archivePrefix: 'datasets/observatory/raw',
     visualizationsPrefix: 'datasets/observatory/visualizations',
     reportsPrefix: 'datasets/observatory/reports',
     overviewPrefix: 'datasets/observatory/reports/overview',
@@ -147,7 +149,9 @@ const FALLBACK_OBSERVATORY_SETTINGS: ObservatoryModuleSettings = {
     source: 'observatory.events'
   },
   dashboard: {
-    lookbackMinutes: 720
+    lookbackMinutes: 720,
+    burstQuietMs: 5_000,
+    snapshotFreshnessMs: 60_000
   },
   core: {
     baseUrl: 'http://127.0.0.1:4000'
@@ -165,7 +169,7 @@ const FALLBACK_OBSERVATORY_SETTINGS: ObservatoryModuleSettings = {
   },
   principals: {
     dataGenerator: 'observatory-data-generator',
-    inboxNormalizer: 'observatory-inbox-normalizer',
+    minutePreprocessor: 'observatory-minute-preprocessor',
     timestoreLoader: 'observatory-timestore-loader',
     visualizationRunner: 'observatory-visualization-runner',
     dashboardAggregator: 'observatory-dashboard-aggregator',

--- a/modules/environmental-observatory/src/workflows/burstFinalize.ts
+++ b/modules/environmental-observatory/src/workflows/burstFinalize.ts
@@ -1,0 +1,84 @@
+import { createWorkflow, createWorkflowTrigger, type WorkflowDefinition } from '@apphub/module-sdk';
+
+import type { ObservatoryModuleSecrets, ObservatoryModuleSettings } from '../runtime/settings';
+
+const definition: WorkflowDefinition = {
+  slug: 'observatory-burst-finalize',
+  name: 'Observatory Burst Finalize',
+  version: 1,
+  description: 'Convert burst window expirations into downstream aggregation signals.',
+  parametersSchema: {
+    type: 'object',
+    properties: {
+      partitionKey: { type: 'string', minLength: 1 },
+      producedAt: { type: 'string' },
+      expiresAt: { type: 'string' },
+      reason: { type: 'string' }
+    },
+    required: ['partitionKey']
+  },
+  steps: [
+    {
+      id: 'finalize-burst',
+      name: 'Emit burst finalized signal',
+      type: 'job',
+      jobSlug: 'observatory-burst-finalizer',
+      parameters: {
+        partitionKey: '{{ parameters.partitionKey }}',
+        producedAt: '{{ parameters.producedAt }}',
+        expiresAt: '{{ parameters.expiresAt }}',
+        reason: '{{ parameters.reason }}'
+      },
+      produces: [
+        {
+          assetId: 'observatory.burst.ready',
+          partitioning: {
+            type: 'timeWindow',
+            granularity: 'minute',
+            format: 'YYYY-MM-DDTHH:mm',
+            lookbackWindows: 1440
+          }
+        }
+      ]
+    }
+  ]
+};
+
+const triggers = [
+  createWorkflowTrigger({
+    name: 'Finalize burst on quiet-window expiry',
+    description: 'Run when the burst window asset TTL elapses, signalling no new drops arrived.',
+    eventType: 'asset.expired',
+    predicates: [
+      {
+        path: '$.payload.assetId',
+        operator: 'equals',
+        value: 'observatory.burst.window'
+      },
+      {
+        path: '$.payload.reason',
+        operator: 'equals',
+        value: 'ttl'
+      }
+    ],
+    parameterTemplate: {
+      partitionKey: '{{ event.payload.partitionKey | default: event.payload.workflowSlug }}',
+      producedAt: '{{ event.payload.producedAt }}',
+      expiresAt: '{{ event.payload.expiresAt }}',
+      reason: '{{ event.payload.reason }}'
+    },
+    idempotencyKeyExpression:
+      'burst-finalize-{{ event.payload.partitionKey | default: event.payload.workflowSlug }}-{{ event.payload.expiresAt }}'
+  })
+];
+
+export const burstFinalizeWorkflow = createWorkflow<
+  ObservatoryModuleSettings,
+  ObservatoryModuleSecrets
+>({
+  name: definition.slug,
+  displayName: definition.name,
+  description: definition.description,
+  definition,
+  triggers
+});

--- a/modules/environmental-observatory/src/workflows/index.ts
+++ b/modules/environmental-observatory/src/workflows/index.ts
@@ -2,5 +2,6 @@ export { minuteDataGeneratorWorkflow } from './minuteDataGenerator';
 export { minuteIngestWorkflow } from './minuteIngest';
 export { dailyPublicationWorkflow } from './dailyPublication';
 export { dashboardAggregateWorkflow } from './dashboardAggregate';
+export { burstFinalizeWorkflow } from './burstFinalize';
 export { calibrationImportWorkflow } from './calibrationImport';
 export { calibrationReprocessWorkflow } from './calibrationReprocess';

--- a/modules/environmental-observatory/src/workflows/minuteIngest.ts
+++ b/modules/environmental-observatory/src/workflows/minuteIngest.ts
@@ -29,7 +29,7 @@ const definition: WorkflowDefinition = {
       id: 'normalize-inbox',
       name: 'Normalize inbox files',
       type: 'job',
-      jobSlug: 'observatory-inbox-normalizer',
+      jobSlug: 'observatory-minute-preprocessor',
       parameters: {
         minute: '{{ parameters.minute | default: run.trigger.schedule.occurrence | slice: 0, 16 }}',
         maxFiles: '{{ parameters.maxFiles | default: defaultParameters.maxFiles }}',
@@ -71,6 +71,24 @@ const definition: WorkflowDefinition = {
             granularity: 'minute',
             format: 'YYYY-MM-DDTHH:mm',
             lookbackWindows: 1440
+          },
+          autoMaterialize: {
+            enabled: false
+          }
+        },
+        {
+          assetId: 'observatory.burst.window',
+          partitioning: {
+            type: 'timeWindow',
+            granularity: 'minute',
+            format: 'YYYY-MM-DDTHH:mm',
+            lookbackWindows: 1440
+          },
+          freshness: {
+            ttlMs: 5000
+          },
+          autoMaterialize: {
+            enabled: false
           }
         }
       ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@types/node": "^24.5.2",
         "chokidar": "^3.6.0",
         "concurrently": "^9.2.1",
+        "esbuild": "^0.23.0",
         "kafkajs": "^2.2.4",
         "openapi-typescript-codegen": "^0.29.0",
         "typescript": "^5.9.2"
@@ -38,6 +39,7 @@
         "@apphub/filestore-client": "0.1.0",
         "@apphub/module-registry": "0.1.0",
         "@apphub/module-sdk": "0.1.0",
+        "@aws-sdk/client-s3": "^3.896.0",
         "commander": "^11.1.0",
         "yaml": "^2.8.1"
       },
@@ -503,6 +505,70 @@
         "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/@astrojs/react/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
+      "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/android-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
+      "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
+      "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/android-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
+      "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@astrojs/react/node_modules/@esbuild/darwin-arm64": {
       "version": "0.25.10",
       "cpu": [
@@ -512,6 +578,310 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
+      "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
+      "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
+      "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
+      "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
+      "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
+      "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
+      "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
+      "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
+      "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
+      "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
+      "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
+      "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
+      "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
+      "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
+      "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -2111,6 +2481,446 @@
       ],
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.23.1.tgz",
+      "integrity": "sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.23.1.tgz",
+      "integrity": "sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.23.1.tgz",
+      "integrity": "sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.23.1.tgz",
+      "integrity": "sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.23.1.tgz",
+      "integrity": "sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.23.1.tgz",
+      "integrity": "sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.23.1.tgz",
+      "integrity": "sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.23.1.tgz",
+      "integrity": "sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.23.1.tgz",
+      "integrity": "sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.23.1.tgz",
+      "integrity": "sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.23.1.tgz",
+      "integrity": "sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.23.1.tgz",
+      "integrity": "sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.23.1.tgz",
+      "integrity": "sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.23.1.tgz",
+      "integrity": "sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.23.1.tgz",
+      "integrity": "sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.23.1.tgz",
+      "integrity": "sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.23.1.tgz",
+      "integrity": "sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.23.1.tgz",
+      "integrity": "sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.23.1.tgz",
+      "integrity": "sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.23.1.tgz",
+      "integrity": "sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz",
+      "integrity": "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.23.1.tgz",
+      "integrity": "sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.23.1.tgz",
+      "integrity": "sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.23.1.tgz",
+      "integrity": "sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.23.1.tgz",
+      "integrity": "sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -5384,6 +6194,70 @@
         "url": "https://github.com/sponsors/ota-meshi"
       }
     },
+    "node_modules/astro/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
+      "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/android-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
+      "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
+      "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/android-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
+      "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/astro/node_modules/@esbuild/darwin-arm64": {
       "version": "0.25.10",
       "cpu": [
@@ -5393,6 +6267,310 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
+      "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
+      "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
+      "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
+      "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
+      "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
+      "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
+      "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
+      "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
+      "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
+      "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
+      "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
+      "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
+      "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
+      "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
+      "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -7259,6 +8437,46 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.23.1.tgz",
+      "integrity": "sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.23.1",
+        "@esbuild/android-arm": "0.23.1",
+        "@esbuild/android-arm64": "0.23.1",
+        "@esbuild/android-x64": "0.23.1",
+        "@esbuild/darwin-arm64": "0.23.1",
+        "@esbuild/darwin-x64": "0.23.1",
+        "@esbuild/freebsd-arm64": "0.23.1",
+        "@esbuild/freebsd-x64": "0.23.1",
+        "@esbuild/linux-arm": "0.23.1",
+        "@esbuild/linux-arm64": "0.23.1",
+        "@esbuild/linux-ia32": "0.23.1",
+        "@esbuild/linux-loong64": "0.23.1",
+        "@esbuild/linux-mips64el": "0.23.1",
+        "@esbuild/linux-ppc64": "0.23.1",
+        "@esbuild/linux-riscv64": "0.23.1",
+        "@esbuild/linux-s390x": "0.23.1",
+        "@esbuild/linux-x64": "0.23.1",
+        "@esbuild/netbsd-x64": "0.23.1",
+        "@esbuild/openbsd-arm64": "0.23.1",
+        "@esbuild/openbsd-x64": "0.23.1",
+        "@esbuild/sunos-x64": "0.23.1",
+        "@esbuild/win32-arm64": "0.23.1",
+        "@esbuild/win32-ia32": "0.23.1",
+        "@esbuild/win32-x64": "0.23.1"
       }
     },
     "node_modules/escalade": {
@@ -14133,6 +15351,74 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
+      "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
+      "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
+      "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
+      "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
       "version": "0.25.10",
       "cpu": [
@@ -14143,6 +15429,329 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
+      "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
+      "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
+      "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
+      "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
+      "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
+      "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
+      "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
+      "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
+      "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
+      "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
+      "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
+      "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
+      "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
+      "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
+      "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -14787,6 +16396,70 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
+      "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
+      "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
+      "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
+      "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
       "version": "0.25.10",
       "cpu": [
@@ -14796,6 +16469,310 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
+      "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
+      "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
+      "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
+      "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
+      "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
+      "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
+      "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
+      "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
+      "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
+      "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
+      "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
+      "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
+      "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
+      "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
+      "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@types/node": "^24.5.2",
     "chokidar": "^3.6.0",
     "concurrently": "^9.2.1",
+    "esbuild": "^0.23.0",
     "kafkajs": "^2.2.4",
     "openapi-typescript-codegen": "^0.29.0",
     "typescript": "^5.9.2"

--- a/packages/module-registry/src/core.ts
+++ b/packages/module-registry/src/core.ts
@@ -243,7 +243,7 @@ function resolveWorkflowDefinition(
 function isModuleJobSlugValue(value: string): value is ModuleJobSlug {
   switch (value) {
     case 'observatory-data-generator':
-    case 'observatory-inbox-normalizer':
+    case 'observatory-minute-preprocessor':
     case 'observatory-timestore-loader':
     case 'observatory-visualization-runner':
     case 'observatory-dashboard-aggregator':

--- a/packages/module-registry/src/types.ts
+++ b/packages/module-registry/src/types.ts
@@ -50,7 +50,7 @@ export type JobManifestTemplate = {
 
 export type ModuleJobSlug =
   | 'observatory-data-generator'
-  | 'observatory-inbox-normalizer'
+  | 'observatory-minute-preprocessor'
   | 'observatory-timestore-loader'
   | 'observatory-visualization-runner'
   | 'observatory-dashboard-aggregator'

--- a/services/core/openapi.json
+++ b/services/core/openapi.json
@@ -39998,26 +39998,84 @@
                     "type": "object"
                   },
                   "artifact": {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "required": [
-                      "data"
-                    ],
-                    "properties": {
-                      "filename": {
-                        "type": "string",
-                        "minLength": 1
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": [
+                          "data"
+                        ],
+                        "properties": {
+                          "storage": {
+                            "type": "string",
+                            "enum": [
+                              "inline"
+                            ]
+                          },
+                          "filename": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "contentType": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "data": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "Base64-encoded module bundle contents."
+                          },
+                          "size": {
+                            "type": "integer",
+                            "minimum": 1
+                          },
+                          "checksum": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        }
                       },
-                      "contentType": {
-                        "type": "string",
-                        "minLength": 1
-                      },
-                      "data": {
-                        "type": "string",
-                        "minLength": 1,
-                        "description": "Base64-encoded module bundle contents."
+                      {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": [
+                          "storage",
+                          "bucket",
+                          "key",
+                          "size",
+                          "checksum"
+                        ],
+                        "properties": {
+                          "storage": {
+                            "type": "string",
+                            "enum": [
+                              "s3"
+                            ]
+                          },
+                          "bucket": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "key": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "contentType": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "size": {
+                            "type": "integer",
+                            "minimum": 1
+                          },
+                          "checksum": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "Hex-encoded SHA-256 checksum of the stored artifact."
+                          }
+                        }
                       }
-                    }
+                    ]
                   }
                 }
               }


### PR DESCRIPTION
## Summary
- refactor observatory ingest + burst orchestration including new burst finalizer job
- switch module deploy to support S3 artifact storage and mirror config inside runtime scratch roots
- tighten e2e coverage for burst window flow and update deployment scripts/docs

## Testing
- npm run build --workspace @apphub/cli
- npm run build --workspace @apphub/environmental-observatory-module
- npm run e2e *(fails: observatory-burst-finalize timed out waiting for burst window expiry)*