### PR TITLE
feat(frontend): simplify module jobs view

### DIFF
--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Osiris AppHub</title>
   </head>

--- a/apps/frontend/public/favicon.svg
+++ b/apps/frontend/public/favicon.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 48">
+  <defs>
+    <linearGradient id="eyeOuter" x1="6" y1="4" x2="66" y2="44" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0f766e" />
+      <stop offset="1" stop-color="#22d3ee" />
+    </linearGradient>
+    <radialGradient id="eyeInner" cx="50%" cy="50%" r="50%">
+      <stop offset="0" stop-color="#0f766e" stop-opacity="0.95" />
+      <stop offset="0.45" stop-color="#083b39" stop-opacity="0.88" />
+      <stop offset="1" stop-color="#011a19" stop-opacity="0.95" />
+    </radialGradient>
+    <radialGradient id="eyeHighlight" cx="36%" cy="32%" r="40%">
+      <stop offset="0" stop-color="#bef8ff" stop-opacity="0.9" />
+      <stop offset="1" stop-color="#bef8ff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <path
+    d="M36 4C20.5 4 8.09 13.73 3 24c5.09 10.27 17.5 20 33 20s27.91-9.73 33-20C63.91 13.73 51.5 4 36 4Z"
+    fill="url(#eyeOuter)"
+    fill-opacity="0.32"
+    stroke="url(#eyeOuter)"
+    stroke-width="2"
+    stroke-linejoin="round"
+  />
+  <ellipse cx="36" cy="24" rx="12.5" ry="12" fill="url(#eyeInner)" />
+  <circle cx="36" cy="24" r="6" fill="#22d3ee" opacity="0.9" />
+  <circle cx="30" cy="19" r="4" fill="url(#eyeHighlight)" />
+  <path
+    d="M12 24c5-6.5 13.3-10.5 24-10.5S55 17.5 60 24c-5 6.5-13.3 10.5-24 10.5S17 30.5 12 24Z"
+    fill="none"
+    stroke="rgba(34, 211, 238, 0.35)"
+    stroke-width="1.4"
+    stroke-linecap="round"
+  />
+</svg>

--- a/apps/frontend/src/theme/integrations/workflowGraphTheme.ts
+++ b/apps/frontend/src/theme/integrations/workflowGraphTheme.ts
@@ -43,14 +43,14 @@ const NODE_COLOR_TOKENS = (theme: ThemeDefinition): Record<WorkflowGraphCanvasNo
     badgeText: theme.semantics.accent.onAccent
   },
   'step-job': {
-    primary: theme.semantics.status.success,
-    secondary: theme.semantics.status.info,
-    badgeText: theme.semantics.status.successOn
+    primary: theme.semantics.status.info,
+    secondary: theme.semantics.text.accent,
+    badgeText: theme.semantics.status.infoOn
   },
   'step-service': {
-    primary: theme.semantics.status.info,
+    primary: theme.semantics.status.success,
     secondary: theme.semantics.accent.default,
-    badgeText: theme.semantics.status.infoOn
+    badgeText: theme.semantics.status.successOn
   },
   'step-fanout': {
     primary: theme.semantics.status.warning,
@@ -59,7 +59,7 @@ const NODE_COLOR_TOKENS = (theme: ThemeDefinition): Record<WorkflowGraphCanvasNo
   },
   'trigger-event': {
     primary: theme.semantics.accent.emphasis,
-    secondary: theme.semantics.status.info,
+    secondary: theme.semantics.status.warning,
     badgeText: theme.semantics.accent.onAccent
   },
   'trigger-definition': {
@@ -69,7 +69,7 @@ const NODE_COLOR_TOKENS = (theme: ThemeDefinition): Record<WorkflowGraphCanvasNo
   },
   schedule: {
     primary: theme.semantics.text.secondary,
-    secondary: theme.semantics.accent.default,
+    secondary: theme.semantics.status.info,
     badgeText: theme.semantics.text.inverse
   },
   asset: {
@@ -79,7 +79,7 @@ const NODE_COLOR_TOKENS = (theme: ThemeDefinition): Record<WorkflowGraphCanvasNo
   },
   'event-source': {
     primary: theme.semantics.status.success,
-    secondary: theme.semantics.status.info,
+    secondary: theme.semantics.accent.emphasis,
     badgeText: theme.semantics.status.successOn
   }
 });

