### PR TITLE
fix: ensure ingest loader waits for normalized asset

### DIFF
--- a/modules/environmental-observatory/src/workflows/minuteIngest.ts
+++ b/modules/environmental-observatory/src/workflows/minuteIngest.ts
@@ -53,6 +53,7 @@ const definition: WorkflowDefinition = {
       name: 'Load timestore partition',
       type: 'job',
       jobSlug: 'observatory-timestore-loader',
+      dependsOn: ['normalize-inbox'],
       parameters: {
         minute: '{{ steps.normalize-inbox.result.minute | default: parameters.minute | default: run.trigger.schedule.occurrence | slice: 0, 16 }}',
         rawAsset: '{{ steps.normalize-inbox.result }}',


### PR DESCRIPTION
## Summary
- gate the timestore loader on the normalization step so run templates resolve as expected

## Testing
- npm run build --workspace @apphub/environmental-observatory-module
