### PR TITLE
fix: align dashboard workflow provisioning

### DIFF
--- a/services/core/src/assetMaterializerWorker.ts
+++ b/services/core/src/assetMaterializerWorker.ts
@@ -803,6 +803,11 @@ export class AssetMaterializer {
       if (!producedConfig) {
         return;
       }
+      if (!producedConfig.policy) {
+        // This asset does not opt-in to automated refreshes (including expiry).
+        // Emit the expiry event, but skip enqueueing the producing workflow again.
+        return;
+      }
       const assetKey = this.buildAssetKey(workflowId, payload.assetId);
       const partitionMap = this.latestAssets.get(assetKey);
       if (partitionMap) {


### PR DESCRIPTION
## Summary
- merge module manifest schedules/triggers into workflow provisioning when customization skips them
- accept string inputs for dashboard lookback minutes and fall back to configured defaults
- skip auto-refresh enqueue when produced assets disable policies via module configuration

## Testing
- not run (not requested)
