### PR TITLE
feat: expose timestore staging reads

### DIFF
--- a/docker/observatory-e2e.compose.yml
+++ b/docker/observatory-e2e.compose.yml
@@ -6,9 +6,9 @@ x-shared-env: &shared-env
   PORT: 4000
   APPHUB_SESSION_SECRET: apphub-e2e-session
   APPHUB_AUTH_DISABLED: "1"
-  APPHUB_ALLOW_INLINE_MODE: "false"
+  APPHUB_ALLOW_INLINE_MODE: "${APPHUB_ALLOW_INLINE_MODE:-false}"
   APPHUB_EVENTS_MODE: redis
-  APPHUB_STREAMING_ENABLED: "false"
+  APPHUB_STREAMING_ENABLED: "${APPHUB_STREAMING_ENABLED:-false}"
   APPHUB_BUILD_EXECUTION_MODE: stub
   APPHUB_LAUNCH_EXECUTION_MODE: stub
   APPHUB_METRICS_ENABLED: "true"
@@ -48,16 +48,25 @@ x-shared-env: &shared-env
   APPHUB_JOB_BUNDLE_S3_ACCESS_KEY_ID: apphub
   APPHUB_JOB_BUNDLE_S3_SECRET_ACCESS_KEY: apphub123
   OBSERVATORY_CONFIG_PATH: /tmp/apphub-observatory/scratch/config/observatory-config.json
-  TIMESTORE_STORAGE_DRIVER: s3
+  TIMESTORE_STORAGE_DRIVER: "${TIMESTORE_STORAGE_DRIVER:-s3}"
   TIMESTORE_S3_BUCKET: apphub-timestore
   TIMESTORE_S3_ENDPOINT: http://minio:9000
   TIMESTORE_S3_REGION: us-east-1
   TIMESTORE_S3_FORCE_PATH_STYLE: "true"
   TIMESTORE_S3_ACCESS_KEY_ID: apphub
   TIMESTORE_S3_SECRET_ACCESS_KEY: apphub123
-  TIMESTORE_STAGING_FLUSH_MAX_ROWS: "1"
-  TIMESTORE_STAGING_FLUSH_MAX_BYTES: "0"
-  TIMESTORE_STAGING_FLUSH_MAX_AGE_MS: "0"
+  TIMESTORE_STREAMING_BUFFER_ENABLED: "${TIMESTORE_STREAMING_BUFFER_ENABLED:-0}"
+  TIMESTORE_STREAMING_BUFFER_FALLBACK: "${TIMESTORE_STREAMING_BUFFER_FALLBACK:-parquet_only}"
+  TIMESTORE_STREAMING_BATCHERS: "${TIMESTORE_STREAMING_BATCHERS:-[]}"
+  TIMESTORE_STREAMING_CONNECTORS: "${TIMESTORE_STREAMING_CONNECTORS:-[]}"
+  TIMESTORE_BULK_CONNECTORS: "${TIMESTORE_BULK_CONNECTORS:-[]}"
+  APPHUB_STREAM_BROKER_URL: "${APPHUB_STREAM_BROKER_URL:-}"
+  TIMESTORE_TEST_API_ENABLED: "${TIMESTORE_TEST_API_ENABLED:-0}"
+  TIMESTORE_TEST_HOT_BUFFER_ENABLED: "${TIMESTORE_TEST_HOT_BUFFER_ENABLED:-1}"
+  TIMESTORE_TEST_HOT_BUFFER_STATE: "${TIMESTORE_TEST_HOT_BUFFER_STATE:-ready}"
+  TIMESTORE_STAGING_FLUSH_MAX_ROWS: "${TIMESTORE_STAGING_FLUSH_MAX_ROWS:-1}"
+  TIMESTORE_STAGING_FLUSH_MAX_BYTES: "${TIMESTORE_STAGING_FLUSH_MAX_BYTES:-0}"
+  TIMESTORE_STAGING_FLUSH_MAX_AGE_MS: "${TIMESTORE_STAGING_FLUSH_MAX_AGE_MS:-0}"
   AWS_ACCESS_KEY_ID: apphub
   AWS_SECRET_ACCESS_KEY: apphub123
   AWS_REGION: us-east-1
@@ -228,30 +237,13 @@ services:
       - minio
     environment:
       <<: *shared-env
+      REDIS_URL: inline
+      TIMESTORE_MANIFEST_CACHE_ENABLED: "false"
+      TIMESTORE_FILESTORE_SYNC_ENABLED: "false"
       PORT: 4200
     restart: unless-stopped
     ports:
       - "${APPHUB_E2E_TIMESTORE_PORT:-4420}:4200"
-    volumes: *runtime-volume
-
-  timestore-ingest:
-    image: apphub/timestore:e2e
-    depends_on:
-      - timestore
-    environment:
-      <<: *shared-env
-    restart: unless-stopped
-    command: ["services/timestore/dist/workers/ingestionWorker.js"]
-    volumes: *runtime-volume
-
-  timestore-partition:
-    image: apphub/timestore:e2e
-    depends_on:
-      - timestore
-    environment:
-      <<: *shared-env
-    restart: unless-stopped
-    command: ["services/timestore/dist/workers/partitionBuildWorker.js"]
     volumes: *runtime-volume
 
 volumes:

