### PR TITLE
chore: automate discord setup and surface invite link

### DIFF
--- a/apps/website/src/pages/index.astro
+++ b/apps/website/src/pages/index.astro
@@ -166,12 +166,15 @@ const observatoryTakeaways = [
           <a class="button button--secondary" href="/technical">Review the technical brief</a>
           <a class="button button--ghost" href="https://demo.osiris-apphub.com" target="_blank" rel="noreferrer">Browse the live demo (read-only)</a>
           <a class="button button--ghost" href="https://github.com/benediktbwimmer/apphub" target="_blank" rel="noreferrer">View on GitHub</a>
+          <a class="button button--ghost" href="https://discord.gg/STJGs5zHCN" target="_blank" rel="noreferrer">Join the Discord</a>
         </div>
         <div class="hero__contributor">
           <strong>Join the crew:</strong>
           <span>
             We are actively looking for contributors across the stack—core services, SDKs, and this website. If you want to shape onboarding playbooks, strengthen the platform, or ship UI polish, email
-            <a href="mailto:osirisapphub@gmail.com">osirisapphub@gmail.com</a>.
+            <a href="mailto:osirisapphub@gmail.com">osirisapphub@gmail.com</a>
+            or hop into our
+            <a href="https://discord.gg/STJGs5zHCN" target="_blank" rel="noreferrer">Discord server</a>.
           </span>
         </div>
         <dl class="hero__stats" aria-label="Current commitments">

--- a/docs/discord-server-setup.md
+++ b/docs/discord-server-setup.md
@@ -1,0 +1,35 @@
+# Discord Server Setup for Osiris AppHub
+
+The repository ships with `scripts/setup-discord-server.js`, which bootstraps roles, categories, and channels for the Osiris AppHub community server. Use it anytime you need to recreate the structure or bring a fresh server in line with the OSS collaboration defaults.
+
+## Prerequisites
+
+- A Discord bot in your account (private is recommended) that has been invited to the target server.
+- The bot token, stored securely. Never commit it to source control.
+- Optional: set `DISCORD_GUILD_NAME` if the server is not named `Osiris AppHub`.
+
+## Running the script
+
+```bash
+DISCORD_BOT_TOKEN="<your-bot-token>" \
+DISCORD_GUILD_NAME="Osiris AppHub" \
+node scripts/setup-discord-server.js
+```
+
+The script is idempotent. It creates or updates the following:
+
+- **Roles**: Maintainer (admin), Core Team, Contributor, Community, Bots.
+- **Categories**: Info, Development, Community, Voice.
+- **Info Channels**: `#welcome`, `#announcements`, `#changelog`, `#release-notes` (read-only for everyone except Maintainer/Core Team).
+- **Development Channels**: `#general-dev`, `#frontend`, `#services`, `#infra`, `#testing`.
+- **Community Channels**: `#introductions`, `#support`, `#showcase`.
+- **Voice Channels**: `Standups`, `Pairing`.
+
+If a channel already exists, the script re-homes it under the expected category and refreshes the read-only permissions for announcement channels.
+
+## Operational Notes
+
+- Keep the bot token in a secrets manager or `.env` file ignored by git.
+- Rerun the script after manual structural changes to bring the server back to the canonical layout.
+- Extend the role/channel definitions inside the script when the collaboration model evolves; rerun to apply.
+- For public community features (Rules, Membership Screening), enable them manually inside Discord once the base structure is in place.

--- a/scripts/seed-discord-content.js
+++ b/scripts/seed-discord-content.js
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+/*
+ * Seed the Osiris AppHub Discord server with baseline onboarding messages.
+ * Usage: DISCORD_BOT_TOKEN=... node scripts/seed-discord-content.js
+ */
+
+const token = process.env.DISCORD_BOT_TOKEN;
+if (!token) {
+  console.error('DISCORD_BOT_TOKEN environment variable is required.');
+  process.exit(1);
+}
+
+const guildName = process.env.DISCORD_GUILD_NAME || 'Osiris AppHub';
+const apiBase = 'https://discord.com/api/v10';
+
+const CHANNEL_CONTENT = {
+  welcome: [
+    `👋 **Welcome to Osiris AppHub!**\n\nThanks for joining the open-source community that powers every part of AppHub. Kick things off with these steps:\n\n• Review roadmap updates in {{channel:announcements}}.\n• Say hello in {{channel:introductions}} and share what you want to work on.\n• Looking for a task? Browse GitHub issues and sync with maintainers in {{channel:general-dev}}.\n\n**Helpful links**\n• Repo: https://github.com/benediktbwimmer/apphub\n• Docs: https://github.com/benediktbwimmer/apphub/tree/main/docs\n• Local dev: run npm install, then npm run dev.\n\nNeed a hand? Post in {{channel:support}} and a maintainer will follow up.`
+  ],
+  announcements: [
+    `📢 **Announcements Channel Guidelines**\n\nThis space hosts project-wide updates: roadmap milestones, community calls, infra downtime, and major hiring or partnership notes.\n\nMaintainers: when you post, lead with a bold headline, include GitHub links, and tag specific workspaces (e.g., {{channel:frontend}}) if there is follow up discussion. Keep chatter in threads so the main feed stays high-signal.`
+  ],
+  changelog: [
+    `🛠️ **Weekly Changelog Thread**\n\nDrop summaries of merged pull requests, notable fixes, and dependency bumps here. A helpful format is:\n\n**Week of YYYY-MM-DD**\n- \[feat] Short description (link to PR)\n- \[fix] Notable bug fix\n- Docs or release notes references\n\nThis history powers release notes and keeps contributors in sync.`
+  ],
+  'release-notes': [
+    `🚀 **Release Notes Staging**\n\nUse this channel to draft the copy that goes into GitHub releases or the marketing newsletter. Before publishing:\n\n1. Link to the changelog items or PRs you are referencing.\n2. Summarize any migrations, configuration tweaks, or downtime expectations.\n3. Tag the right maintainers for review.\n\nOnce approved, move the text to GitHub Releases and drop a link back here.`
+  ],
+  'general-dev': [
+    `👩‍💻 **Development Coordination**\n\nPlanning an issue or opening a PR? Share it here so others can hop in. Best practices:\n\n• Post a quick blurb with a GitHub link when you start work.\n• Use threads for design proposals and code review follow-ups.\n• Call out testing or environment steps so QA knows how to validate.\n\nFor topic-specific dives, jump into {{channel:frontend}}, {{channel:services}}, {{channel:infra}}, or {{channel:testing}}.`
+  ],
+  general: [
+    `👋 This channel is for lightweight chatter and quick questions. For focused development coordination head to {{channel:general-dev}}, and for help requests use {{channel:support}}. New here? Say hi in {{channel:introductions}}!`
+  ],
+  frontend: [
+    `🎨 **Frontend Crew HQ**\n\nDiscuss the Vite + React app in {{channel:frontend}}. Share component APIs, screenshot diffs, and accessibility notes. Handy commands:\n\n• Dev server: npm run dev --workspace @apphub/frontend\n• Tests: npm test --workspace @apphub/frontend\n• Lint: npm run lint --workspace @apphub/frontend\n\nRemember to post UI gifs or Storybook links when you tweak AppHub experiences.`
+  ],
+  services: [
+    `🧠 **Core Services Discussion**\n\nUse this space for API layer, workers, and module runtime changes. Keep teammates unblocked by sharing:\n\n• Schema or queue changes before they land\n• Perf regressions or logs that need attention\n• Links to relevant docs in services/ or packages/\n\nNeed database or Redis help? Loop in infra folks via {{channel:infra}}.`
+  ],
+  infra: [
+    `🏗️ **Infra & Operations**\n\nCoordinate deployment scripts, observability, and environments here. Useful threads include:\n\n• Docker image or Terraform updates\n• Monitoring alerts for AppHub deployments\n• Pre-merge checklists for migrations\n\nInfra changes that affect developers should always be cross-posted to {{channel:announcements}}.`
+  ],
+  testing: [
+    `✅ **Testing & QA**\n\nTrack the state of automated suites and manual validation. Share:\n\n• Vitest or Node test failures with logs\n• Plans for integration tests under tests/\n• Manual walkthrough notes for the showcase environments\n\nBefore merging major features, drop your validation checklist here so others can replicate it.`
+  ],
+  support: [
+    `🙋 **Support Requests**\n\nAsk for help with setup, bugs, or deployment snafus. When you open a request, include:\n\n• What you were doing and the expected outcome\n• Logs, screenshots, or stack traces\n• GitHub issue links if one exists\n\nA maintainer will follow up and move confirmed bugs into GitHub. Urgent production issues should be escalated in {{channel:announcements}} once resolved.`
+  ],
+  introductions: [
+    `👋 **Introduce Yourself**\n\nLet the community know who you are! Helpful prompts:\n\n• What brings you to Osiris AppHub?\n• What tools or services do you want to learn?\n• Link your GitHub or recent project.\n\nMaintainers keep an eye on this channel so they can suggest good first issues.`
+  ],
+  showcase: [
+    `🌟 **Show & Tell**\n\nShare screenshots, Loom demos, or recordings of what you built with AppHub. For each post, include:\n\n• What problem you solved\n• The modules or services involved\n• Links to PRs or docs\n\nWe spotlight the best demos in {{channel:announcements}} and future community calls.`
+  ]
+};
+
+async function discordRequest(path, options = {}, attempt = 0) {
+  const response = await fetch(`${apiBase}${path}`, {
+    headers: {
+      Authorization: `Bot ${token}`,
+      'Content-Type': 'application/json'
+    },
+    ...options
+  });
+
+  if (response.status === 204) {
+    return null;
+  }
+
+  if (response.status === 429) {
+    const data = await response.json();
+    const retryAfter = data.retry_after ?? 1;
+    await new Promise((resolve) => setTimeout(resolve, retryAfter * 1000));
+    if (attempt > 5) {
+      throw new Error(`Rate limited on ${path}`);
+    }
+    return discordRequest(path, options, attempt + 1);
+  }
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Discord API ${response.status} ${response.statusText} on ${path}: ${text}`);
+  }
+
+  return response.json();
+}
+
+function injectChannelMentions(content, channelMap) {
+  return content.replace(/\{\{channel:([^}]+)\}\}/g, (_, name) => {
+    const channel = channelMap.get(name.toLowerCase());
+    if (!channel) {
+      console.warn(`Channel placeholder {{channel:${name}}} missing; leaving as plain text.`);
+      return `#${name}`;
+    }
+    return `<#${channel.id}>`;
+  });
+}
+
+async function ensureMessages(guildId, botId, channelMap) {
+  for (const [name, messages] of Object.entries(CHANNEL_CONTENT)) {
+    const channel = channelMap.get(name.toLowerCase());
+    if (!channel) {
+      console.warn(`Skipping channel "${name}"; not found in guild.`);
+      continue;
+    }
+    for (let index = 0; index < messages.length; index += 1) {
+      const marker = `[seeded-by-apphub-assistant:${name}-${index + 1}]`;
+      const rendered = injectChannelMentions(messages[index], channelMap);
+      const existing = await discordRequest(`/channels/${channel.id}/messages?limit=50`, {
+        method: 'GET'
+      });
+      const existingMessage = Array.isArray(existing)
+        ? existing.find((message) => message.author?.id === botId && message.content.includes(marker))
+        : null;
+      const payload = {
+        content: `${rendered}
+
+${marker}`,
+        allowed_mentions: { parse: [] }
+      };
+      if (existingMessage) {
+        await discordRequest(`/channels/${channel.id}/messages/${existingMessage.id}`, {
+          method: 'PATCH',
+          body: JSON.stringify(payload)
+        });
+        console.log(`Updated message ${index + 1} in #${channel.name}`);
+        continue;
+      }
+      await discordRequest(`/channels/${channel.id}/messages`, {
+        method: 'POST',
+        body: JSON.stringify(payload)
+      });
+      console.log(`Seeded message ${index + 1} in #${channel.name}`);
+    }
+  }
+}
+
+(async function main() {
+  try {
+    console.log(`Seeding Discord server "${guildName}" with baseline content...`);
+    const guilds = await discordRequest('/users/@me/guilds', { method: 'GET' });
+    const guild = guilds.find((entry) => entry.name.toLowerCase() === guildName.toLowerCase());
+    if (!guild) {
+      throw new Error(`Bot is not a member of a guild named "${guildName}".`);
+    }
+
+    const botUser = await discordRequest('/users/@me', { method: 'GET' });
+    const channels = await discordRequest(`/guilds/${guild.id}/channels`, { method: 'GET' });
+    const channelMap = new Map();
+    channels
+      .filter((channel) => channel.type === 0)
+      .forEach((channel) => channelMap.set(channel.name.toLowerCase(), channel));
+
+    await ensureMessages(guild.id, botUser.id, channelMap);
+    console.log('Channel content seeding complete.');
+  } catch (error) {
+    console.error('Failed to seed Discord content:', error);
+    process.exit(1);
+  }
+})();

