### PR TITLE
feat: streamline module toolkit ergonomics

### DIFF
--- a/modules/observatory/README.md
+++ b/modules/observatory/README.md
@@ -12,7 +12,7 @@ npm run test
 
 ## Structure
 
-- `src/settings.ts` – typed Zod schema + `createSettingsLoader` to produce module settings/secrets.
+- `src/settings.ts` – typed Zod schema + `createModuleSettingsDefinition` wired to shared env presets.
 - `src/security.ts` – centralized principals and secrets wiring via `defineModuleSecurity`.
 - `src/triggers.ts` – parameter definitions authored with the typed trigger DSL; exported via a registry.
 - `src/jobs/` – job parameter definitions, also exposed through a registry.

--- a/modules/observatory/module.ts
+++ b/modules/observatory/module.ts
@@ -4,6 +4,7 @@ import {
   secretsRef,
   settingsRef
 } from '@apphub/module-sdk';
+import type { ModuleTargetDefinition } from '@apphub/module-sdk';
 import type { ObservatorySettings, ObservatorySecrets } from './src/config/settings';
 import {
   defaultSettings,
@@ -12,26 +13,9 @@ import {
   resolveSecretsFromRaw
 } from './src/config/settings';
 import { security } from './src/config/security';
-import {
-  dataGeneratorJob,
-  minutePreprocessorJob,
-  timestoreLoaderJob,
-  visualizationRunnerJob,
-  dashboardAggregatorJob,
-  reportPublisherJob,
-  calibrationImporterJob,
-  calibrationPlannerJob,
-  calibrationReprocessorJob
-} from './src/jobs';
-import { dashboardService, adminService } from './src/services';
-import {
-  minuteDataGeneratorWorkflow,
-  minuteIngestWorkflow,
-  dailyPublicationWorkflow,
-  dashboardAggregateWorkflow,
-  calibrationImportWorkflow,
-  calibrationReprocessWorkflow
-} from './src/workflows';
+import { jobs } from './src/jobs';
+import { services } from './src/services';
+import { workflows } from './src/workflows';
 
 export default defineModule<ObservatorySettings, ObservatorySecrets>({
   metadata: {
@@ -98,22 +82,8 @@ export default defineModule<ObservatorySettings, ObservatorySecrets>({
     }
   },
   targets: [
-    dataGeneratorJob,
-    minutePreprocessorJob,
-    timestoreLoaderJob,
-    visualizationRunnerJob,
-    dashboardAggregatorJob,
-    reportPublisherJob,
-    calibrationImporterJob,
-    calibrationPlannerJob,
-    calibrationReprocessorJob,
-    dashboardService,
-    adminService,
-    minuteDataGeneratorWorkflow,
-    minuteIngestWorkflow,
-    dailyPublicationWorkflow,
-    dashboardAggregateWorkflow,
-    calibrationImportWorkflow,
-    calibrationReprocessWorkflow
-  ]
+    ...jobs.values(),
+    ...services.values(),
+    ...workflows.values()
+  ] as ModuleTargetDefinition<ObservatorySettings, ObservatorySecrets>[]
 });

--- a/modules/observatory/src/config/security.ts
+++ b/modules/observatory/src/config/security.ts
@@ -8,27 +8,27 @@ const PRINCIPAL_DEFINITIONS = {
     description: 'Generates synthetic telemetry CSVs.'
   },
   minutePreprocessor: {
-      subject: 'observatory-minute-preprocessor',
-      description: 'Normalizes raw uploads before ingest.'
-    },
-    timestoreLoader: {
-      subject: 'observatory-timestore-loader'
-    },
-    visualizationRunner: {
-      subject: 'observatory-visualization-runner'
-    },
-    dashboardAggregator: {
-      subject: 'observatory-dashboard-aggregator'
-    },
-    calibrationImporter: {
-      subject: 'observatory-calibration-importer'
-    },
-    calibrationPlanner: {
-      subject: 'observatory-calibration-planner'
-    },
-    calibrationReprocessor: {
-      subject: 'observatory-calibration-reprocessor'
-    }
+    subject: 'observatory-minute-preprocessor',
+    description: 'Normalizes raw uploads before ingest.'
+  },
+  timestoreLoader: {
+    subject: 'observatory-timestore-loader'
+  },
+  visualizationRunner: {
+    subject: 'observatory-visualization-runner'
+  },
+  dashboardAggregator: {
+    subject: 'observatory-dashboard-aggregator'
+  },
+  calibrationImporter: {
+    subject: 'observatory-calibration-importer'
+  },
+  calibrationPlanner: {
+    subject: 'observatory-calibration-planner'
+  },
+  calibrationReprocessor: {
+    subject: 'observatory-calibration-reprocessor'
+  }
 } satisfies Record<string, PrincipalDefinition>;
 
 const SECRET_DEFINITIONS = {
@@ -69,3 +69,4 @@ export const security = defineModuleSecurity<
 
 export const PRINCIPALS = security.listPrincipals();
 export const SECRETS = security.listSecrets();
+export const PRINCIPAL_SUBJECTS = security.principalSettings();

--- a/modules/observatory/src/jobs/calibrationImporter.ts
+++ b/modules/observatory/src/jobs/calibrationImporter.ts
@@ -34,7 +34,7 @@ const parametersSchema = z
 
 export type CalibrationImporterParameters = z.infer<typeof parametersSchema>;
 
-interface CalibrationImporterResult {
+export interface CalibrationImporterResult {
   calibrationId: string;
   instrumentId: string;
   effectiveAt: string;

--- a/modules/observatory/src/jobs/calibrationReprocessor.ts
+++ b/modules/observatory/src/jobs/calibrationReprocessor.ts
@@ -151,7 +151,7 @@ interface WorkflowRunRecord {
   triggeredBy: string | null;
 }
 
-interface CalibrationReprocessorResult {
+export interface CalibrationReprocessorResult {
   planId: string;
   planPath: string;
   planNodeId: number | null;

--- a/modules/observatory/src/jobs/index.ts
+++ b/modules/observatory/src/jobs/index.ts
@@ -1,9 +1,34 @@
-export { dataGeneratorJob } from './dataGenerator';
-export { minutePreprocessorJob } from './minutePreprocessor';
-export { timestoreLoaderJob } from './timestoreLoader';
-export { visualizationRunnerJob } from './visualizationRunner';
-export { dashboardAggregatorJob } from './dashboardAggregator';
-export { reportPublisherJob } from './reportPublisher';
-export { calibrationImporterJob } from './calibrationImporter';
-export { calibrationPlannerJob } from './calibrationPlanner';
-export { calibrationReprocessorJob } from './calibrationReprocessor';
+import { createTargetRegistryFromArray } from '@apphub/module-toolkit';
+import { dataGeneratorJob } from './dataGenerator';
+import { minutePreprocessorJob } from './minutePreprocessor';
+import { timestoreLoaderJob } from './timestoreLoader';
+import { visualizationRunnerJob } from './visualizationRunner';
+import { dashboardAggregatorJob } from './dashboardAggregator';
+import { reportPublisherJob } from './reportPublisher';
+import { calibrationImporterJob } from './calibrationImporter';
+import { calibrationPlannerJob } from './calibrationPlanner';
+import { calibrationReprocessorJob } from './calibrationReprocessor';
+
+export const jobs = createTargetRegistryFromArray([
+  dataGeneratorJob,
+  minutePreprocessorJob,
+  timestoreLoaderJob,
+  visualizationRunnerJob,
+  dashboardAggregatorJob,
+  reportPublisherJob,
+  calibrationImporterJob,
+  calibrationPlannerJob,
+  calibrationReprocessorJob
+]);
+
+export {
+  dataGeneratorJob,
+  minutePreprocessorJob,
+  timestoreLoaderJob,
+  visualizationRunnerJob,
+  dashboardAggregatorJob,
+  reportPublisherJob,
+  calibrationImporterJob,
+  calibrationPlannerJob,
+  calibrationReprocessorJob
+};

--- a/modules/observatory/src/services/index.ts
+++ b/modules/observatory/src/services/index.ts
@@ -1,2 +1,10 @@
-export { dashboardService } from './dashboard';
-export { adminService } from './admin';
+import { createTargetRegistryFromArray } from '@apphub/module-toolkit';
+import { dashboardService } from './dashboard';
+import { adminService } from './admin';
+
+export const services = createTargetRegistryFromArray([
+  dashboardService,
+  adminService
+]);
+
+export { dashboardService, adminService };

--- a/modules/observatory/src/workflows/index.ts
+++ b/modules/observatory/src/workflows/index.ts
@@ -1,6 +1,25 @@
-export { minuteDataGeneratorWorkflow } from './minuteDataGenerator';
-export { minuteIngestWorkflow } from './minuteIngest';
-export { dailyPublicationWorkflow } from './dailyPublication';
-export { dashboardAggregateWorkflow } from './dashboardAggregate';
-export { calibrationImportWorkflow } from './calibrationImport';
-export { calibrationReprocessWorkflow } from './calibrationReprocess';
+import { createTargetRegistryFromArray } from '@apphub/module-toolkit';
+import { minuteDataGeneratorWorkflow } from './minuteDataGenerator';
+import { minuteIngestWorkflow } from './minuteIngest';
+import { dailyPublicationWorkflow } from './dailyPublication';
+import { dashboardAggregateWorkflow } from './dashboardAggregate';
+import { calibrationImportWorkflow } from './calibrationImport';
+import { calibrationReprocessWorkflow } from './calibrationReprocess';
+
+export const workflows = createTargetRegistryFromArray([
+  minuteDataGeneratorWorkflow,
+  minuteIngestWorkflow,
+  dailyPublicationWorkflow,
+  dashboardAggregateWorkflow,
+  calibrationImportWorkflow,
+  calibrationReprocessWorkflow
+]);
+
+export {
+  minuteDataGeneratorWorkflow,
+  minuteIngestWorkflow,
+  dailyPublicationWorkflow,
+  dashboardAggregateWorkflow,
+  calibrationImportWorkflow,
+  calibrationReprocessWorkflow
+};

--- a/packages/module-toolkit/src/config.ts
+++ b/packages/module-toolkit/src/config.ts
@@ -1,4 +1,5 @@
 import type { ZodTypeAny, infer as ZodInfer } from 'zod';
+import type { ModuleSecurityRegistry } from './security';
 
 export interface SettingsLoaderOptions<
   TSettingsSchema extends ZodTypeAny,
@@ -45,4 +46,607 @@ export function createSettingsLoader<
 
     return { settings, secrets } as SettingsLoadResult<TSettingsSchema, TSecretsSchema>;
   };
+}
+
+type PlainObject = Record<string, unknown>;
+
+export interface EnvBindingInput<TTarget> {
+  value: string;
+  current: unknown;
+  env: Record<string, string | undefined>;
+  draft: TTarget;
+}
+
+export interface EnvBinding<TTarget> {
+  key: string;
+  path: string;
+  map?: (input: EnvBindingInput<TTarget>) => unknown;
+  parse?: (value: string) => unknown;
+  when?: (input: Omit<EnvBindingInput<TTarget>, 'current'>) => boolean;
+  trim?: boolean;
+}
+
+export interface EnvBindingPreset<TTarget> {
+  resolve(): EnvBinding<TTarget>[];
+}
+
+export type EnvBindingPresetLike<TTarget> =
+  | EnvBindingPreset<TTarget>
+  | (() => EnvBinding<TTarget>[])
+  | EnvBinding<TTarget>[];
+
+export function createEnvBindingPreset<TTarget>(
+  bindings: EnvBinding<TTarget>[]
+): EnvBindingPreset<TTarget> {
+  return {
+    resolve: () => bindings.map((binding) => ({ ...binding }))
+  } satisfies EnvBindingPreset<TTarget>;
+}
+
+type EnvBindingPresetEntry = EnvBindingPresetLike<any>;
+
+const envBindingPresetRegistry = new Map<string, EnvBindingPresetEntry>();
+
+export function registerEnvBindingPreset<TTarget>(
+  name: string,
+  preset: EnvBindingPresetLike<TTarget>
+): void {
+  envBindingPresetRegistry.set(name, preset as EnvBindingPresetEntry);
+}
+
+export function getEnvBindingPreset<TTarget>(name: string): EnvBindingPresetLike<TTarget> {
+  const preset = envBindingPresetRegistry.get(name);
+  if (!preset) {
+    throw new Error(`Env binding preset '${name}' is not registered`);
+  }
+  return preset as EnvBindingPresetLike<TTarget>;
+}
+
+type EnvSourceMode = 'fill' | 'override';
+
+export interface EnvSourceResult {
+  values: Record<string, string | undefined>;
+  mode?: EnvSourceMode;
+}
+
+export interface EnvSourceInput extends SettingsLoadInput {
+  currentEnv: Record<string, string | undefined>;
+}
+
+export type EnvSourceHandler = (input: EnvSourceInput) => EnvSourceResult | Record<string, string | undefined> | void;
+
+export interface EnvSource {
+  resolve(input: EnvSourceInput): EnvSourceResult | Record<string, string | undefined> | void;
+}
+
+export function createEnvSource(handler: EnvSourceHandler): EnvSource {
+  return {
+    resolve: handler
+  } satisfies EnvSource;
+}
+
+type EnvSourceLike = EnvSource | EnvSourceHandler;
+
+export interface DefineSettingsOptions<
+  TSettingsSchema extends ZodTypeAny,
+  TSecretsSchema extends ZodTypeAny | undefined = undefined
+> {
+  settingsSchema: TSettingsSchema;
+  secretsSchema?: TSecretsSchema;
+  defaults: () => ZodInfer<TSettingsSchema>;
+  secretsDefaults?: () => TSecretsSchema extends ZodTypeAny ? ZodInfer<TSecretsSchema> : undefined;
+  envBindings?: EnvBinding<ZodInfer<TSettingsSchema>>[];
+  envBindingPresets?: EnvBindingPresetLike<ZodInfer<TSettingsSchema>>[];
+  envBindingPresetKeys?: string[];
+  secretsEnvBindings?: EnvBinding<
+    TSecretsSchema extends ZodTypeAny ? ZodInfer<TSecretsSchema> : Record<string, unknown>
+  >[];
+  secretsEnvBindingPresets?: EnvBindingPresetLike<
+    TSecretsSchema extends ZodTypeAny ? ZodInfer<TSecretsSchema> : Record<string, unknown>
+  >[];
+  secretsEnvBindingPresetKeys?: string[];
+  resolveEnv?: (input: SettingsLoadInput) => Record<string, string | undefined>;
+  resolveSecretsEnv?: (input: SettingsLoadInput) => Record<string, string | undefined>;
+  envSources?: EnvSourceLike[];
+  secretsEnvSources?: EnvSourceLike[];
+}
+
+export interface DefinedSettings<
+  TSettingsSchema extends ZodTypeAny,
+  TSecretsSchema extends ZodTypeAny | undefined = undefined
+> {
+  load(input?: SettingsLoadInput): SettingsLoadResult<TSettingsSchema, TSecretsSchema>;
+  defaultSettings(): ZodInfer<TSettingsSchema>;
+  defaultSecrets(): TSecretsSchema extends ZodTypeAny ? ZodInfer<TSecretsSchema> : undefined;
+  resolveSettings(raw: unknown): ZodInfer<TSettingsSchema>;
+  resolveSecrets(raw: unknown): TSecretsSchema extends ZodTypeAny ? ZodInfer<TSecretsSchema> : undefined;
+  mergeSettingsOverrides(
+    base: ZodInfer<TSettingsSchema>,
+    overrides: Record<string, unknown>
+  ): ZodInfer<TSettingsSchema>;
+  mergeSecretsOverrides(
+    base: TSecretsSchema extends ZodTypeAny ? ZodInfer<TSecretsSchema> : undefined,
+    overrides: Record<string, unknown>
+  ): TSecretsSchema extends ZodTypeAny ? ZodInfer<TSecretsSchema> : undefined;
+}
+
+export interface ModuleSettingsDefinitionOptions<
+  TSettingsSchema extends ZodTypeAny,
+  TSecretsSchema extends ZodTypeAny | undefined = undefined,
+  TSecurity extends ModuleSecurityRegistry<any, any, any> | undefined = undefined
+> extends Omit<
+    DefineSettingsOptions<TSettingsSchema, TSecretsSchema>,
+    'envBindingPresets' | 'envBindingPresetKeys' | 'secretsEnvBindingPresets' | 'secretsEnvBindingPresetKeys'
+  > {
+  envPresetKeys?: string[];
+  envPresets?: EnvBindingPresetLike<ZodInfer<TSettingsSchema>>[];
+  secretsEnvPresetKeys?: string[];
+  secretsEnvPresets?: EnvBindingPresetLike<
+    TSecretsSchema extends ZodTypeAny ? ZodInfer<TSecretsSchema> : Record<string, unknown>
+  >[];
+  security?: TSecurity;
+  principalOverrides?: Record<string, string>;
+  applyPrincipalDefaults?: (
+    settings: ZodInfer<TSettingsSchema>,
+    principals: Record<string, string>
+  ) => void;
+}
+
+export function defineSettings<
+  TSettingsSchema extends ZodTypeAny,
+  TSecretsSchema extends ZodTypeAny | undefined = undefined
+>(
+  options: DefineSettingsOptions<TSettingsSchema, TSecretsSchema>
+): DefinedSettings<TSettingsSchema, TSecretsSchema> {
+  type Settings = ZodInfer<TSettingsSchema>;
+  type Secrets = TSecretsSchema extends ZodTypeAny ? ZodInfer<TSecretsSchema> : undefined;
+
+  const settingsDefaults = () => cloneDeep(options.defaults());
+  const secretsDefaults = options.secretsSchema
+    ? () =>
+        cloneDeep(
+          (options.secretsDefaults
+            ? options.secretsDefaults()
+            : ({} as ZodInfer<NonNullable<TSecretsSchema>>)) as NonNullable<Secrets>
+        )
+    : undefined;
+
+  const envBindingPresets = normalizeBindingPresets(
+    options.envBindingPresets,
+    options.envBindingPresetKeys
+  );
+  const secretsEnvBindingPresets = normalizeBindingPresets(
+    options.secretsEnvBindingPresets,
+    options.secretsEnvBindingPresetKeys
+  );
+
+  function resolveEnv(input: SettingsLoadInput): Record<string, string | undefined> {
+    const base = { ...(options.resolveEnv ? options.resolveEnv(input) : input.env ?? process.env) };
+    return applyEnvSources(base, options.envSources ?? [], input);
+  }
+
+  function resolveSecretsEnv(input: SettingsLoadInput): Record<string, string | undefined> {
+    if (options.resolveSecretsEnv) {
+      const base = { ...options.resolveSecretsEnv(input) };
+      return applyEnvSources(base, options.secretsEnvSources ?? [], input);
+    }
+    if (input.secretsEnv) {
+      const base = { ...input.secretsEnv };
+      return applyEnvSources(base, options.secretsEnvSources ?? [], input);
+    }
+    if (options.resolveEnv) {
+      const base = { ...options.resolveEnv(input) };
+      return applyEnvSources(base, options.secretsEnvSources ?? [], input);
+    }
+    const base = { ...(input.env ?? process.env) };
+    return applyEnvSources(base, options.secretsEnvSources ?? [], input);
+  }
+
+  function buildSettings(env: Record<string, string | undefined>): Settings {
+    const draft = settingsDefaults();
+    const bindings = [...envBindingPresets, ...(options.envBindings ?? [])];
+    if (bindings.length) {
+      applyEnvBindings(draft, env, bindings);
+    }
+    return options.settingsSchema.parse(draft);
+  }
+
+  function buildSecrets(env: Record<string, string | undefined>): Secrets {
+    if (!options.secretsSchema) {
+      return undefined as Secrets;
+    }
+    const draft = (secretsDefaults ? secretsDefaults() : ({} as NonNullable<Secrets>)) as NonNullable<Secrets>;
+    const bindings = [
+      ...secretsEnvBindingPresets,
+      ...((options.secretsEnvBindings as EnvBinding<NonNullable<Secrets>>[]) ?? [])
+    ];
+    if (bindings.length) {
+      applyEnvBindings(draft, env, bindings as EnvBinding<NonNullable<Secrets>>[]);
+    }
+    return options.secretsSchema.parse(draft) as Secrets;
+  }
+
+  function load(input: SettingsLoadInput = {}): SettingsLoadResult<TSettingsSchema, TSecretsSchema> {
+    const env = resolveEnv(input);
+    const secretsEnv = resolveSecretsEnv(input);
+    const settings = buildSettings(env);
+    const secrets = options.secretsSchema ? buildSecrets(secretsEnv) : undefined;
+    return { settings, secrets } as SettingsLoadResult<TSettingsSchema, TSecretsSchema>;
+  }
+
+  function defaultSettings(): Settings {
+    return buildSettings(resolveEnv({}));
+  }
+
+  function defaultSecrets(): Secrets {
+    if (!options.secretsSchema) {
+      return undefined as Secrets;
+    }
+    return buildSecrets(resolveSecretsEnv({}));
+  }
+
+  function mergeSettingsOverrides(
+    base: Settings,
+    overrides: Record<string, unknown>
+  ): Settings {
+    const clone = cloneDeep(base);
+    mergeInto(clone as PlainObject, overrides);
+    return options.settingsSchema.parse(clone);
+  }
+
+  function mergeSecretsOverrides(
+    base: Secrets,
+    overrides: Record<string, unknown>
+  ): Secrets {
+    if (!options.secretsSchema) {
+      return undefined as Secrets;
+    }
+    const draft = cloneDeep(base ?? ({} as Secrets));
+    mergeSecrets(draft as PlainObject, overrides);
+    return options.secretsSchema.parse(draft as NonNullable<Secrets>) as Secrets;
+  }
+
+  function resolveSettings(raw: unknown): Settings {
+    if (!isPlainObject(raw)) {
+      return defaultSettings();
+    }
+    const base = defaultSettings();
+    return mergeSettingsOverrides(base, raw);
+  }
+
+  function resolveSecrets(raw: unknown): Secrets {
+    if (!options.secretsSchema) {
+      return undefined as Secrets;
+    }
+    if (!isPlainObject(raw)) {
+      return defaultSecrets();
+    }
+    const base = defaultSecrets();
+    return mergeSecretsOverrides(base, raw);
+  }
+
+  return {
+    load,
+    defaultSettings,
+    defaultSecrets,
+    resolveSettings,
+    resolveSecrets,
+    mergeSettingsOverrides,
+    mergeSecretsOverrides
+  } satisfies DefinedSettings<TSettingsSchema, TSecretsSchema>;
+}
+
+export function coerceNumber(value: string | undefined, fallback: number): number {
+  if (value === undefined || value === null) {
+    return fallback;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+export function coerceNullableNumber(
+  value: string | undefined,
+  fallback: number | null
+): number | null {
+  if (value === undefined || value === null || value.trim().length === 0) {
+    return fallback;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+export function coerceBoolean(value: string | undefined, fallback: boolean): boolean {
+  if (value === undefined || value === null) {
+    return fallback;
+  }
+  const normalized = value.trim().toLowerCase();
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) {
+    return true;
+  }
+  if (['0', 'false', 'no', 'off'].includes(normalized)) {
+    return false;
+  }
+  return fallback;
+}
+
+function applyEnvBindings<TTarget>(
+  draft: TTarget,
+  env: Record<string, string | undefined>,
+  bindings: EnvBinding<TTarget>[]
+): void {
+  for (const binding of bindings) {
+    const raw = env[binding.key];
+    if (raw === undefined || raw === null) {
+      continue;
+    }
+
+    const trimmed = binding.trim === false ? raw : raw.trim();
+    if (trimmed.length === 0) {
+      continue;
+    }
+
+    const current = getPath(draft, binding.path);
+    const baseInput = {
+      value: trimmed,
+      current,
+      env,
+      draft
+    } satisfies EnvBindingInput<TTarget>;
+
+    if (binding.when && !binding.when({ value: trimmed, env, draft })) {
+      continue;
+    }
+
+    let next: unknown;
+    if (binding.map) {
+      next = binding.map(baseInput);
+    } else if (binding.parse) {
+      next = binding.parse(trimmed);
+    } else {
+      next = trimmed;
+    }
+
+    if (next === undefined) {
+      continue;
+    }
+
+    setPath(draft, binding.path, next);
+  }
+}
+
+function normalizeBindingPresets<TTarget>(
+  presets?: EnvBindingPresetLike<TTarget>[],
+  presetKeys?: string[]
+): EnvBinding<TTarget>[] {
+  const inputs: Array<EnvBindingPresetLike<TTarget>> = [];
+  if (presetKeys?.length) {
+    for (const key of presetKeys) {
+      inputs.push(getEnvBindingPreset<TTarget>(key));
+    }
+  }
+  if (presets?.length) {
+    inputs.push(...presets);
+  }
+  if (inputs.length === 0) {
+    return [];
+  }
+  const resolved: EnvBinding<TTarget>[] = [];
+  for (const preset of inputs) {
+    if (Array.isArray(preset)) {
+      resolved.push(...preset.map((binding) => ({ ...binding })));
+      continue;
+    }
+    if (typeof preset === 'function') {
+      resolved.push(...preset().map((binding) => ({ ...binding })));
+      continue;
+    }
+    resolved.push(...preset.resolve().map((binding) => ({ ...binding })));
+  }
+  return resolved;
+}
+
+function applyEnvSources(
+  base: Record<string, string | undefined>,
+  sources: EnvSourceLike[],
+  input: SettingsLoadInput
+): Record<string, string | undefined> {
+  if (!sources.length) {
+    return base;
+  }
+  for (const source of sources) {
+    const handler = typeof source === 'function' ? source : source.resolve.bind(source);
+    const result = handler({ ...input, currentEnv: base });
+    if (!result) {
+      continue;
+    }
+    const normalized = normalizeEnvSourceResult(result);
+    if (normalized.mode === 'fill') {
+      for (const [key, value] of Object.entries(normalized.values)) {
+        const current = base[key];
+        const hasCurrent = typeof current === 'string' && current.trim().length > 0;
+        if (!hasCurrent && value !== undefined) {
+          base[key] = value;
+        }
+      }
+    } else {
+      for (const [key, value] of Object.entries(normalized.values)) {
+        if (value === undefined) {
+          delete base[key];
+        } else {
+          base[key] = value;
+        }
+      }
+    }
+  }
+  return base;
+}
+
+function normalizeEnvSourceResult(
+  result: EnvSourceResult | Record<string, string | undefined>
+): EnvSourceResult {
+  if ('values' in result) {
+    const sourceResult = result as EnvSourceResult;
+    const mode = (sourceResult.mode ?? 'override') as EnvSourceMode;
+    return {
+      values: Object.assign({}, sourceResult.values),
+      mode
+    } satisfies EnvSourceResult;
+  }
+  return {
+    values: { ...result },
+    mode: 'override'
+  } satisfies EnvSourceResult;
+}
+
+function hasPrincipalsSlot(value: unknown): value is { principals: Record<string, string> } {
+  return Boolean(value) && typeof value === 'object' && 'principals' in (value as Record<string, unknown>);
+}
+
+export function createModuleSettingsDefinition<
+  TSettingsSchema extends ZodTypeAny,
+  TSecretsSchema extends ZodTypeAny | undefined = undefined,
+  TSecurity extends ModuleSecurityRegistry<any, any, any> | undefined = undefined
+>(
+  options: ModuleSettingsDefinitionOptions<TSettingsSchema, TSecretsSchema, TSecurity>
+) {
+  const {
+    envPresetKeys,
+    envPresets,
+    secretsEnvPresetKeys,
+    secretsEnvPresets,
+    security,
+    principalOverrides,
+    applyPrincipalDefaults,
+    defaults,
+    ...rest
+  } = options;
+
+  const principalDefaults = security
+    ? security.principalSettings(principalOverrides)
+    : undefined;
+
+  const wrappedDefaults = () => {
+    const base = defaults();
+    if (principalDefaults) {
+      if (applyPrincipalDefaults) {
+        applyPrincipalDefaults(base, principalDefaults);
+      } else if (hasPrincipalsSlot(base)) {
+        base.principals = {
+          ...principalDefaults,
+          ...(base.principals as Record<string, string>)
+        } as Record<string, string>;
+      }
+    }
+    return base;
+  };
+
+  return defineSettings({
+    ...rest,
+    defaults: wrappedDefaults,
+    envBindingPresetKeys: envPresetKeys,
+    envBindingPresets: envPresets,
+    secretsEnvBindingPresetKeys: secretsEnvPresetKeys,
+    secretsEnvBindingPresets: secretsEnvPresets
+  });
+}
+
+function mergeInto(target: PlainObject, overrides: Record<string, unknown>): PlainObject {
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) {
+      continue;
+    }
+    if (isPlainObject(value)) {
+      const existing = target[key];
+      if (isPlainObject(existing)) {
+        mergeInto(existing as PlainObject, value as PlainObject);
+      } else {
+        target[key] = cloneDeep(value) as unknown;
+      }
+      continue;
+    }
+    target[key] = value as unknown;
+  }
+  return target;
+}
+
+function mergeSecrets(target: PlainObject, overrides: Record<string, unknown>): PlainObject {
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) {
+      continue;
+    }
+    if (value === null) {
+      delete target[key];
+      continue;
+    }
+    if (typeof value === 'string' && value.trim().length === 0) {
+      delete target[key];
+      continue;
+    }
+    if (isPlainObject(value)) {
+      const existing = target[key];
+      if (isPlainObject(existing)) {
+        mergeSecrets(existing as PlainObject, value as PlainObject);
+      } else {
+        target[key] = cloneDeep(value);
+      }
+      continue;
+    }
+    target[key] = value;
+  }
+  return target;
+}
+
+function cloneDeep<T>(value: T): T {
+  if (typeof globalThis.structuredClone === 'function') {
+    return globalThis.structuredClone(value);
+  }
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function isPlainObject(value: unknown): value is PlainObject {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function getPath(target: unknown, path: string): unknown {
+  if (!path) {
+    return target;
+  }
+  const segments = path.split('.');
+  let cursor: any = target as any;
+  for (const segment of segments) {
+    if (cursor == null) {
+      return undefined;
+    }
+    const key = toKey(segment);
+    cursor = cursor[key];
+  }
+  return cursor;
+}
+
+function setPath(target: unknown, path: string, value: unknown): void {
+  const segments = path.split('.');
+  let cursor: any = target as any;
+  for (let index = 0; index < segments.length; index += 1) {
+    const segment = segments[index];
+    const key = toKey(segment);
+    if (index === segments.length - 1) {
+      cursor[key] = value;
+      return;
+    }
+    if (!isPlainObject(cursor[key]) && !Array.isArray(cursor[key])) {
+      cursor[key] = isNumericKey(segments[index + 1]) ? [] : {};
+    }
+    cursor = cursor[key];
+  }
+}
+
+function toKey(segment: string): string | number {
+  if (isNumericKey(segment)) {
+    return Number(segment);
+  }
+  return segment;
+}
+
+function isNumericKey(value: string): boolean {
+  return /^\d+$/.test(value);
 }

--- a/packages/module-toolkit/src/index.ts
+++ b/packages/module-toolkit/src/index.ts
@@ -1,12 +1,58 @@
 export type { JsonValue, BuildContext } from './types';
 export type { JsonPath } from './paths';
-export { createSettingsLoader } from './config';
+export {
+  createSettingsLoader,
+  defineSettings,
+  createModuleSettingsDefinition,
+  coerceNumber,
+  coerceNullableNumber,
+  coerceBoolean,
+  createEnvBindingPreset,
+  createEnvSource,
+  registerEnvBindingPreset,
+  getEnvBindingPreset
+} from './config';
+export type {
+  EnvBinding,
+  EnvBindingInput,
+  EnvBindingPreset,
+  EnvBindingPresetLike,
+  EnvSource,
+  EnvSourceHandler,
+  EnvSourceInput,
+  EnvSourceResult,
+  DefinedSettings,
+  DefineSettingsOptions,
+  ModuleSettingsDefinitionOptions
+} from './config';
+export {
+  COMMON_ENV_PRESET_KEYS,
+  ENV_PRESET_FILESTORE,
+  ENV_PRESET_TIMESTORE,
+  ENV_PRESET_METASTORE,
+  ENV_PRESET_CALIBRATIONS,
+  ENV_PRESET_EVENTS,
+  ENV_PRESET_DASHBOARD,
+  ENV_PRESET_CORE,
+  ENV_PRESET_SECRETS_STANDARD,
+  ENV_PRESET_REPROCESS,
+  ENV_PRESET_INGEST,
+  ENV_PRESET_GENERATOR
+} from './presets';
+export { MODULE_PRESET_KEYS } from './presets/modules';
 export { defineTrigger, defineTrigger as createTrigger } from './trigger';
 export {
   eventPath as event,
   triggerPath as trigger,
   fromConfig,
-  literal
+  literal,
+  eventField,
+  triggerMetadataField,
+  predicateEquals,
+  predicateExists,
+  predicateIn,
+  predicateEqualsConfig,
+  resolvePredicates
 } from './trigger';
 export { defineJobParameters } from './job';
 export { ValueBuilder } from './valueBuilder';
@@ -24,7 +70,10 @@ export {
 export {
   createTriggerRegistry,
   createJobRegistry,
+  createTargetRegistry,
+  createTargetRegistryFromArray,
   type TriggerRegistry,
-  type JobRegistry
+  type JobRegistry,
+  type TargetRegistry
 } from './registry';
 export { jsonPath, collectPaths } from './jsonPath';

--- a/packages/module-toolkit/src/presets/common.ts
+++ b/packages/module-toolkit/src/presets/common.ts
@@ -1,0 +1,213 @@
+import { createEnvBindingPreset, registerEnvBindingPreset } from '../config';
+
+export const ENV_PRESET_FILESTORE = 'apphub.env.filestore';
+export const ENV_PRESET_TIMESTORE = 'apphub.env.timestore';
+export const ENV_PRESET_METASTORE = 'apphub.env.metastore';
+export const ENV_PRESET_CALIBRATIONS = 'apphub.env.calibrations';
+export const ENV_PRESET_EVENTS = 'apphub.env.events';
+export const ENV_PRESET_DASHBOARD = 'apphub.env.dashboard';
+export const ENV_PRESET_CORE = 'apphub.env.core';
+export const ENV_PRESET_SECRETS_STANDARD = 'apphub.env.secrets.standard';
+export const ENV_PRESET_REPROCESS = 'apphub.env.reprocess';
+export const ENV_PRESET_INGEST = 'apphub.env.ingest';
+export const ENV_PRESET_GENERATOR = 'apphub.env.generator';
+
+registerEnvBindingPreset(
+  ENV_PRESET_FILESTORE,
+  createEnvBindingPreset([
+    { key: 'OBSERVATORY_FILESTORE_BASE_URL', path: 'filestore.baseUrl' },
+    { key: 'OBSERVATORY_FILESTORE_BACKEND_KEY', path: 'filestore.backendKey' },
+    {
+      key: 'OBSERVATORY_FILESTORE_BACKEND_ID',
+      path: 'filestore.backendId',
+      map: ({ value, current }) => {
+        const parsed = Number(value);
+        return Number.isFinite(parsed) ? parsed : (current as number | null);
+      }
+    },
+    { key: 'OBSERVATORY_FILESTORE_INBOX_PREFIX', path: 'filestore.inboxPrefix' },
+    { key: 'OBSERVATORY_FILESTORE_STAGING_PREFIX', path: 'filestore.stagingPrefix' },
+    { key: 'OBSERVATORY_FILESTORE_ARCHIVE_PREFIX', path: 'filestore.archivePrefix' },
+    { key: 'OBSERVATORY_FILESTORE_VISUALIZATIONS_PREFIX', path: 'filestore.visualizationsPrefix' },
+    { key: 'OBSERVATORY_FILESTORE_REPORTS_PREFIX', path: 'filestore.reportsPrefix' },
+    { key: 'OBSERVATORY_FILESTORE_OVERVIEW_PREFIX', path: 'filestore.overviewPrefix' },
+    { key: 'OBSERVATORY_FILESTORE_CALIBRATIONS_PREFIX', path: 'filestore.calibrationsPrefix' },
+    { key: 'OBSERVATORY_FILESTORE_PLANS_PREFIX', path: 'filestore.plansPrefix' }
+  ])
+);
+
+registerEnvBindingPreset(
+  ENV_PRESET_TIMESTORE,
+  createEnvBindingPreset([
+    { key: 'OBSERVATORY_TIMESTORE_BASE_URL', path: 'timestore.baseUrl' },
+    { key: 'OBSERVATORY_TIMESTORE_DATASET_SLUG', path: 'timestore.datasetSlug' },
+    { key: 'OBSERVATORY_TIMESTORE_DATASET_NAME', path: 'timestore.datasetName' },
+    { key: 'OBSERVATORY_TIMESTORE_TABLE_NAME', path: 'timestore.tableName' },
+    { key: 'OBSERVATORY_TIMESTORE_STORAGE_TARGET_ID', path: 'timestore.storageTargetId' },
+    { key: 'OBSERVATORY_TIMESTORE_PARTITION_NAMESPACE', path: 'timestore.partitionNamespace' },
+    {
+      key: 'OBSERVATORY_DASHBOARD_LOOKBACK_MINUTES',
+      path: 'timestore.lookbackMinutes',
+      map: ({ value, current }) => {
+        const parsed = Number(value);
+        return Number.isFinite(parsed) ? parsed : (current as number);
+      }
+    }
+  ])
+);
+
+registerEnvBindingPreset(
+  ENV_PRESET_METASTORE,
+  createEnvBindingPreset([
+    { key: 'OBSERVATORY_METASTORE_BASE_URL', path: 'metastore.baseUrl' },
+    { key: 'OBSERVATORY_METASTORE_NAMESPACE', path: 'metastore.namespace' }
+  ])
+);
+
+registerEnvBindingPreset(
+  ENV_PRESET_CALIBRATIONS,
+  createEnvBindingPreset([
+    { key: 'OBSERVATORY_CALIBRATIONS_BASE_URL', path: 'calibrations.baseUrl' },
+    { key: 'OBSERVATORY_CALIBRATIONS_NAMESPACE', path: 'calibrations.namespace' }
+  ])
+);
+
+registerEnvBindingPreset(
+  ENV_PRESET_EVENTS,
+  createEnvBindingPreset([{ key: 'OBSERVATORY_EVENTS_SOURCE', path: 'events.source' }])
+);
+
+registerEnvBindingPreset(
+  ENV_PRESET_DASHBOARD,
+  createEnvBindingPreset([
+    {
+      key: 'OBSERVATORY_DASHBOARD_LOOKBACK_MINUTES',
+      path: 'dashboard.lookbackMinutes',
+      map: ({ value, current }) => {
+        const parsed = Number(value);
+        return Number.isFinite(parsed) ? parsed : (current as number);
+      }
+    },
+    {
+      key: 'OBSERVATORY_DASHBOARD_BURST_QUIET_MS',
+      path: 'dashboard.burstQuietMs',
+      map: ({ value, current }) => {
+        const parsed = Number(value);
+        return Number.isFinite(parsed) ? parsed : (current as number);
+      }
+    },
+    {
+      key: 'OBSERVATORY_DASHBOARD_SNAPSHOT_FRESHNESS_MS',
+      path: 'dashboard.snapshotFreshnessMs',
+      map: ({ value, current }) => {
+        if (value === undefined || value === null || value.trim().length === 0) {
+          return current as number | null;
+        }
+        const parsed = Number(value);
+        return Number.isFinite(parsed) ? parsed : (current as number | null);
+      }
+    }
+  ])
+);
+
+registerEnvBindingPreset(
+  ENV_PRESET_CORE,
+  createEnvBindingPreset([{ key: 'OBSERVATORY_CORE_BASE_URL', path: 'core.baseUrl' }])
+);
+
+registerEnvBindingPreset(
+  ENV_PRESET_SECRETS_STANDARD,
+  createEnvBindingPreset([
+    { key: 'OBSERVATORY_FILESTORE_TOKEN', path: 'filestoreToken' },
+    { key: 'OBSERVATORY_TIMESTORE_TOKEN', path: 'timestoreToken' },
+    { key: 'OBSERVATORY_METASTORE_TOKEN', path: 'metastoreToken' },
+    { key: 'OBSERVATORY_CALIBRATIONS_TOKEN', path: 'calibrationsToken' },
+    { key: 'OBSERVATORY_EVENTS_TOKEN', path: 'eventsToken' },
+    { key: 'OBSERVATORY_CORE_TOKEN', path: 'coreApiToken' }
+  ])
+);
+
+registerEnvBindingPreset(
+  ENV_PRESET_REPROCESS,
+  createEnvBindingPreset([
+    { key: 'OBSERVATORY_REPROCESS_WORKFLOW_SLUG', path: 'reprocess.ingestWorkflowSlug' },
+    { key: 'OBSERVATORY_REPROCESS_INGEST_ASSET_ID', path: 'reprocess.ingestAssetId' },
+    { key: 'OBSERVATORY_REPROCESS_METASTORE_NAMESPACE', path: 'reprocess.metastoreNamespace' },
+    {
+      key: 'OBSERVATORY_REPROCESS_POLL_INTERVAL_MS',
+      path: 'reprocess.pollIntervalMs',
+      map: ({ value, current }) => {
+        const parsed = Number(value);
+        return Number.isFinite(parsed) ? parsed : (current as number);
+      }
+    }
+  ])
+);
+
+registerEnvBindingPreset(
+  ENV_PRESET_INGEST,
+  createEnvBindingPreset([
+    {
+      key: 'OBSERVATORY_INGEST_MAX_FILES',
+      path: 'ingest.maxFiles',
+      map: ({ value, current }) => {
+        const parsed = Number(value);
+        return Number.isFinite(parsed) ? parsed : (current as number);
+      }
+    },
+    { key: 'OBSERVATORY_INGEST_METASTORE_NAMESPACE', path: 'ingest.metastoreNamespace' }
+  ])
+);
+
+registerEnvBindingPreset(
+  ENV_PRESET_GENERATOR,
+  createEnvBindingPreset([
+    { key: 'OBSERVATORY_GENERATOR_MINUTE', path: 'generator.minute' },
+    {
+      key: 'OBSERVATORY_GENERATOR_ROWS_PER_INSTRUMENT',
+      path: 'generator.rowsPerInstrument',
+      map: ({ value, current }) => {
+        const parsed = Number(value);
+        return Number.isFinite(parsed) ? parsed : (current as number);
+      }
+    },
+    {
+      key: 'OBSERVATORY_GENERATOR_INTERVAL_MINUTES',
+      path: 'generator.intervalMinutes',
+      map: ({ value, current }) => {
+        const parsed = Number(value);
+        return Number.isFinite(parsed) ? parsed : (current as number);
+      }
+    },
+    {
+      key: 'OBSERVATORY_GENERATOR_INSTRUMENT_COUNT',
+      path: 'generator.instrumentCount',
+      map: ({ value, current }) => {
+        const parsed = Number(value);
+        return Number.isFinite(parsed) ? parsed : (current as number);
+      }
+    },
+    {
+      key: 'OBSERVATORY_GENERATOR_SEED',
+      path: 'generator.seed',
+      map: ({ value, current }) => {
+        const parsed = Number(value);
+        return Number.isFinite(parsed) ? parsed : (current as number);
+      }
+    }
+  ])
+);
+
+export const COMMON_ENV_PRESET_KEYS = {
+  filestore: ENV_PRESET_FILESTORE,
+  timestore: ENV_PRESET_TIMESTORE,
+  metastore: ENV_PRESET_METASTORE,
+  calibrations: ENV_PRESET_CALIBRATIONS,
+  events: ENV_PRESET_EVENTS,
+  dashboard: ENV_PRESET_DASHBOARD,
+  core: ENV_PRESET_CORE,
+  standardSecrets: ENV_PRESET_SECRETS_STANDARD,
+  reprocess: ENV_PRESET_REPROCESS,
+  ingest: ENV_PRESET_INGEST,
+  generator: ENV_PRESET_GENERATOR
+} as const;

--- a/packages/module-toolkit/src/presets/index.ts
+++ b/packages/module-toolkit/src/presets/index.ts
@@ -1,0 +1,1 @@
+export * from './common';

--- a/packages/module-toolkit/src/presets/modules/index.ts
+++ b/packages/module-toolkit/src/presets/modules/index.ts
@@ -1,0 +1,18 @@
+import { COMMON_ENV_PRESET_KEYS } from '../common';
+
+export const MODULE_PRESET_KEYS = {
+  observatory: {
+    core: [
+      COMMON_ENV_PRESET_KEYS.filestore,
+      COMMON_ENV_PRESET_KEYS.timestore,
+      COMMON_ENV_PRESET_KEYS.metastore,
+      COMMON_ENV_PRESET_KEYS.calibrations,
+      COMMON_ENV_PRESET_KEYS.events,
+      COMMON_ENV_PRESET_KEYS.dashboard,
+      COMMON_ENV_PRESET_KEYS.core
+    ],
+    workflows: [COMMON_ENV_PRESET_KEYS.reprocess, COMMON_ENV_PRESET_KEYS.ingest],
+    generator: [COMMON_ENV_PRESET_KEYS.generator],
+    secrets: [COMMON_ENV_PRESET_KEYS.standardSecrets]
+  }
+} as const;

--- a/packages/module-toolkit/templates/observatory-module/src/triggers.ts
+++ b/packages/module-toolkit/templates/observatory-module/src/triggers.ts
@@ -1,8 +1,10 @@
 import {
   defineTrigger,
   createTriggerRegistry,
-  event,
-  fromConfig
+  eventField,
+  fromConfig,
+  predicateEquals,
+  resolvePredicates
 } from '@apphub/module-toolkit';
 import type { ObservatorySettings } from './settings';
 
@@ -27,13 +29,11 @@ const minuteIngestTrigger = defineTrigger<FilestoreUploadEvent, TriggerMetadata,
   workflowSlug: 'observatory-minute-ingest',
   name: 'Observatory minute ingest',
   eventType: 'filestore.command.completed',
-  predicates: [
-    { path: '$.payload.command', operator: 'equals', value: 'uploadFile' }
-  ],
+  predicates: (context) => resolvePredicates(context, predicateEquals('$.payload.command', 'uploadFile')),
   parameters: {
-    minute: event<FilestoreUploadEvent>('payload.node.metadata.minute').default('unknown'),
-    instrumentId: event<FilestoreUploadEvent>('payload.node.metadata.instrumentId').default('unknown'),
-    commandPath: event<FilestoreUploadEvent>('payload.path'),
+    minute: eventField<FilestoreUploadEvent>((event) => event.payload.node.metadata.minute).default('unknown'),
+    instrumentId: eventField<FilestoreUploadEvent>((event) => event.payload.node.metadata.instrumentId).default('unknown'),
+    commandPath: eventField<FilestoreUploadEvent>((event) => event.payload.path),
     inboxPrefix: fromConfig<ObservatorySettings>((settings) => settings.filestore.inboxPrefix)
   }
 });

--- a/packages/module-toolkit/tests/config.test.ts
+++ b/packages/module-toolkit/tests/config.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, test } from 'vitest';
 import { z } from 'zod';
-import { createSettingsLoader } from '../src/index';
+import {
+  createSettingsLoader,
+  defineSettings,
+  createEnvBindingPreset,
+  createEnvSource,
+  registerEnvBindingPreset,
+  createModuleSettingsDefinition,
+  defineModuleSecurity
+} from '../src/index';
 
 describe('createSettingsLoader', () => {
   test('parses environment into typed settings and secrets', () => {
@@ -37,5 +45,130 @@ describe('createSettingsLoader', () => {
     expect(result.settings.datasetSlug).toBe('observatory-timeseries');
     expect(result.settings.maxFiles).toBe(200);
     expect(result.secrets?.apiToken).toBe('secret-token');
+  });
+});
+
+describe('defineSettings', () => {
+  const settingsSchema = z.object({
+    service: z.object({
+      baseUrl: z.string().url(),
+      retries: z.number().int()
+    }),
+    flags: z.object({ enableFeature: z.boolean() })
+  });
+
+  const secretsSchema = z.object({ token: z.string().optional() });
+
+  registerEnvBindingPreset(
+    'test.service.base',
+    createEnvBindingPreset([
+      { key: 'SERVICE_BASE_URL', path: 'service.baseUrl' },
+      {
+        key: 'SERVICE_RETRIES',
+        path: 'service.retries',
+        map: ({ value, current }) => {
+          const parsed = Number(value);
+          return Number.isFinite(parsed) ? parsed : (current as number);
+        }
+      }
+    ])
+  );
+
+  const definition = defineSettings({
+    settingsSchema,
+    secretsSchema,
+    defaults: () => ({
+      service: {
+        baseUrl: 'http://localhost:3000',
+        retries: 3
+      },
+      flags: {
+        enableFeature: false
+      }
+    }),
+    secretsDefaults: () => ({ token: undefined }),
+    envBindingPresetKeys: ['test.service.base'],
+    envBindings: [
+      {
+        key: 'ENABLE_FEATURE',
+        path: 'flags.enableFeature',
+        map: ({ value }) => value.toLowerCase() === 'true'
+      }
+    ],
+    secretsEnvBindingPresets: [createEnvBindingPreset([{ key: 'SERVICE_TOKEN', path: 'token' }])],
+    envSources: [createEnvSource(() => ({ values: { SERVICE_RETRIES: '4' }, mode: 'fill' }))]
+  });
+
+  test('load applies defaults, env bindings, and secrets', () => {
+    const result = definition.load({
+      env: {
+        SERVICE_BASE_URL: 'https://api.example.com',
+        SERVICE_RETRIES: '5',
+        ENABLE_FEATURE: 'true'
+      },
+      secretsEnv: {
+        SERVICE_TOKEN: 's3cr3t'
+      }
+    });
+
+    expect(result.settings.service.baseUrl).toBe('https://api.example.com');
+    expect(result.settings.service.retries).toBe(5);
+    expect(result.settings.flags.enableFeature).toBe(true);
+    expect(result.secrets?.token).toBe('s3cr3t');
+  });
+
+  test('envSources can backfill missing values before bindings apply', () => {
+    const defaults = definition.defaultSettings();
+    expect(defaults.service.retries).toBe(4);
+  });
+
+  test('resolveSettings merges overrides onto defaults', () => {
+    const resolved = definition.resolveSettings({
+      service: { retries: 10 }
+    });
+
+    expect(resolved.service.retries).toBe(10);
+    expect(resolved.service.baseUrl).toBe('http://localhost:3000');
+    expect(resolved.flags.enableFeature).toBe(false);
+  });
+
+  test('resolveSecrets removes keys when override is null or empty', () => {
+    const base = definition.defaultSecrets();
+    base.token = 'base-token';
+
+    const merged = definition.mergeSecretsOverrides(base, {
+      token: ''
+    });
+
+    expect(merged.token).toBeUndefined();
+  });
+
+  test('createModuleSettingsDefinition injects principal defaults', () => {
+    const security = defineModuleSecurity<{ token?: string }>({
+      principals: {
+        worker: { subject: 'observatory-worker' }
+      }
+    });
+
+    const schema = z.object({
+      principals: z.object({
+        worker: z.string()
+      }),
+      flags: z.object({
+        enableFeature: z.boolean()
+      })
+    });
+
+    const moduleDefinition = createModuleSettingsDefinition({
+      settingsSchema: schema,
+      defaults: () => ({
+        principals: { worker: 'custom-worker' },
+        flags: { enableFeature: false }
+      }),
+      security
+    });
+
+    const result = moduleDefinition.defaultSettings();
+    expect(result.principals.worker).toBe('custom-worker');
   });
 });

--- a/packages/module-toolkit/tests/registry.test.ts
+++ b/packages/module-toolkit/tests/registry.test.ts
@@ -6,7 +6,9 @@ import {
   fromConfig,
   createTriggerRegistry,
   defineJobParameters,
-  createJobRegistry
+  createJobRegistry,
+  createTargetRegistry,
+  createTargetRegistryFromArray
 } from '../src/index';
 
 interface EventPayload {
@@ -63,5 +65,16 @@ describe('registry helpers', () => {
     const [params] = registry.buildAll({ settings: { baseUrl: 'http://localhost' } });
     expect(params.baseUrl).toBe('http://localhost');
     expect(params.constant).toBe('value');
+  });
+
+  test('createTargetRegistry aggregates arbitrary targets', () => {
+    const targetA = { name: 'target-a' };
+    const targetB = { name: 'target-b' };
+
+    const registry = createTargetRegistryFromArray([targetA, targetB]);
+
+    expect(registry.slugs).toEqual(['target-a', 'target-b']);
+    expect(registry.get('target-a')).toBe(targetA);
+    expect(registry.values()).toEqual([targetA, targetB]);
   });
 });

--- a/packages/module-toolkit/tests/security.test.ts
+++ b/packages/module-toolkit/tests/security.test.ts
@@ -31,6 +31,24 @@ describe('defineModuleSecurity', () => {
 
     // list helpers
     expect(security.listPrincipals()).toHaveLength(2);
+    expect(security.principalSubjects()).toEqual({
+      dashboardAggregator: 'observatory-dashboard-aggregator',
+      timestoreLoader: 'observatory-timestore-loader'
+    });
+    expect(security.principalSettings({ dashboardAggregator: 'override' })).toEqual({
+      dashboardAggregator: 'override',
+      timestoreLoader: 'observatory-timestore-loader'
+    });
+    expect(security.principalSettingsPath('dashboardAggregator')).toBe('principals.dashboardAggregator');
+    const selector = security.principalSelector<'dashboardAggregator'>('dashboardAggregator');
+    expect(
+      selector({
+        principals: { dashboardAggregator: 'observatory-dashboard-aggregator' }
+      })
+    ).toBe('observatory-dashboard-aggregator');
+    expect(security.secretSettingsPath('timestoreToken')).toBe('secrets.timestoreToken');
+    const secretSelector = security.secretSelector('timestoreToken');
+    expect(secretSelector({ timestoreToken: 'abc' })).toBe('abc');
     const bundle = security.secretsBundle({ timestoreToken: 'abc' });
     expect(bundle.timestoreToken.value()).toBe('abc');
     expect(bundle.timestoreToken.exists()).toBe(true);


### PR DESCRIPTION
## Summary
- expand module-toolkit with reusable env binding preset registry, module settings helper, and selector utilities for principals/secrets
- refactor observatory module and template to consume new helpers, reducing boilerplate across triggers, registries, and settings
- document updated ergonomics and extend unit coverage for presets, selectors, and trigger predicates

## Testing
- npm run test --workspace @apphub/module-toolkit
- npm run lint -- --cache
- npm run build