--- a/apps/frontend/src/workflows/components/WorkflowTopologyPreview.tsx
+++ b/apps/frontend/src/workflows/components/WorkflowTopologyPreview.tsx
@@ -1,10 +1,38 @@
-import { useMemo } from 'react';
+import classNames from 'classnames';
+import {
+  useMemo,
+  useState,
+  useCallback,
+  useRef,
+  useEffect,
+  type FormEvent
+} from 'react';
 import { ReactFlowProvider } from 'reactflow';
-import { Spinner } from '../../components';
+import { Modal, Spinner } from '../../components';
 import { getStatusToneClasses } from '../../theme/statusTokens';
+import { useWorkflowAccess } from '../hooks/useWorkflowAccess';
 import { useWorkflowGraph } from '../hooks/useWorkflowGraph';
-import type { WorkflowDefinition } from '../types';
-import WorkflowGraphCanvas from './WorkflowGraphCanvas';
+import {
+  ApiError,
+  getWorkflowRun,
+  listWorkflowRunSteps,
+  searchWorkflowRuns
+} from '../api';
+import {
+  buildWorkflowRunOverlayFromSnapshot
+} from '../graph/liveStatus';
+import type {
+  WorkflowDefinition,
+  WorkflowRun,
+  WorkflowRunStep
+} from '../types';
+import type { WorkflowGraphLiveOverlay } from '../graph';
+import WorkflowGraphCanvas, {
+  type WorkflowGraphCanvasNodeData
+} from './WorkflowGraphCanvas';
+import WorkflowRunDetails from './WorkflowRunDetails';
+import StatusBadge from './StatusBadge';
+import { formatTimestamp } from '../formatters';
 
 type WorkflowTopologyPreviewProps = {
   workflow: WorkflowDefinition | null;
@@ -16,20 +44,211 @@ const HEADER_TITLE_CLASSES = 'text-scale-lg font-weight-semibold text-primary';
 const HEADER_SUBTEXT_CLASSES = 'text-scale-xs text-secondary';
 const INFO_TEXT_CLASSES = 'mt-4 text-scale-sm text-secondary';
 const ERROR_TEXT_CLASSES = `mt-4 text-scale-sm font-weight-semibold ${getStatusToneClasses('danger')}`;
+const RUN_FORM_CLASSES = 'mt-4 flex flex-col gap-3 sm:flex-row sm:items-end';
+const RUN_FIELD_CONTAINER_CLASSES = 'flex flex-1 flex-col gap-1';
+const RUN_FIELD_LABEL_CLASSES = 'text-scale-xs font-weight-semibold uppercase tracking-[0.2em] text-muted';
+const RUN_FIELD_INPUT_CLASSES =
+  'h-10 rounded-2xl border border-subtle bg-surface-glass px-4 font-mono text-scale-sm text-primary shadow-inner transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent';
+const RUN_FORM_BUTTON_ROW_CLASSES = 'flex items-center gap-2';
+const RUN_PRIMARY_BUTTON_CLASSES =
+  'inline-flex h-10 items-center justify-center rounded-full border border-accent bg-accent px-4 text-scale-xs font-weight-semibold text-inverse shadow-elevation-md transition-colors hover:bg-accent-strong focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent disabled:cursor-not-allowed disabled:opacity-60';
+const RUN_SECONDARY_BUTTON_CLASSES =
+  'inline-flex h-10 items-center justify-center rounded-full border border-subtle bg-surface-glass px-4 text-scale-xs font-weight-semibold text-secondary shadow-elevation-sm transition-colors hover:border-accent-soft hover:text-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent disabled:cursor-not-allowed disabled:opacity-60';
+const RUN_HELP_TEXT_CLASSES = 'text-scale-xs text-muted';
+const RUN_STATUS_SUMMARY_CLASSES = 'mt-3 flex flex-wrap items-center gap-2 text-scale-xs text-secondary';
+const RUN_ERROR_TEXT_CLASSES = 'text-scale-xs font-weight-semibold text-status-danger';
+const MODAL_CONTENT_CLASSES = 'max-w-4xl';
+const MODAL_BODY_CLASSES = 'p-6 sm:p-8';
+const MODAL_CLOSE_BUTTON_CLASSES =
+  'inline-flex items-center rounded-full border border-subtle bg-surface-glass px-3 py-1 text-[11px] font-weight-semibold uppercase tracking-[0.18em] text-secondary shadow-elevation-sm transition-colors hover:border-accent-soft hover:bg-accent-soft hover:text-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent';
 
 export default function WorkflowTopologyPreview({ workflow }: WorkflowTopologyPreviewProps) {
-  const { graph, graphLoading, graphError, overlay } = useWorkflowGraph();
+  const graphContext = useWorkflowGraph();
+  const { graph, graphLoading, graphError, overlay } = graphContext;
+  const { authorizedFetch, pushToast } = useWorkflowAccess();
   const workflowId = workflow?.id ?? null;
   const filters = useMemo(
     () => (workflowId ? { workflowIds: [workflowId] } : { workflowIds: [] }),
     [workflowId]
   );
+  const [runQuery, setRunQuery] = useState('');
+  const [runLoading, setRunLoading] = useState(false);
+  const [runError, setRunError] = useState<string | null>(null);
+  const [runOverlay, setRunOverlay] = useState<WorkflowGraphLiveOverlay | null>(null);
+  const [currentRun, setCurrentRun] = useState<WorkflowRun | null>(null);
+  const [currentRunSteps, setCurrentRunSteps] = useState<WorkflowRunStep[]>([]);
+  const [selectedNode, setSelectedNode] = useState<WorkflowGraphCanvasNodeData | null>(null);
+  const [runDetailsOpen, setRunDetailsOpen] = useState(false);
+  const graphContainerRef = useRef<HTMLDivElement | null>(null);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  const [fullscreenSupported, setFullscreenSupported] = useState(true);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') {
+      setFullscreenSupported(false);
+      return;
+    }
+    setFullscreenSupported(document.fullscreenEnabled ?? true);
+    const handleFullscreenChange = () => {
+      const element = graphContainerRef.current;
+      setIsFullscreen(document.fullscreenElement === element);
+    };
+    document.addEventListener('fullscreenchange', handleFullscreenChange);
+    return () => {
+      document.removeEventListener('fullscreenchange', handleFullscreenChange);
+    };
+  }, []);
+
+  const handleToggleFullscreen = useCallback(() => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+    const element = graphContainerRef.current;
+    if (!element) {
+      return;
+    }
+    if (document.fullscreenElement === element) {
+      document.exitFullscreen?.().catch(() => {});
+    } else {
+      element.requestFullscreen?.().catch(() => {});
+    }
+  }, []);
+
+  const workflowNode = workflowId ? graph?.workflowsIndex.byId[workflowId] ?? null : null;
+
+  const overlayToRender = runOverlay ?? overlay ?? null;
+
+  const clearRunSelection = useCallback((options?: { preserveError?: boolean }) => {
+    setRunOverlay(null);
+    setCurrentRun(null);
+    setCurrentRunSteps([]);
+    if (!options?.preserveError) {
+      setRunError(null);
+    }
+    setSelectedNode(null);
+    setRunDetailsOpen(false);
+  }, []);
+
+  const lookupRun = useCallback(
+    async (query: string) => {
+      const trimmed = query.trim();
+      if (!authorizedFetch) {
+        setRunError('Missing authentication context');
+        return;
+      }
+      if (trimmed.length === 0) {
+        clearRunSelection();
+        return;
+      }
+      setRunLoading(true);
+      setRunError(null);
+      try {
+        let run: WorkflowRun | null = null;
+        try {
+          run = await getWorkflowRun(authorizedFetch, trimmed);
+        } catch (error) {
+          if (!(error instanceof ApiError) || error.status !== 404) {
+            throw error;
+          }
+        }
+
+        if (!run) {
+          const results = await searchWorkflowRuns(authorizedFetch, { search: trimmed, limit: 10 });
+          const normalizedQuery = trimmed.toLowerCase();
+          const exactMatch = results.find((entry) => entry.run.runKey?.toLowerCase() === normalizedQuery);
+          const idMatch = results.find((entry) => entry.run.id === trimmed);
+          run = exactMatch?.run ?? idMatch?.run ?? results[0]?.run ?? null;
+        }
+
+        if (!run) {
+          setRunError('Workflow run not found. Confirm the ID or run key and try again.');
+          clearRunSelection({ preserveError: true });
+          return;
+        }
+
+        const { run: detailedRun, steps } = await listWorkflowRunSteps(authorizedFetch, run.id);
+        const snapshotOverlay = buildWorkflowRunOverlayFromSnapshot(detailedRun, steps);
+        setRunOverlay(snapshotOverlay);
+        setCurrentRun(detailedRun);
+        setCurrentRunSteps(steps);
+        setSelectedNode(null);
+        setRunDetailsOpen(false);
+      } catch (error) {
+        const message =
+          error instanceof ApiError
+            ? error.message
+            : error instanceof Error
+              ? error.message
+              : 'Failed to load workflow run';
+        setRunError(message);
+        clearRunSelection({ preserveError: true });
+        pushToast?.({
+          tone: 'danger',
+          title: 'Run lookup failed',
+          description: message
+        });
+      } finally {
+        setRunLoading(false);
+      }
+    },
+    [authorizedFetch, clearRunSelection, pushToast]
+  );
+
+  const handleRunSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      void lookupRun(runQuery);
+    },
+    [lookupRun, runQuery]
+  );
+
+  const handleNodeSelect = useCallback((_: string, data: WorkflowGraphCanvasNodeData) => {
+    if (
+      data.kind === 'workflow' ||
+      data.kind === 'step-job' ||
+      data.kind === 'step-service' ||
+      data.kind === 'step-fanout'
+    ) {
+      setSelectedNode(data);
+      setRunDetailsOpen(true);
+    }
+  }, []);
+
+  const handleCanvasClick = useCallback(() => {
+    setSelectedNode(null);
+  }, []);
+
+  const highlightedStepId = selectedNode && selectedNode.kind.startsWith('step') ? selectedNode.refId : null;
+
+  const orderedSteps = useMemo(() => {
+    if (!highlightedStepId) {
+      return currentRunSteps;
+    }
+    const target = currentRunSteps.find((step) => step.stepId === highlightedStepId);
+    if (!target) {
+      return currentRunSteps;
+    }
+    return [target, ...currentRunSteps.filter((step) => step.stepId !== highlightedStepId)];
+  }, [currentRunSteps, highlightedStepId]);
+
+  useEffect(() => {
+    if (!runDetailsOpen) {
+      return;
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setRunDetailsOpen(false);
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [runDetailsOpen]);
 
   if (!workflow) {
     return null;
   }
-
-  const workflowNode = workflowId ? graph?.workflowsIndex.byId[workflowId] ?? null : null;
 
   return (
     <section className={CONTAINER_CLASSES}>
@@ -39,6 +258,55 @@ export default function WorkflowTopologyPreview({ workflow }: WorkflowTopologyPr
           Visualize the triggers, steps, assets, and schedules associated with this workflow.
         </p>
       </div>
+
+      <form className={RUN_FORM_CLASSES} onSubmit={handleRunSubmit}>
+        <div className={RUN_FIELD_CONTAINER_CLASSES}>
+          <label htmlFor="workflow-run-lookup" className={RUN_FIELD_LABEL_CLASSES}>
+            Inspect Run Overlay
+          </label>
+          <input
+            id="workflow-run-lookup"
+            type="text"
+            value={runQuery}
+            onChange={(event) => setRunQuery(event.target.value)}
+            placeholder="Paste a workflow run ID or run key"
+            className={RUN_FIELD_INPUT_CLASSES}
+            autoComplete="off"
+            spellCheck={false}
+          />
+          <p className={RUN_HELP_TEXT_CLASSES}>
+            Loads run status details onto the graph so you can trace what happened.
+          </p>
+        </div>
+        <div className={RUN_FORM_BUTTON_ROW_CLASSES}>
+          <button
+            type="submit"
+            className={RUN_PRIMARY_BUTTON_CLASSES}
+            disabled={runLoading}
+          >
+            {runLoading ? 'Loading…' : 'Load run'}
+          </button>
+          <button
+            type="button"
+            onClick={() => clearRunSelection()}
+            className={RUN_SECONDARY_BUTTON_CLASSES}
+            disabled={runLoading && !runOverlay}
+          >
+            Clear
+          </button>
+        </div>
+      </form>
+
+      {runError && <p className={RUN_ERROR_TEXT_CLASSES}>{runError}</p>}
+
+      {currentRun && (
+        <div className={RUN_STATUS_SUMMARY_CLASSES}>
+          <StatusBadge status={currentRun.status} />
+          <span>{currentRun.runKey ? `Run key ${currentRun.runKey}` : 'No run key'}</span>
+          <span>Updated {formatTimestamp(currentRun.updatedAt)}</span>
+          <span>Triggered by {currentRun.triggeredBy ?? 'manual'}</span>
+        </div>
+      )}
 
       {graphLoading && (
         <p className={INFO_TEXT_CLASSES}>
@@ -55,21 +323,67 @@ export default function WorkflowTopologyPreview({ workflow }: WorkflowTopologyPr
       )}
 
       {!graphLoading && !graphError && workflowNode && (
-        <div className="mt-4 h-[560px]">
+        <div
+          ref={graphContainerRef}
+          className={classNames(
+            'relative mt-4 h-[560px]',
+            isFullscreen && 'mt-0 h-full w-full'
+          )}
+        >
           <ReactFlowProvider>
             <WorkflowGraphCanvas
               graph={graph}
               loading={graphLoading}
               error={graphError}
               filters={filters}
-              overlay={overlay ?? null}
+              overlay={overlayToRender}
               interactionMode="interactive"
               fitViewPadding={0.12}
               autoFit
+              height={isFullscreen ? '100vh' : '100%'}
+              onNodeSelect={handleNodeSelect}
+              onCanvasClick={handleCanvasClick}
+              fullscreen={{
+                isActive: isFullscreen,
+                onToggle: handleToggleFullscreen,
+                supported: fullscreenSupported
+              }}
             />
           </ReactFlowProvider>
         </div>
       )}
+
+      <Modal
+        open={runDetailsOpen}
+        onClose={() => setRunDetailsOpen(false)}
+        contentClassName={`${MODAL_CONTENT_CLASSES} w-full max-h-screen overflow-hidden`}
+      >
+        <div className={`${MODAL_BODY_CLASSES} h-full max-h-[90vh] overflow-y-auto`}
+          role="presentation"
+        >
+          <div className="mb-4 flex justify-end">
+            <button
+              type="button"
+              onClick={() => setRunDetailsOpen(false)}
+              className={MODAL_CLOSE_BUTTON_CLASSES}
+            >
+              Close
+            </button>
+          </div>
+          {currentRun ? (
+            <WorkflowRunDetails
+              run={currentRun}
+              steps={orderedSteps}
+              stepsLoading={false}
+              stepsError={null}
+            />
+          ) : (
+            <p className="text-scale-sm text-secondary">
+              Load a workflow run overlay to inspect execution details for selected nodes.
+            </p>
+          )}
+        </div>
+      </Modal>
     </section>
   );
 }

--- a/apps/frontend/src/workflows/components/WorkflowTopologyPreview.tsx
+++ b/apps/frontend/src/workflows/components/WorkflowTopologyPreview.tsx
@@ -183,7 +183,7 @@ export default function WorkflowTopologyPreview({ workflow }: WorkflowTopologyPr
         setRunError(message);
         clearRunSelection({ preserveError: true });
         pushToast?.({
-          tone: 'danger',
+          tone: 'error',
           title: 'Run lookup failed',
           description: message
         });

--- a/scripts/check-openapi-clients.mjs
+++ b/scripts/check-openapi-clients.mjs
@@ -28,5 +28,6 @@ const pending = diff
 if (pending.length > 0) {
   console.error('OpenAPI client artifacts are out of date.');
   console.error('Run `npm run generate:openapi-clients` and commit the updated files.');
+  console.error('Diff summary:\n' + diff);
   process.exitCode = 1;
 }

--- a/scripts/generate-openapi-clients.mjs
+++ b/scripts/generate-openapi-clients.mjs
@@ -174,6 +174,7 @@ async function generateClient({ name, workspace, spec, output, clientName }) {
 }
 
 async function main() {
+  await ensureWorkspaceBuild('@apphub/module-registry', ['packages/module-registry/dist/index.js']);
   await ensureWorkspaceBuild('@apphub/module-sdk', ['packages/module-sdk/dist/index.js']);
 
   for (const service of services) {

--- a/scripts/generate-openapi-clients.mjs
+++ b/scripts/generate-openapi-clients.mjs
@@ -176,6 +176,8 @@ async function generateClient({ name, workspace, spec, output, clientName }) {
 async function main() {
   await ensureWorkspaceBuild('@apphub/module-registry', ['packages/module-registry/dist/index.js']);
   await ensureWorkspaceBuild('@apphub/module-sdk', ['packages/module-sdk/dist/index.js']);
+  await ensureWorkspaceBuild('@apphub/shared', ['packages/shared/dist/index.js']);
+  await ensureWorkspaceBuild('@apphub/filestore-client', ['packages/filestore-client/dist/index.js']);
 
   for (const service of services) {
     // eslint-disable-next-line no-console


### PR DESCRIPTION
## Summary
- reuse the marketing favicon in the frontend bundle
- pare the jobs page down to module jobs with essential metadata
- show a lightweight recent run list for demo readiness

## Testing
- npm run lint --workspace @apphub/frontend
