### PR TITLE
fix/demo module services

### DIFF
--- a/apps/frontend/src/utils/url.ts
+++ b/apps/frontend/src/utils/url.ts
@@ -3,7 +3,7 @@ import { API_BASE_URL } from '../config';
 const LOOPBACK_HOST_PREFIX = /^127\./;
 const LOOPBACK_HOSTS = new Set(['127.0.0.1', 'localhost', '::1', '::ffff:127.0.0.1', '0.0.0.0']);
 
-function isLoopbackHost(host: string): boolean {
+export function isLoopbackHost(host: string): boolean {
   const normalized = host.replace(/^\[(.*)\]$/, '$1').toLowerCase();
   return LOOPBACK_HOSTS.has(normalized) || LOOPBACK_HOST_PREFIX.test(normalized);
 }

--- a/docker/demo-stack.compose.yml
+++ b/docker/demo-stack.compose.yml
@@ -410,6 +410,24 @@ services:
         source: ${APPHUB_DATA_ROOT:-./demo-data}/scratch
         target: /var/lib/apphub/scratch
 
+  core-module-services:
+    build:
+      <<: *build-config
+      target: core-runtime
+    restart: unless-stopped
+    depends_on:
+      core-api:
+        condition: service_healthy
+    environment:
+      <<: *shared-env
+      MODULE_SERVICE_HOST: core-module-services
+      MODULE_SERVICE_PORT_RANGE: 4310-4399
+    command: ["node", "services/core/dist/moduleServices/runner.js"]
+    volumes:
+      - type: bind
+        source: ${APPHUB_DATA_ROOT:-./demo-data}/scratch
+        target: /var/lib/apphub/scratch
+
   metastore:
     build:
       <<: *build-config

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@types/node": "^24.5.2",
         "chokidar": "^3.6.0",
         "concurrently": "^9.2.1",
-        "esbuild": "^0.23.0",
+        "esbuild": "^0.23.1",
         "kafkajs": "^2.2.4",
         "openapi-typescript-codegen": "^0.29.0",
         "typescript": "^5.9.2"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^24.5.2",
     "chokidar": "^3.6.0",
     "concurrently": "^9.2.1",
-    "esbuild": "^0.23.0",
+    "esbuild": "^0.23.1",
     "kafkajs": "^2.2.4",
     "openapi-typescript-codegen": "^0.29.0",
     "typescript": "^5.9.2"

--- a/services/timestore/tests/serviceConfig.test.ts
+++ b/services/timestore/tests/serviceConfig.test.ts
@@ -1,0 +1,76 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, test } from 'node:test';
+
+let originalScratch: string | undefined;
+let originalStaging: string | undefined;
+let originalRedis: string | undefined;
+let originalDatabase: string | undefined;
+let originalInline: string | undefined;
+let configModule: typeof import('../src/config/serviceConfig');
+let scratchRoot: string;
+
+beforeEach(async () => {
+  originalScratch = process.env.APPHUB_SCRATCH_ROOT;
+  originalStaging = process.env.TIMESTORE_STAGING_DIRECTORY;
+  originalRedis = process.env.REDIS_URL;
+  originalDatabase = process.env.TIMESTORE_DATABASE_URL;
+  originalInline = process.env.APPHUB_ALLOW_INLINE_MODE;
+
+  process.env.REDIS_URL = 'redis://127.0.0.1:6379';
+  process.env.TIMESTORE_DATABASE_URL =
+    process.env.TIMESTORE_DATABASE_URL ?? 'postgres://apphub:apphub@localhost:5432/apphub';
+  process.env.APPHUB_ALLOW_INLINE_MODE = 'true';
+
+  scratchRoot = await mkdtemp(path.join(tmpdir(), 'timestore-scratch-'));
+  configModule = await import('../src/config/serviceConfig');
+});
+
+afterEach(async () => {
+  process.env.APPHUB_SCRATCH_ROOT = originalScratch;
+  if (originalStaging === undefined) {
+    delete process.env.TIMESTORE_STAGING_DIRECTORY;
+  } else {
+    process.env.TIMESTORE_STAGING_DIRECTORY = originalStaging;
+  }
+  if (originalRedis === undefined) {
+    delete process.env.REDIS_URL;
+  } else {
+    process.env.REDIS_URL = originalRedis;
+  }
+  if (originalDatabase === undefined) {
+    delete process.env.TIMESTORE_DATABASE_URL;
+  } else {
+    process.env.TIMESTORE_DATABASE_URL = originalDatabase;
+  }
+  if (originalInline === undefined) {
+    delete process.env.APPHUB_ALLOW_INLINE_MODE;
+  } else {
+    process.env.APPHUB_ALLOW_INLINE_MODE = originalInline;
+  }
+  configModule.resetCachedServiceConfig();
+  await rm(scratchRoot, { recursive: true, force: true });
+});
+
+test('staging directory defaults to scratch root when not provided', () => {
+  process.env.APPHUB_SCRATCH_ROOT = scratchRoot;
+  delete process.env.TIMESTORE_STAGING_DIRECTORY;
+  configModule.resetCachedServiceConfig();
+
+  const config = configModule.loadServiceConfig();
+  assert.equal(config.staging.directory, path.join(scratchRoot, 'timestore', 'staging'));
+  assert.equal(config.staging.flush.eagerWhenBytesOnly, false);
+});
+
+test('legacy staging directory rewrites to scratch root when available', () => {
+  const legacyPath = path.resolve(process.cwd(), 'services', 'data', 'timestore', 'staging');
+  process.env.APPHUB_SCRATCH_ROOT = scratchRoot;
+  process.env.TIMESTORE_STAGING_DIRECTORY = legacyPath;
+  configModule.resetCachedServiceConfig();
+
+  const config = configModule.loadServiceConfig();
+  assert.equal(config.staging.directory, path.join(scratchRoot, 'timestore', 'staging'));
+  assert.equal(config.staging.flush.eagerWhenBytesOnly, false);
+});


### PR DESCRIPTION
## Summary
- rewrite legacy staging directory to use APPHUB_SCRATCH_ROOT so demo workers share the same scratch volume
- add an opt-in flag for eager flushes when only a byte threshold is configured; defaults preserve 1GB batching in production
- cover staging directory behaviour with a focused unit test and documented env override for the demo stack

## Testing
- npx tsx --test services/timestore/tests/serviceConfig.test.ts
- curl -X POST http://localhost:4200/v1/datasets/observatory-timeseries/ingest ... (manual ingest)
- curl -X POST http://localhost:4200/v1/datasets/observatory-timeseries/query ... (verify rows returned)