--- a/scripts/setup-discord-server.js
+++ b/scripts/setup-discord-server.js
@@ -1,0 +1,303 @@
+#!/usr/bin/env node
+/*
+ * Script to configure the Osiris AppHub Discord server for OSS collaboration.
+ * Usage: DISCORD_BOT_TOKEN=your_token node scripts/setup-discord-server.js
+ */
+
+const token = process.env.DISCORD_BOT_TOKEN;
+if (!token) {
+  console.error('DISCORD_BOT_TOKEN environment variable is required.');
+  process.exit(1);
+}
+
+const guildName = process.env.DISCORD_GUILD_NAME || 'Osiris AppHub';
+const apiBase = 'https://discord.com/api/v10';
+
+const PERMISSIONS = {
+  ADMINISTRATOR: 8n,
+  MANAGE_CHANNELS: 16n,
+  MANAGE_GUILD: 32n,
+  SEND_MESSAGES: 2048n,
+  MANAGE_MESSAGES: 8192n,
+  CREATE_PUBLIC_THREADS: 34359738368n,
+  CREATE_PRIVATE_THREADS: 68719476736n,
+  SEND_MESSAGES_IN_THREADS: 274877906944n,
+  MANAGE_THREADS: 17179869184n,
+  MANAGE_ROLES: 268435456n,
+  MANAGE_WEBHOOKS: 536870912n,
+  USE_APPLICATION_COMMANDS: 2147483648n
+};
+
+function combinePermissions(keys) {
+  return keys.reduce((total, key) => total | (PERMISSIONS[key] ?? 0n), 0n).toString();
+}
+
+async function discordRequest(path, options = {}, attempt = 0) {
+  const response = await fetch(`${apiBase}${path}`, {
+    headers: {
+      Authorization: `Bot ${token}`,
+      'Content-Type': 'application/json'
+    },
+    ...options
+  });
+
+  if (response.status === 204) {
+    return null;
+  }
+
+  if (response.status === 429) {
+    const data = await response.json();
+    const retryAfter = data.retry_after ?? 1;
+    await new Promise((resolve) => setTimeout(resolve, retryAfter * 1000));
+    if (attempt > 5) {
+      throw new Error(`Rate limited too many times on ${path}`);
+    }
+    return discordRequest(path, options, attempt + 1);
+  }
+
+  if (!response.ok) {
+    const data = await response.text();
+    throw new Error(`Discord API ${response.status} ${response.statusText} on ${path}: ${data}`);
+  }
+
+  return response.json();
+}
+
+async function findGuildByName(name) {
+  const guilds = await discordRequest('/users/@me/guilds', { method: 'GET' });
+  const guild = guilds.find((entry) => entry.name.toLowerCase() === name.toLowerCase());
+  if (!guild) {
+    throw new Error(`Bot is not a member of a guild named "${name}".`);
+  }
+  return guild;
+}
+
+async function ensureRoles(guildId) {
+  const desiredRoles = [
+    {
+      name: 'Maintainer',
+      permissions: combinePermissions(['ADMINISTRATOR']),
+      color: 0xff7283,
+      hoist: true,
+      mentionable: true
+    },
+    {
+      name: 'Core Team',
+      permissions: combinePermissions([
+        'MANAGE_CHANNELS',
+        'MANAGE_THREADS',
+        'MANAGE_MESSAGES',
+        'CREATE_PUBLIC_THREADS',
+        'CREATE_PRIVATE_THREADS',
+        'SEND_MESSAGES_IN_THREADS',
+        'USE_APPLICATION_COMMANDS'
+      ]),
+      color: 0x5865f2,
+      hoist: true,
+      mentionable: true
+    },
+    {
+      name: 'Contributor',
+      permissions: combinePermissions([
+        'SEND_MESSAGES',
+        'CREATE_PUBLIC_THREADS',
+        'CREATE_PRIVATE_THREADS',
+        'SEND_MESSAGES_IN_THREADS'
+      ]),
+      color: 0x57f287,
+      mentionable: true
+    },
+    {
+      name: 'Community',
+      permissions: '0',
+      color: 0xfee75c,
+      mentionable: true
+    },
+    {
+      name: 'Bots',
+      permissions: combinePermissions([
+        'SEND_MESSAGES',
+        'MANAGE_MESSAGES',
+        'USE_APPLICATION_COMMANDS'
+      ]),
+      color: 0x99aab5,
+      mentionable: true
+    }
+  ];
+
+  const existingRoles = await discordRequest(`/guilds/${guildId}/roles`, { method: 'GET' });
+  const rolesByName = new Map(existingRoles.map((role) => [role.name.toLowerCase(), role]));
+
+  const results = {};
+  for (const config of desiredRoles) {
+    const existing = rolesByName.get(config.name.toLowerCase());
+    if (!existing) {
+      const created = await discordRequest(`/guilds/${guildId}/roles`, {
+        method: 'POST',
+        body: JSON.stringify(config)
+      });
+      console.log(`Created role: ${config.name}`);
+      results[config.name] = created;
+    } else {
+      const needsUpdate =
+        existing.permissions !== config.permissions ||
+        existing.color !== config.color ||
+        Boolean(existing.hoist) !== Boolean(config.hoist) ||
+        Boolean(existing.mentionable) !== Boolean(config.mentionable);
+      if (needsUpdate) {
+        await discordRequest(`/guilds/${guildId}/roles/${existing.id}`, {
+          method: 'PATCH',
+          body: JSON.stringify(config)
+        });
+        console.log(`Updated role: ${config.name}`);
+      }
+      results[config.name] = existing;
+    }
+  }
+
+  return results;
+}
+
+function buildReadOnlyOverwrites(guildId, maintainerRoleId, coreTeamRoleId) {
+  const denyValue = combinePermissions([
+    'SEND_MESSAGES',
+    'CREATE_PUBLIC_THREADS',
+    'CREATE_PRIVATE_THREADS',
+    'SEND_MESSAGES_IN_THREADS'
+  ]);
+  const allowValue = combinePermissions([
+    'SEND_MESSAGES',
+    'CREATE_PUBLIC_THREADS',
+    'CREATE_PRIVATE_THREADS',
+    'SEND_MESSAGES_IN_THREADS',
+    'MANAGE_MESSAGES'
+  ]);
+
+  const overwrites = [
+    { id: guildId, type: 0, deny: denyValue }
+  ];
+  if (maintainerRoleId) {
+    overwrites.push({ id: maintainerRoleId, type: 0, allow: allowValue });
+  }
+  if (coreTeamRoleId) {
+    overwrites.push({ id: coreTeamRoleId, type: 0, allow: allowValue });
+  }
+  return overwrites;
+}
+
+async function ensureCategoriesAndChannels(guildId, roles) {
+  const existingChannels = await discordRequest(`/guilds/${guildId}/channels`, { method: 'GET' });
+  const channelByName = new Map(
+    existingChannels.map((channel) => [`${channel.type}:${channel.name.toLowerCase()}`, channel])
+  );
+
+  const categories = [
+    {
+      name: 'Info',
+      channels: [
+        { name: 'welcome', type: 0, readOnly: true },
+        { name: 'announcements', type: 0, readOnly: true },
+        { name: 'changelog', type: 0, readOnly: true },
+        { name: 'release-notes', type: 0, readOnly: true }
+      ]
+    },
+    {
+      name: 'Development',
+      channels: [
+        { name: 'general-dev', type: 0 },
+        { name: 'frontend', type: 0 },
+        { name: 'services', type: 0 },
+        { name: 'infra', type: 0 },
+        { name: 'testing', type: 0 }
+      ]
+    },
+    {
+      name: 'Community',
+      channels: [
+        { name: 'introductions', type: 0 },
+        { name: 'support', type: 0 },
+        { name: 'showcase', type: 0 }
+      ]
+    },
+    {
+      name: 'Voice',
+      channels: [
+        { name: 'Standups', type: 2 },
+        { name: 'Pairing', type: 2 }
+      ]
+    }
+  ];
+
+  for (const categoryConfig of categories) {
+    const categoryKey = `4:${categoryConfig.name.toLowerCase()}`;
+    let category = channelByName.get(categoryKey);
+    if (!category) {
+      category = await discordRequest(`/guilds/${guildId}/channels`, {
+        method: 'POST',
+        body: JSON.stringify({
+          name: categoryConfig.name,
+          type: 4
+        })
+      });
+      console.log(`Created category: ${categoryConfig.name}`);
+      channelByName.set(categoryKey, category);
+    }
+
+    for (const channelConfig of categoryConfig.channels) {
+      const key = `${channelConfig.type}:${channelConfig.name.toLowerCase()}`;
+      let channel = channelByName.get(key);
+      const body = {
+        name: channelConfig.name,
+        type: channelConfig.type,
+        parent_id: category.id
+      };
+
+      if (channelConfig.type === 0 && channelConfig.readOnly) {
+        body.permission_overwrites = buildReadOnlyOverwrites(
+          guildId,
+          roles['Maintainer']?.id,
+          roles['Core Team']?.id
+        );
+      }
+
+      if (!channel) {
+        channel = await discordRequest(`/guilds/${guildId}/channels`, {
+          method: 'POST',
+          body: JSON.stringify(body)
+        });
+        console.log(`Created channel: #${channelConfig.name}`);
+        channelByName.set(key, channel);
+      } else {
+        const patchBody = {
+          name: channelConfig.name,
+          parent_id: category.id
+        };
+        if (channelConfig.type === 0 && channelConfig.readOnly) {
+          patchBody.permission_overwrites = buildReadOnlyOverwrites(
+            guildId,
+            roles['Maintainer']?.id,
+            roles['Core Team']?.id
+          );
+        }
+        await discordRequest(`/channels/${channel.id}`, {
+          method: 'PATCH',
+          body: JSON.stringify(patchBody)
+        });
+        console.log(`Updated channel: #${channelConfig.name}`);
+      }
+    }
+  }
+}
+
+(async function main() {
+  try {
+    console.log(`Configuring Discord server "${guildName}"...`);
+    const guild = await findGuildByName(guildName);
+    const roles = await ensureRoles(guild.id);
+    await ensureCategoriesAndChannels(guild.id, roles);
+    console.log('Discord server setup completed.');
+  } catch (error) {
+    console.error('Failed to configure Discord server:', error);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- script the discord server bootstrap and channel seeding flows
- add docs covering how to rerun the automation safely
- surface the community Discord invite on the marketing hero

## Testing
- npm run lint --workspace @apphub/website