--- a/modules/observatory/src/deployment/configBuilder.ts
+++ b/modules/observatory/src/deployment/configBuilder.ts
@@ -244,7 +244,7 @@ export function createEventDrivenObservatoryConfig(
       'filestore.archivePrefix'
     ),
     visualizationsPrefix: resolveString(
-      getVar('OBSERVATORY_FILESTORE_VIS_PREFIX'),
+      getVar('OBSERVATORY_FILESTORE_VISUALIZATIONS_PREFIX', ['OBSERVATORY_FILESTORE_VIS_PREFIX']),
       'datasets/observatory/visualizations',
       'filestore.visualizationsPrefix'
     ),

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "minikube:down": "node scripts/minikube-down.mjs",
     "minikube:verify": "node scripts/minikube-verify.mjs",
     "e2e": "tsx tests/e2e/observatory.e2e.ts",
+    "e2e:timestore": "tsx tests/e2e/timestore.e2e.ts",
     "module:admin": "npm run module:admin --workspace @apphub/core --"
   },
   "devDependencies": {

--- a/services/timestore/src/routes/ingest.ts
+++ b/services/timestore/src/routes/ingest.ts
@@ -179,6 +179,7 @@ export async function registerIngestionRoutes(app: FastifyInstance): Promise<voi
           return reply.status(flushPending ? 202 : 201).send({
             mode: 'inline',
             flushPending,
+            jobId: flushPending ? `inline:${params.datasetSlug}` : undefined,
             dataset: result.result.dataset,
             storageTarget: result.result.storageTarget,
             manifest: result.result.manifest ?? null

--- a/services/timestore/src/routes/testHarness.ts
+++ b/services/timestore/src/routes/testHarness.ts
@@ -1,0 +1,87 @@
+import type { FastifyInstance, FastifyRequest } from 'fastify';
+import { z } from 'zod';
+import { authorizeAdminAccess } from '../service/iam';
+import { getHotBufferTestStore, setHotBufferTestHarness } from '../streaming/hotBuffer';
+
+const paramsSchema = z.object({
+  datasetSlug: z.string().min(1)
+});
+
+const updateRequestSchema = z
+  .object({
+    watermark: z.string().min(1).optional(),
+    rows: z
+      .array(
+        z.object({
+          timestamp: z.string().min(1),
+          payload: z.record(z.unknown())
+        })
+      )
+      .optional(),
+    enabled: z.boolean().optional(),
+    state: z.enum(['ready', 'unavailable']).optional(),
+    clear: z.boolean().optional()
+  })
+  .strict();
+
+function parseTimestamp(label: string, value: string): number {
+  const parsed = Date.parse(value);
+  if (Number.isNaN(parsed)) {
+    throw new Error(`Invalid ${label} timestamp '${value}'`);
+  }
+  return parsed;
+}
+
+export async function registerTestHarnessRoutes(app: FastifyInstance): Promise<void> {
+  app.post('/__test__/streaming/hot-buffer/:datasetSlug', async (request, reply) => {
+    await authorizeAdminAccess(request as FastifyRequest);
+
+    const params = paramsSchema.parse(request.params ?? {});
+    const body = updateRequestSchema.parse(request.body ?? {});
+
+    const store = getHotBufferTestStore();
+    if (!store) {
+      reply.status(503);
+      return {
+        error: 'Streaming hot buffer test harness is not active'
+      };
+    }
+
+    if (body.clear) {
+      store.clear();
+    }
+
+    let rowsAdded = 0;
+    if (body.rows) {
+      for (const entry of body.rows) {
+        const timestampMs = parseTimestamp('row', entry.timestamp);
+        store.ingest(params.datasetSlug, entry.payload, timestampMs);
+        rowsAdded += 1;
+      }
+    }
+
+    if (body.watermark) {
+      const watermarkMs = parseTimestamp('watermark', body.watermark);
+      store.setWatermark(params.datasetSlug, watermarkMs);
+    }
+
+    if (body.enabled !== undefined || body.state) {
+      setHotBufferTestHarness({
+        store,
+        enabled: body.enabled ?? true,
+        state: body.state ?? 'ready'
+      });
+    }
+
+    return {
+      datasetSlug: params.datasetSlug,
+      rowsAdded,
+      watermarkApplied: body.watermark ?? null,
+      harness: {
+        enabled: body.enabled ?? true,
+        state: body.state ?? 'ready'
+      }
+    };
+  });
+}
+

--- a/tests/e2e/lib/timestoreClient.ts
+++ b/tests/e2e/lib/timestoreClient.ts
@@ -14,25 +14,186 @@ export interface DatasetQueryRequest {
   timestampColumn?: string;
   columns?: string[] | null;
   limit?: number;
+  downsample?: {
+    intervalUnit?: 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month';
+    intervalSize?: number;
+    aggregations: Array<{
+      fn: 'avg' | 'min' | 'max' | 'sum' | 'median' | 'count' | 'count_distinct' | 'percentile';
+      column?: string;
+      alias?: string;
+      percentile?: number;
+    }>;
+  } | null;
+  filters?: Record<string, unknown> | null;
 }
 
 export interface DatasetQueryResponse {
-  data: {
-    rows: Array<Record<string, unknown>>;
-    columns: string[];
-    mode: string;
-  };
+  rows: Array<Record<string, unknown>>;
+  columns: string[];
+  mode: string;
+  warnings?: string[];
+  streaming?: Record<string, unknown> | null;
 }
 
 type DatasetQueryPayload =
-  | DatasetQueryResponse
-  | {
-      rows: Array<Record<string, unknown>>;
-      columns: string[];
-      mode: string;
-      warnings?: unknown;
-      streaming?: unknown;
+  | { data: DatasetQueryResponse }
+  | DatasetQueryResponse;
+
+export interface DatasetIngestionRequest {
+  datasetName?: string;
+  storageTargetId?: string;
+  tableName?: string;
+  schema: {
+    fields: Array<{ name: string; type: string }>;
+    evolution?: Record<string, unknown>;
+  };
+  partition: {
+    key: Record<string, string>;
+    attributes?: Record<string, string>;
+    timeRange: {
+      start: string;
+      end: string;
     };
+  };
+  rows: Array<Record<string, unknown>>;
+  idempotencyKey?: string;
+}
+
+export interface DatasetRecordSummary {
+  id: string;
+  slug: string;
+  name: string;
+  status: string;
+  writeFormat: string;
+  updatedAt: string;
+  createdAt?: string;
+  defaultStorageTargetId?: string | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface DatasetDetailResponse {
+  dataset: DatasetRecordSummary & {
+    description: string | null;
+    metadata: Record<string, unknown> | null;
+  };
+  etag?: string;
+}
+
+export interface DatasetManifestPartition {
+  id: string;
+  filePath: string;
+  rowCount: number;
+  storageTargetId?: string;
+}
+
+export interface DatasetManifestPayload {
+  datasetId: string;
+  manifest?: {
+    id: string;
+    version: number;
+    manifestShard?: string | null;
+    totalRows?: number;
+    partitions: DatasetManifestPartition[];
+  };
+  manifests?: Array<{
+    id: string;
+    version: number;
+    manifestShard?: string | null;
+    totalRows?: number;
+    partitions: DatasetManifestPartition[];
+  }>;
+  staging?: {
+    totalRows: number;
+    batches: Array<{
+      batchId: string;
+      tableName: string;
+      rowCount: number;
+      timeRange: {
+        start: string;
+        end: string;
+      };
+      stagedAt: string;
+      schema: Array<{
+        name: string;
+        type: string;
+      }>;
+    }>;
+  };
+}
+
+export type DatasetFlushResponse =
+  | {
+      mode: 'inline';
+      status: 'noop' | 'flushed';
+      batches: number;
+      rows: number;
+      manifest: {
+        id: string;
+        version: number;
+        shard: string | null;
+      } | null;
+    }
+  | {
+      mode: 'queued';
+      status: 'queued';
+      jobId: string;
+      datasetSlug?: string;
+    };
+
+export interface SqlReadResponse {
+  executionId: string;
+  columns: string[];
+  rows: Array<Record<string, unknown>>;
+  truncated: boolean;
+  warnings?: string[];
+  statistics?: {
+    rowCount: number;
+    elapsedMs?: number;
+  };
+}
+
+export interface SqlExecResponse {
+  command: string;
+  rowCount: number;
+}
+
+export interface SqlSchemaResponse {
+  fetchedAt: string;
+  tables: Array<{
+    name: string;
+    description?: string | null;
+    columns: Array<Record<string, unknown>>;
+    partitionKeys?: string[];
+  }>;
+  warnings?: string[];
+}
+
+export interface StreamingStatusResponse {
+  enabled: boolean;
+  state: 'disabled' | 'ready' | 'degraded' | 'unconfigured';
+  reason: string | null;
+  broker: Record<string, unknown>;
+  batchers: Record<string, unknown>;
+  hotBuffer: {
+    enabled: boolean;
+    state: 'disabled' | 'ready' | 'unavailable';
+    datasets: number;
+    healthy: boolean;
+    lastRefreshAt: string | null;
+    lastIngestAt: string | null;
+  };
+}
+
+export interface HotBufferUpdateRequest {
+  watermark?: string;
+  rows?: Array<{
+    timestamp: string;
+    payload: Record<string, unknown>;
+  }>;
+  enabled?: boolean;
+  state?: 'ready' | 'unavailable';
+  clear?: boolean;
+}
 
 export class TimestoreClient {
   private readonly baseUrl: string;
@@ -51,7 +212,20 @@ export class TimestoreClient {
     return this.token ? { Authorization: `Bearer ${this.token}` } : {};
   }
 
-  async queryDataset(slug: string, request: DatasetQueryRequest): Promise<DatasetQueryResponse['data']> {
+  async ingestDataset(slug: string, request: DatasetIngestionRequest): Promise<number> {
+    const response = await requestJson<Record<string, unknown>>(
+      this.resolve(`/datasets/${slug}/ingest`),
+      {
+        method: 'POST',
+        headers: this.authHeaders(),
+        body: request,
+        expectedStatus: [200, 201, 202]
+      }
+    );
+    return response.status;
+  }
+
+  async queryDataset(slug: string, request: DatasetQueryRequest): Promise<DatasetQueryResponse> {
     const response = await requestJson<DatasetQueryPayload>(
       this.resolve(`/datasets/${slug}/query`),
       {
@@ -62,9 +236,108 @@ export class TimestoreClient {
       }
     );
     const payload = response.payload;
-    if ('data' in payload && payload.data) {
+    if ('data' in payload) {
       return payload.data;
     }
-    return payload as unknown as DatasetQueryResponse['data'];
+    return payload as DatasetQueryResponse;
+  }
+
+  async getDataset(idOrSlug: string): Promise<DatasetDetailResponse> {
+    const response = await requestJson<DatasetDetailResponse>(
+      this.resolve(`/admin/datasets/${idOrSlug}`),
+      {
+        headers: this.authHeaders(),
+        expectedStatus: 200
+      }
+    );
+    return response.payload;
+  }
+
+  async listDatasets(): Promise<DatasetRecordSummary[]> {
+    const response = await requestJson<{ datasets: DatasetRecordSummary[] }>(
+      this.resolve('/admin/datasets'),
+      {
+        headers: this.authHeaders(),
+        expectedStatus: 200
+      }
+    );
+    return response.payload.datasets ?? [];
+  }
+
+  async getDatasetManifest(idOrSlug: string): Promise<DatasetManifestPayload | null> {
+    const response = await requestJson<DatasetManifestPayload | { error: string }>(
+      this.resolve(`/admin/datasets/${idOrSlug}/manifest`),
+      {
+        headers: this.authHeaders(),
+        expectedStatus: [200, 404]
+      }
+    );
+    if (response.status === 404) {
+      return null;
+    }
+    return response.payload as DatasetManifestPayload;
+  }
+
+  async getSqlSchema(): Promise<SqlSchemaResponse> {
+    const response = await requestJson<SqlSchemaResponse>(this.resolve('/sql/schema'), {
+      headers: this.authHeaders(),
+      expectedStatus: 200
+    });
+    return response.payload;
+  }
+
+  async sqlRead(sql: string): Promise<SqlReadResponse> {
+    const response = await requestJson<SqlReadResponse>(this.resolve('/sql/read'), {
+      method: 'POST',
+      headers: this.authHeaders(),
+      body: { sql },
+      expectedStatus: 200
+    });
+    return response.payload;
+  }
+
+  async sqlExec(sql: string): Promise<SqlExecResponse> {
+    const response = await requestJson<SqlExecResponse>(this.resolve('/sql/exec'), {
+      method: 'POST',
+      headers: this.authHeaders(),
+      body: { sql },
+      expectedStatus: 200
+    });
+    return response.payload;
+  }
+
+  async getStreamingStatus(): Promise<StreamingStatusResponse> {
+    const response = await requestJson<StreamingStatusResponse>(
+      this.resolve('/streaming/status'),
+      {
+        headers: this.authHeaders(),
+        expectedStatus: 200
+      }
+    );
+    return response.payload;
+  }
+
+  async updateHotBuffer(datasetSlug: string, payload: HotBufferUpdateRequest): Promise<void> {
+    await requestJson<Record<string, unknown>>(
+      this.resolve(`/__test__/streaming/hot-buffer/${datasetSlug}`),
+      {
+        method: 'POST',
+        headers: this.authHeaders(),
+        body: payload,
+        expectedStatus: 200
+      }
+    );
+  }
+
+  async triggerFlush(datasetIdOrSlug: string): Promise<DatasetFlushResponse> {
+    const response = await requestJson<DatasetFlushResponse>(
+      this.resolve(`/admin/datasets/${datasetIdOrSlug}/flush`),
+      {
+        method: 'POST',
+        headers: this.authHeaders(),
+        expectedStatus: [200, 202]
+      }
+    );
+    return response.payload;
   }
 }

--- a/tests/e2e/timestore.e2e.ts
+++ b/tests/e2e/timestore.e2e.ts
@@ -1,0 +1,564 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import path from 'node:path';
+import { promises as fs } from 'node:fs';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { test } from 'node:test';
+
+import { startStack } from './lib/stack';
+import { waitForEndpoint } from './lib/http';
+import { analyzeLogs } from './lib/logs';
+import { TimestoreClient, type DatasetManifestPayload } from './lib/timestoreClient';
+import {
+  CORE_BASE_URL,
+  TIMESTORE_BASE_URL,
+  OPERATOR_TOKEN
+} from './lib/env';
+
+const SKIP_STACK = process.env.APPHUB_E2E_SKIP_STACK === '1';
+const PRESERVE_STACK = process.env.APPHUB_E2E_PRESERVE_STACK === '1';
+const TEST_ID = randomUUID().slice(0, 8);
+const TEST_TIMEOUT_MS = (() => {
+  const raw = process.env.APPHUB_E2E_TEST_TIMEOUT;
+  if (!raw) {
+    return 240_000;
+  }
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 240_000;
+})();
+
+function sanitizeViewSlug(slug: string): string {
+  const trimmed = slug.trim();
+  const replaced = trimmed.replace(/[^A-Za-z0-9_]/g, '_');
+  const collapsed = replaced.replace(/_+/g, '_');
+  const stripped = collapsed.replace(/^_+|_+$/g, '');
+  const fallback = stripped.length > 0 ? stripped : 'dataset';
+  if (/^[0-9]/.test(fallback)) {
+    return `d_${fallback}`;
+  }
+  return fallback;
+}
+
+function buildViewName(slug: string): string {
+  return `timestore.${sanitizeViewSlug(slug)}`;
+}
+
+async function waitForQueryRows(
+  client: TimestoreClient,
+  slug: string,
+  request: Parameters<TimestoreClient['queryDataset']>[1],
+  expectedRows: number,
+  options: { timeoutMs?: number; pollIntervalMs?: number; label?: string; log?: (line: string) => void } = {}
+) {
+  const timeout = options.timeoutMs ?? 180_000;
+  const pollInterval = options.pollIntervalMs ?? 2_000;
+  const deadline = Date.now() + timeout;
+  let lastError: unknown = null;
+  const label = options.label ?? slug;
+  const log = options.log;
+
+  while (Date.now() < deadline) {
+    try {
+      const result = await client.queryDataset(slug, request);
+      if (result.rows.length >= expectedRows) {
+        log?.(`waitForQueryRows(${label}): satisfied with ${result.rows.length} rows`);
+        return result;
+      }
+      lastError = new Error(`received ${result.rows.length} rows (expected ${expectedRows})`);
+      log?.(`waitForQueryRows(${label}): ${result.rows.length}/${expectedRows} rows, retrying`);
+    } catch (error) {
+      lastError = error;
+      log?.(`waitForQueryRows(${label}): error ${(error as Error)?.message ?? error}`);
+    }
+    await sleep(pollInterval);
+  }
+
+  const message = lastError instanceof Error ? lastError.message : String(lastError ?? 'unknown error');
+  throw new Error(`Timed out waiting for dataset ${slug} rows (${message})`);
+}
+
+async function waitForSqlCount(
+  client: TimestoreClient,
+  viewName: string,
+  expectedCount: number,
+  options: { timeoutMs?: number; pollIntervalMs?: number; log?: (line: string) => void } = {}
+) {
+  const timeout = options.timeoutMs ?? 120_000;
+  const pollInterval = options.pollIntervalMs ?? 2_000;
+  const deadline = Date.now() + timeout;
+  let lastError: unknown = null;
+  const log = options.log;
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await client.sqlRead(`SELECT COUNT(*) AS row_count FROM ${viewName}`);
+      const value = response.rows[0]?.row_count ?? response.rows[0]?.ROW_COUNT;
+      const numeric = typeof value === 'number' ? value : Number(value ?? 0);
+      if (Number.isFinite(numeric) && numeric === expectedCount) {
+        log?.(`waitForSqlCount(${viewName}): count=${numeric}, satisfied`);
+        return response;
+      }
+      lastError = new Error(`row_count=${numeric}, expected=${expectedCount}`);
+      log?.(`waitForSqlCount(${viewName}): row_count=${numeric}, retrying`);
+    } catch (error) {
+      lastError = error;
+      log?.(`waitForSqlCount(${viewName}): error ${(error as Error)?.message ?? error}`);
+    }
+    await sleep(pollInterval);
+  }
+
+  const message = lastError instanceof Error ? lastError.message : String(lastError ?? 'unknown error');
+  throw new Error(`Timed out waiting for SQL runtime for ${viewName} (${message})`);
+}
+
+async function waitForManifestCondition(
+  client: TimestoreClient,
+  slug: string,
+  predicate: (manifest: DatasetManifestPayload | null) => boolean,
+  options: { timeoutMs?: number; pollIntervalMs?: number; label?: string; log?: (line: string) => void } = {}
+): Promise<DatasetManifestPayload | null> {
+  const timeout = options.timeoutMs ?? 120_000;
+  const pollInterval = options.pollIntervalMs ?? 2_000;
+  const deadline = Date.now() + timeout;
+  const label = options.label ?? slug;
+  const log = options.log;
+  let lastManifest: DatasetManifestPayload | null = null;
+
+  while (Date.now() < deadline) {
+    try {
+      const manifest = await client.getDatasetManifest(slug);
+      lastManifest = manifest ?? null;
+      if (predicate(lastManifest)) {
+        log?.(`waitForManifestCondition(${label}): predicate satisfied`);
+        return lastManifest;
+      }
+      log?.(
+        `waitForManifestCondition(${label}): predicate not yet satisfied (partitions=${countPublishedPartitions(
+          lastManifest
+        )}, stagingRows=${manifestStagingRows(lastManifest)}), retrying`
+      );
+    } catch (error) {
+      log?.(`waitForManifestCondition(${label}): error ${(error as Error)?.message ?? error}`);
+    }
+    await sleep(pollInterval);
+  }
+
+  throw new Error(`Timed out waiting for manifest condition on dataset ${slug}`);
+}
+
+function countPublishedPartitions(manifest: DatasetManifestPayload | null): number {
+  if (!manifest) {
+    return 0;
+  }
+  if (manifest.manifests && manifest.manifests.length > 0) {
+    return manifest.manifests.reduce(
+      (total, entry) => total + (entry.partitions?.length ?? 0),
+      0
+    );
+  }
+  return manifest.manifest?.partitions?.length ?? 0;
+}
+
+function manifestStagingRows(manifest: DatasetManifestPayload | null): number {
+  if (!manifest?.staging) {
+    return 0;
+  }
+  return manifest.staging.totalRows ?? 0;
+}
+
+function sumPartitionRows(manifest: DatasetManifestPayload | null): number {
+  if (!manifest) {
+    return 0;
+  }
+  const partitions = manifest.manifests && manifest.manifests.length > 0
+    ? manifest.manifests.flatMap((entry) => entry.partitions ?? [])
+    : manifest.manifest?.partitions ?? [];
+  return partitions.reduce((total, partition) => total + (partition?.rowCount ?? 0), 0);
+}
+
+function assertRowsInclude(
+  actualRows: Array<Record<string, unknown>>,
+  expectedRows: Array<Record<string, unknown>>,
+  label: string
+) {
+  for (const expected of expectedRows) {
+    const keys = Object.keys(expected);
+    const matchIndex = actualRows.findIndex((candidate) =>
+      keys.every((key) => valuesEqual(expected[key], candidate[key]))
+    );
+    assert.notEqual(matchIndex, -1, `Expected row not found in ${label}: ${JSON.stringify(expected)}`);
+  }
+}
+
+function valuesEqual(expected: unknown, actual: unknown): boolean {
+  if (typeof expected === 'number') {
+    const numeric = typeof actual === 'number' ? actual : Number(actual ?? NaN);
+    return Number.isFinite(numeric) && Math.abs(numeric - expected) < 1e-9;
+  }
+  if (typeof expected === 'boolean') {
+    return actual === expected;
+  }
+  if (expected === null || expected === undefined) {
+    return actual === expected;
+  }
+  return String(actual) === String(expected);
+}
+
+function iso(timestamp: number): string {
+  return new Date(timestamp).toISOString();
+}
+
+test('timestore row-threshold flush behavior', { timeout: TEST_TIMEOUT_MS }, async (t) => {
+  const flushRowThreshold = Number(process.env.APPHUB_E2E_FLUSH_ROW_THRESHOLD ?? '6');
+  process.env.TIMESTORE_STAGING_FLUSH_MAX_ROWS = String(flushRowThreshold);
+  process.env.TIMESTORE_STAGING_FLUSH_MAX_BYTES = '0';
+  process.env.TIMESTORE_STAGING_FLUSH_MAX_AGE_MS = '0';
+  process.env.TIMESTORE_STAGING_EAGER_BYTES_ONLY = 'false';
+  process.env.TIMESTORE_TEST_API_ENABLED = process.env.TIMESTORE_TEST_API_ENABLED ?? '1';
+  process.env.TIMESTORE_TEST_HOT_BUFFER_ENABLED =
+    process.env.TIMESTORE_TEST_HOT_BUFFER_ENABLED ?? '1';
+  process.env.TIMESTORE_TEST_HOT_BUFFER_STATE =
+    process.env.TIMESTORE_TEST_HOT_BUFFER_STATE ?? 'ready';
+  process.env.APPHUB_STREAMING_ENABLED = process.env.APPHUB_STREAMING_ENABLED ?? 'true';
+  process.env.TIMESTORE_STREAMING_BUFFER_ENABLED =
+    process.env.TIMESTORE_STREAMING_BUFFER_ENABLED ?? 'true';
+  process.env.APPHUB_STREAM_BROKER_URL = process.env.APPHUB_STREAM_BROKER_URL ?? 'dummy:9092';
+  process.env.TIMESTORE_STREAMING_BATCHERS = process.env.TIMESTORE_STREAMING_BATCHERS ?? '[]';
+  process.env.TIMESTORE_STREAMING_CONNECTORS =
+    process.env.TIMESTORE_STREAMING_CONNECTORS ?? '[]';
+  process.env.TIMESTORE_BULK_CONNECTORS = process.env.TIMESTORE_BULK_CONNECTORS ?? '[]';
+
+  const log = (message: string) => {
+    const line = `[timestore-e2e] ${message}`;
+    console.log(line);
+    t.diagnostic(line);
+  };
+
+  log(`configured staging flush threshold to ${flushRowThreshold} rows`);
+  log(`starting stack (skipUp=${SKIP_STACK})`);
+  const stack = await startStack({ skipUp: SKIP_STACK });
+  const startedAt = new Date();
+
+  if (!SKIP_STACK && !PRESERVE_STACK) {
+    t.after(async () => {
+      log('stopping stack');
+      await stack.stop();
+    });
+  } else if (PRESERVE_STACK) {
+    log('preserving stack after test run (APPHUB_E2E_PRESERVE_STACK=1)');
+  }
+
+  log('waiting for core health');
+  await waitForEndpoint(`${CORE_BASE_URL}/health`, {
+    headers: { Authorization: `Bearer ${OPERATOR_TOKEN}` },
+    expectedStatus: [200, 503]
+  });
+  log('waiting for timestore health');
+  await waitForEndpoint(`${TIMESTORE_BASE_URL}/health`, {
+    headers: { Authorization: `Bearer ${OPERATOR_TOKEN}` },
+    expectedStatus: [200, 503]
+  });
+
+  const client = new TimestoreClient();
+
+  // Batch dataset exercises staging-only reads, automatic parquet flush, and unified queries.
+  const batchSlug = `timestore-e2e-batch-${TEST_ID}`;
+  const batchBaseTime = Date.UTC(2024, 0, 1, 0, 0, 0);
+  const batchSchema = {
+    fields: [
+      { name: 'timestamp', type: 'timestamp' },
+      { name: 'sensor_id', type: 'string' },
+      { name: 'value', type: 'double' },
+      { name: 'is_online', type: 'boolean' }
+    ]
+  } as const;
+  const batchPartitionKey = {
+    key: { window: iso(batchBaseTime), sensor: 'alpha-bravo' },
+    attributes: { region: 'iad' }
+  } as const;
+  const batchQueryRange = {
+    start: iso(batchBaseTime - 5 * 60 * 1000),
+    end: iso(batchBaseTime + 60 * 60 * 1000)
+  };
+
+  const makeBatchRow = (offsetMinutes: number, sensor: string): Record<string, unknown> => ({
+    timestamp: iso(batchBaseTime + offsetMinutes * 60_000),
+    sensor_id: sensor,
+    value: 12 + offsetMinutes / 10,
+    is_online: offsetMinutes % 2 === 0
+  });
+
+  const batchChunk1 = [0, 5, 10, 15].map((offset, index) =>
+    makeBatchRow(offset, index % 2 === 0 ? 'alpha' : 'bravo')
+  );
+  const batchChunk2 = [20, 25, 30, 35].map((offset, index) =>
+    makeBatchRow(offset, index % 2 === 0 ? 'alpha' : 'bravo')
+  );
+  const batchChunk3 = [40, 45].map((offset, index) =>
+    makeBatchRow(offset, index % 2 === 0 ? 'alpha' : 'bravo')
+  );
+
+  const allBatchRows: Record<string, unknown>[] = [];
+
+  async function ingestBatchRows(rows: Record<string, unknown>[], label: string) {
+    const timeRange = {
+      start: String(rows[0]?.timestamp ?? iso(batchBaseTime)),
+      end: String(rows[rows.length - 1]?.timestamp ?? iso(batchBaseTime))
+    };
+    const idempotencyKey = `${label}-${randomUUID()}`;
+    log(`ingesting ${rows.length} rows (${label}) into ${batchSlug}`);
+    await client.ingestDataset(batchSlug, {
+      datasetName: 'E2E Batch Dataset',
+      tableName: 'batch_measurements',
+      schema: batchSchema,
+      partition: {
+        ...batchPartitionKey,
+        timeRange
+      },
+      rows,
+      idempotencyKey
+    });
+    allBatchRows.push(...rows);
+  }
+
+  await ingestBatchRows(batchChunk1, 'batch-stage-1');
+  const batchStage1Query = await waitForQueryRows(
+    client,
+    batchSlug,
+    {
+      timeRange: batchQueryRange,
+      timestampColumn: 'timestamp'
+    },
+    allBatchRows.length,
+    { label: `${batchSlug}-staging`, log }
+  );
+  assertRowsInclude(batchStage1Query.rows, allBatchRows, `${batchSlug}-staging`);
+  const manifestStage1 = await client.getDatasetManifest(batchSlug);
+  assert.equal(countPublishedPartitions(manifestStage1), 0, 'no parquet partitions expected yet');
+  assert.equal(
+    manifestStagingRows(manifestStage1),
+    allBatchRows.length,
+    'staging rows should match ingested rows before flush'
+  );
+
+  await ingestBatchRows(batchChunk2, 'batch-stage-2');
+  const batchAfterFlushQuery = await waitForQueryRows(
+    client,
+    batchSlug,
+    {
+      timeRange: batchQueryRange,
+      timestampColumn: 'timestamp'
+    },
+    allBatchRows.length,
+    { label: `${batchSlug}-post-flush`, log }
+  );
+  assertRowsInclude(batchAfterFlushQuery.rows, allBatchRows, `${batchSlug}-post-flush`);
+
+  const manifestAfterFlush = await waitForManifestCondition(
+    client,
+    batchSlug,
+    (manifest) => countPublishedPartitions(manifest) > 0 && manifestStagingRows(manifest) === 0,
+    { label: `${batchSlug}-flush`, log }
+  );
+  assert.ok(
+    sumPartitionRows(manifestAfterFlush) >= allBatchRows.length,
+    'parquet manifest should contain at least the ingested row count'
+  );
+
+  await ingestBatchRows(batchChunk3, 'batch-stage-3');
+  const batchFinalQuery = await waitForQueryRows(
+    client,
+    batchSlug,
+    {
+      timeRange: batchQueryRange,
+      timestampColumn: 'timestamp'
+    },
+    allBatchRows.length,
+    { label: `${batchSlug}-final`, log }
+  );
+  assertRowsInclude(batchFinalQuery.rows, allBatchRows, `${batchSlug}-final`);
+
+  const manifestWithStaging = await waitForManifestCondition(
+    client,
+    batchSlug,
+    (manifest) =>
+      countPublishedPartitions(manifest) > 0 && manifestStagingRows(manifest) >= batchChunk3.length,
+    { label: `${batchSlug}-staging-after-flush`, log }
+  );
+  assert.equal(
+    manifestStagingRows(manifestWithStaging),
+    batchChunk3.length,
+    'latest ingestion should remain staged while previous data is parquet'
+  );
+
+  const batchView = buildViewName(batchSlug);
+  await waitForSqlCount(client, batchView, allBatchRows.length, { log });
+
+  // Streaming dataset mirrors the batch assertions and ensures hot-buffer data is surfaced.
+  const streamSlug = `timestore-e2e-stream-${TEST_ID}`;
+  const streamBaseTime = Date.UTC(2024, 0, 1, 3, 0, 0);
+  const streamSchema = {
+    fields: [
+      { name: 'timestamp', type: 'timestamp' },
+      { name: 'sensor_id', type: 'string' },
+      { name: 'reading', type: 'double' }
+    ]
+  } as const;
+  const streamPartitionKey = {
+    key: { window: iso(streamBaseTime) },
+    attributes: { source: 'stream' }
+  } as const;
+  const streamQueryRange = {
+    start: iso(streamBaseTime - 5 * 60 * 1000),
+    end: iso(streamBaseTime + 90 * 60 * 1000)
+  };
+
+  const makeStreamRow = (offsetMinutes: number, sensor: string): Record<string, unknown> => ({
+    timestamp: iso(streamBaseTime + offsetMinutes * 60_000),
+    sensor_id: sensor,
+    reading: 20 + offsetMinutes / 20
+  });
+
+  const streamChunk1 = [0, 6, 12].map((offset, index) =>
+    makeStreamRow(offset, index % 2 === 0 ? 'delta' : 'echo')
+  );
+  const streamChunk2 = [18, 24, 30, 36].map((offset, index) =>
+    makeStreamRow(offset, index % 2 === 0 ? 'delta' : 'echo')
+  );
+  const streamChunk3 = [42, 48].map((offset, index) =>
+    makeStreamRow(offset, index % 2 === 0 ? 'delta' : 'echo')
+  );
+  const hotBufferInserts = [
+    makeStreamRow(54, 'delta'),
+    makeStreamRow(60, 'foxtrot')
+  ];
+
+  const allStreamRows: Record<string, unknown>[] = [];
+
+  async function ingestStreamRows(rows: Record<string, unknown>[], label: string) {
+    const timeRange = {
+      start: String(rows[0]?.timestamp ?? iso(streamBaseTime)),
+      end: String(rows[rows.length - 1]?.timestamp ?? iso(streamBaseTime))
+    };
+    const idempotencyKey = `${label}-${randomUUID()}`;
+    log(`ingesting ${rows.length} rows (${label}) into ${streamSlug}`);
+    await client.ingestDataset(streamSlug, {
+      datasetName: 'E2E Streaming Dataset',
+      tableName: 'stream_measurements',
+      schema: streamSchema,
+      partition: {
+        ...streamPartitionKey,
+        timeRange
+      },
+      rows,
+      idempotencyKey
+    });
+    allStreamRows.push(...rows);
+  }
+
+  await ingestStreamRows(streamChunk1, 'stream-stage-1');
+  const streamStage1Query = await waitForQueryRows(
+    client,
+    streamSlug,
+    {
+      timeRange: streamQueryRange,
+      timestampColumn: 'timestamp'
+    },
+    allStreamRows.length,
+    { label: `${streamSlug}-staging`, log }
+  );
+  assertRowsInclude(streamStage1Query.rows, allStreamRows, `${streamSlug}-staging`);
+  const manifestStreamStage1 = await client.getDatasetManifest(streamSlug);
+  assert.equal(countPublishedPartitions(manifestStreamStage1), 0);
+  assert.equal(
+    manifestStagingRows(manifestStreamStage1),
+    allStreamRows.length,
+    'stream staging rows should equal ingested rows before flush'
+  );
+
+  await ingestStreamRows(streamChunk2, 'stream-stage-2');
+  const streamAfterFlushQuery = await waitForQueryRows(
+    client,
+    streamSlug,
+    {
+      timeRange: streamQueryRange,
+      timestampColumn: 'timestamp'
+    },
+    allStreamRows.length,
+    { label: `${streamSlug}-post-flush`, log }
+  );
+  assertRowsInclude(streamAfterFlushQuery.rows, allStreamRows, `${streamSlug}-post-flush`);
+
+  await waitForManifestCondition(
+    client,
+    streamSlug,
+    (manifest) => countPublishedPartitions(manifest) > 0 && manifestStagingRows(manifest) === 0,
+    { label: `${streamSlug}-flush`, log }
+  );
+
+  await ingestStreamRows(streamChunk3, 'stream-stage-3');
+  const streamWithFreshStagingQuery = await waitForQueryRows(
+    client,
+    streamSlug,
+    {
+      timeRange: streamQueryRange,
+      timestampColumn: 'timestamp'
+    },
+    allStreamRows.length,
+    { label: `${streamSlug}-mixed`, log }
+  );
+  assertRowsInclude(streamWithFreshStagingQuery.rows, allStreamRows, `${streamSlug}-mixed`);
+
+  await waitForManifestCondition(
+    client,
+    streamSlug,
+    (manifest) =>
+      countPublishedPartitions(manifest) > 0 && manifestStagingRows(manifest) >= streamChunk3.length,
+    { label: `${streamSlug}-mixed-manifest`, log }
+  );
+
+  log(`injecting ${hotBufferInserts.length} rows into hot buffer for ${streamSlug}`);
+  await client.updateHotBuffer(streamSlug, {
+    watermark: iso(streamBaseTime + 70 * 60 * 1000),
+    rows: hotBufferInserts.map((row) => ({
+      timestamp: String(row.timestamp),
+      payload: row
+    }))
+  });
+
+  const streamExpectedWithHotBuffer = [...allStreamRows, ...hotBufferInserts];
+  const streamFinalQuery = await waitForQueryRows(
+    client,
+    streamSlug,
+    {
+      timeRange: streamQueryRange,
+      timestampColumn: 'timestamp'
+    },
+    streamExpectedWithHotBuffer.length,
+    { label: `${streamSlug}-with-hot-buffer`, log }
+  );
+  assertRowsInclude(streamFinalQuery.rows, streamExpectedWithHotBuffer, `${streamSlug}-with-hot-buffer`);
+  assert.ok(streamFinalQuery.streaming, 'streaming metadata should be populated');
+  assert.equal((streamFinalQuery.streaming as Record<string, unknown>)?.bufferState, 'ready');
+
+  // SQL visibility for streaming datasets should include base ingestion (parquet + staging).
+  const streamView = buildViewName(streamSlug);
+  await waitForSqlCount(client, streamView, allStreamRows.length, { log });
+
+  // Schema discovery should expose both datasets.
+  const schemaSnapshot = await client.getSqlSchema();
+  const tableNames = schemaSnapshot.tables.map((table) => table.name);
+  assert.ok(tableNames.includes(batchView), `expected ${batchView} in SQL schema`);
+  assert.ok(tableNames.includes(streamView), `expected ${streamView} in SQL schema`);
+
+  const logOutput = await stack.collectLogs({ since: startedAt }).catch(() => '');
+  if (logOutput) {
+    const logAnalysis = analyzeLogs(logOutput);
+    assert.equal(logAnalysis.errors.length, 0, `stack errors detected: ${logAnalysis.errors.join('\n')}`);
+
+    const logsDir = path.resolve(process.cwd(), 'logs');
+    await fs.mkdir(logsDir, { recursive: true });
+    const logPath = path.join(logsDir, `timestore-e2e-${TEST_ID}.log`);
+    await fs.writeFile(logPath, logOutput, 'utf8');
+  }
+});


### PR DESCRIPTION
## Summary
- union staged DuckDB batches with published partitions so dataset/query/sql responses include freshly ingested rows
- surface staging metadata via the admin manifest API and the new hot-buffer test harness route to control streaming fixtures
- add timestore e2e coverage and stack wiring (compose env, npm script, client helpers) to exercise staging + streaming flows

## Testing
- npm run lint -- tests/e2e/timestore.e2e.ts *(fails: workspace lint targets treat the extra path as a project and exit with TS5083)*
- docker compose -p apphub-observatory-e2e up ... && curl timestore ingest/query *(staging reads verified; flush hang captured in #199)*

## Follow-up
- #199
