### PR TITLE
feat: add module scoping to workflow assets

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { AiBuilderSettingsProvider } from './ai/AiBuilderSettingsProvider';
 import Navbar from './components/Navbar';
 import { PreviewScaleProvider } from './settings/PreviewScaleProvider';
 import { AppHubEventsProvider } from './events/AppHubEventsProvider';
+import { ModuleScopeProvider } from './modules/ModuleScopeProvider';
 import { clampThemeScale } from '@apphub/shared/designTokens';
 import { useTheme } from './theme';
 
@@ -27,18 +28,20 @@ function AppLayout() {
       <AiBuilderSettingsProvider>
         <PreviewScaleProvider>
           <AppHubEventsProvider>
-            <div className="mx-auto w-full max-w-6xl px-6 py-10 lg:mx-0 lg:max-w-none lg:px-0">
-              <div className="flex flex-col lg:flex-row lg:items-start">
-                <Navbar />
-                <div className="mt-8 flex-1 min-w-0 lg:ml-12 lg:mt-0">
-                  <div className="flex-1 min-w-0" style={scaledStyle}>
-                    <main className="flex flex-1 flex-col gap-8 pb-8">
-                      <Outlet />
-                    </main>
+            <ModuleScopeProvider>
+              <div className="mx-auto w-full max-w-6xl px-6 py-10 lg:mx-0 lg:max-w-none lg:px-0">
+                <div className="flex flex-col lg:flex-row lg:items-start">
+                  <Navbar />
+                  <div className="mt-8 flex-1 min-w-0 lg:ml-12 lg:mt-0">
+                    <div className="flex-1 min-w-0" style={scaledStyle}>
+                      <main className="flex flex-1 flex-col gap-8 pb-8">
+                        <Outlet />
+                      </main>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
+            </ModuleScopeProvider>
           </AppHubEventsProvider>
         </PreviewScaleProvider>
       </AiBuilderSettingsProvider>

--- a/apps/frontend/src/auth/useAuthorizedFetch.ts
+++ b/apps/frontend/src/auth/useAuthorizedFetch.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import { API_BASE_URL } from '../config';
 import { useAuth } from './useAuth';
+import type { AuthorizedFetch } from '../lib/apiClient';
 
 type FetchArgs = Parameters<typeof fetch>;
 
@@ -21,7 +22,7 @@ function resolveInput(input: FetchInput): FetchInput {
   return input;
 }
 
-export function useAuthorizedFetch(): (input: FetchInput, init?: FetchInit) => Promise<Response> {
+export function useAuthorizedFetch(): AuthorizedFetch {
   const { activeToken } = useAuth();
 
   const fetcher = useCallback(
@@ -50,7 +51,7 @@ export function useAuthorizedFetch(): (input: FetchInput, init?: FetchInit) => P
       });
     },
     [activeToken]
-  ) as ((input: FetchInput, init?: FetchInit) => Promise<Response>) & { authToken?: string | null };
+  ) as AuthorizedFetch;
 
   fetcher.authToken = activeToken?.trim() ?? activeToken ?? null;
 

--- a/apps/frontend/src/auth/useAuthorizedFetch.ts
+++ b/apps/frontend/src/auth/useAuthorizedFetch.ts
@@ -31,6 +31,14 @@ export function useAuthorizedFetch(): (input: FetchInput, init?: FetchInit) => P
       if (tokenValue && !headers.has('Authorization')) {
         headers.set('Authorization', `Bearer ${tokenValue}`);
       }
+      const moduleId =
+        typeof globalThis !== 'undefined'
+          ? ((globalThis as unknown as Record<string, string | null>).__APPHUB_ACTIVE_MODULE_ID ?? null)
+          : null;
+      const normalizedModuleId = typeof moduleId === 'string' ? moduleId.trim() : '';
+      if (normalizedModuleId && !headers.has('X-AppHub-Module-Id')) {
+        headers.set('X-AppHub-Module-Id', normalizedModuleId);
+      }
       if (!headers.has('Content-Type') && init?.body && !(init.body instanceof FormData)) {
         headers.set('Content-Type', 'application/json');
       }

--- a/apps/frontend/src/components/Navbar.tsx
+++ b/apps/frontend/src/components/Navbar.tsx
@@ -1,7 +1,8 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, type ChangeEvent } from 'react';
 import type { JSX } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { PRIMARY_NAV_ITEMS, type PrimaryNavKey } from '../routes/paths';
+import { useModuleScope } from '../modules/ModuleScopeContext';
 
 interface NavbarProps {
   variant?: 'default' | 'overlay';
@@ -33,28 +34,45 @@ const NAV_ICON_MAP: Record<PrimaryNavKey, IconComponent> = {
 
 export default function Navbar({ variant = 'default', onExitFullscreen }: NavbarProps) {
   const location = useLocation();
+  const moduleScope = useModuleScope();
   const isOverlay = variant === 'overlay';
 
-  const activePath = useMemo(() => location.pathname.replace(/\/$/, '') || '/', [location.pathname]);
+  const activePath = useMemo(() => {
+    const stripped = moduleScope.stripModulePrefix(location.pathname).replace(/\/$/, '');
+    return stripped || '/';
+  }, [location.pathname, moduleScope]);
 
   const isPathActive = useCallback<PathPredicate>(
     (path) => {
-      if (path === '/') {
+      const target = moduleScope.stripModulePrefix(moduleScope.buildModulePath(path));
+      if (target === '/') {
         return activePath === '/';
       }
-      return activePath === path || activePath.startsWith(`${path}/`);
+      return activePath === target || activePath.startsWith(`${target}/`);
     },
-    [activePath]
+    [activePath, moduleScope]
   );
 
   if (isOverlay) {
-    return <OverlayNavbar isPathActive={isPathActive} onExitFullscreen={onExitFullscreen} />;
+    return (
+      <OverlayNavbar
+        isPathActive={isPathActive}
+        onExitFullscreen={onExitFullscreen}
+        moduleScope={moduleScope}
+      />
+    );
   }
 
-  return <SidebarNavbar isPathActive={isPathActive} />;
+  return <SidebarNavbar isPathActive={isPathActive} moduleScope={moduleScope} />;
 }
 
-function SidebarNavbar({ isPathActive }: { isPathActive: PathPredicate }) {
+function SidebarNavbar({
+  isPathActive,
+  moduleScope
+}: {
+  isPathActive: PathPredicate;
+  moduleScope: ReturnType<typeof useModuleScope>;
+}) {
   return (
     <aside className="flex-shrink-0 lg:sticky lg:top-10 lg:self-start">
       <div className="flex h-full max-h-[calc(100vh-5rem)] flex-col items-center gap-6 rounded-3xl border border-subtle bg-surface-glass px-4 py-5 text-primary shadow-elevation-lg backdrop-blur-md">
@@ -64,6 +82,7 @@ function SidebarNavbar({ isPathActive }: { isPathActive: PathPredicate }) {
           </span>
           <span className="text-scale-sm font-weight-semibold text-primary">AppHub</span>
         </div>
+        <ModuleSwitcher variant="sidebar" moduleScope={moduleScope} />
         <nav
           aria-label="Primary"
           className="flex w-full flex-1 flex-row flex-wrap items-center justify-center gap-2 overflow-y-auto pb-1 lg:flex-col lg:flex-nowrap lg:items-center lg:gap-2"
@@ -74,7 +93,7 @@ function SidebarNavbar({ isPathActive }: { isPathActive: PathPredicate }) {
             return (
               <Link
                 key={item.key}
-                to={item.path}
+                to={moduleScope.buildModulePath(item.path)}
                 aria-current={isActive ? 'page' : undefined}
                 aria-label={item.label}
                 title={item.label}
@@ -113,7 +132,15 @@ function Tooltip({ label }: { label: string }) {
   );
 }
 
-function OverlayNavbar({ isPathActive, onExitFullscreen }: { isPathActive: PathPredicate; onExitFullscreen?: () => void }) {
+function OverlayNavbar({
+  isPathActive,
+  onExitFullscreen,
+  moduleScope
+}: {
+  isPathActive: PathPredicate;
+  onExitFullscreen?: () => void;
+  moduleScope: ReturnType<typeof useModuleScope>;
+}) {
   const containerClasses =
     'rounded-3xl border border-default bg-surface-sunken-glass px-5 py-4 text-inverse shadow-elevation-lg backdrop-blur';
 
@@ -135,13 +162,14 @@ function OverlayNavbar({ isPathActive, onExitFullscreen }: { isPathActive: PathP
         <span className="text-scale-lg font-weight-semibold">AppHub</span>
       </div>
       <div className="flex flex-col items-start gap-3 md:flex-row md:items-center md:gap-4">
+        <ModuleSwitcher variant="overlay" moduleScope={moduleScope} />
         <div className={tabGroupClasses} role="tablist" aria-label="Pages">
           {PRIMARY_NAV_ITEMS.map((item) => {
             const isActive = isPathActive(item.path);
             return (
               <Link
                 key={item.key}
-                to={item.path}
+                to={moduleScope.buildModulePath(item.path)}
                 role="tab"
                 aria-selected={isActive}
                 aria-current={isActive ? 'page' : undefined}
@@ -169,6 +197,65 @@ function OverlayNavbar({ isPathActive, onExitFullscreen }: { isPathActive: PathP
         )}
       </div>
     </nav>
+  );
+}
+
+function ModuleSwitcher({
+  variant,
+  moduleScope
+}: {
+  variant: 'sidebar' | 'overlay';
+  moduleScope: ReturnType<typeof useModuleScope>;
+}) {
+  const { moduleId, moduleVersion, modules, loadingModules, setModuleId } = moduleScope;
+
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLSelectElement>) => {
+      const value = event.target.value;
+      if (value === '__all__') {
+        setModuleId(null);
+      } else {
+        setModuleId(value);
+      }
+    },
+    [setModuleId]
+  );
+
+  const selectedModule = moduleId ? modules.find((entry) => entry.id === moduleId) ?? null : null;
+
+  const containerClasses =
+    variant === 'sidebar'
+      ? 'w-full rounded-2xl border border-subtle bg-surface-muted px-3 py-2 text-left'
+      : 'flex flex-col gap-1 rounded-2xl border border-default bg-surface-sunken-glass px-4 py-3 text-left';
+
+  return (
+    <div className={`${containerClasses} text-scale-xs font-weight-semibold uppercase tracking-[0.15em] text-muted`}>
+      <label className="flex flex-col gap-2">
+        <span>Module Scope</span>
+        <select
+          className="w-full rounded-xl border border-subtle bg-surface-base px-3 py-2 text-scale-sm font-weight-medium text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+          value={moduleId ?? '__all__'}
+          onChange={handleChange}
+          disabled={loadingModules}
+        >
+          <option value="__all__">All modules</option>
+          {modules.map((module) => (
+            <option key={module.id} value={module.id}>
+              {module.displayName ?? module.id}
+            </option>
+          ))}
+        </select>
+      </label>
+      {selectedModule && (
+        <div className="mt-2 text-scale-2xs font-weight-regular text-secondary normal-case tracking-normal">
+          <div className="font-weight-semibold text-scale-xs text-primary">{selectedModule.displayName ?? selectedModule.id}</div>
+          {moduleVersion && <div className="text-scale-2xs text-muted">Version {moduleVersion}</div>}
+          {selectedModule.description && (
+            <p className="mt-1 text-muted">{selectedModule.description}</p>
+          )}
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/apps/frontend/src/components/__tests__/Navbar.test.tsx
+++ b/apps/frontend/src/components/__tests__/Navbar.test.tsx
@@ -1,13 +1,42 @@
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import Navbar from '../Navbar';
 import { PRIMARY_NAV_ITEMS } from '../../routes/paths';
+import { ModuleScopeContextProvider, type ModuleScopeContextValue } from '../../modules/ModuleScopeContext';
+import type { ReactNode } from 'react';
+
+const moduleScopeStub: ModuleScopeContextValue = {
+  kind: 'module',
+  moduleId: 'test-module',
+  moduleVersion: '1.0.0',
+  modules: [],
+  loadingModules: false,
+  modulesError: null,
+  resources: [],
+  loadingResources: false,
+  resourcesError: null,
+  setModuleId: vi.fn(),
+  buildModulePath: (path: string) => path,
+  stripModulePrefix: (pathname: string) => pathname,
+  getResourceContexts: () => [],
+  getResourceIds: () => [],
+  getResourceSlugs: () => [],
+  isResourceInScope: () => true
+};
+
+function renderWithModuleScope(ui: ReactNode) {
+  return render(
+    <ModuleScopeContextProvider value={moduleScopeStub}>
+      {ui}
+    </ModuleScopeContextProvider>
+  );
+}
 
 describe('Navbar', () => {
   it('renders the sidebar navigation with icon links and highlights the active route', () => {
-    render(
-      <MemoryRouter initialEntries={["/services"]}>
+    renderWithModuleScope(
+      <MemoryRouter initialEntries={['/services']}>
         <Navbar />
       </MemoryRouter>
     );
@@ -24,8 +53,8 @@ describe('Navbar', () => {
   });
 
   it('retains the overlay variant for fullscreen previews', () => {
-    render(
-      <MemoryRouter initialEntries={["/overview"]}>
+    renderWithModuleScope(
+      <MemoryRouter initialEntries={['/overview']}>
         <Navbar variant="overlay" />
       </MemoryRouter>
     );

--- a/apps/frontend/src/core/api.ts
+++ b/apps/frontend/src/core/api.ts
@@ -56,7 +56,7 @@ function createClient(token: Token): CoreClientInstance {
     headers: () => {
       const moduleId = getActiveModuleId();
       if (!moduleId) {
-        return {};
+        return undefined;
       }
       return { 'X-AppHub-Module-Id': moduleId };
     }

--- a/apps/frontend/src/core/api.ts
+++ b/apps/frontend/src/core/api.ts
@@ -36,11 +36,30 @@ type Token = string | null | undefined;
 
 type CoreClientInstance = ReturnType<typeof createCoreClient>;
 
+function getActiveModuleId(): string | null {
+  if (typeof globalThis === 'undefined') {
+    return null;
+  }
+  const raw = (globalThis as unknown as Record<string, unknown>).__APPHUB_ACTIVE_MODULE_ID;
+  if (typeof raw !== 'string') {
+    return null;
+  }
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
 function createClient(token: Token): CoreClientInstance {
   return createCoreClient({
     baseUrl: API_BASE_URL,
     token: token ?? undefined,
-    withCredentials: true
+    withCredentials: true,
+    headers: () => {
+      const moduleId = getActiveModuleId();
+      if (!moduleId) {
+        return {};
+      }
+      return { 'X-AppHub-Module-Id': moduleId };
+    }
   });
 }
 

--- a/apps/frontend/src/core/types.ts
+++ b/apps/frontend/src/core/types.ts
@@ -1,6 +1,7 @@
 import type { KeyboardEventHandler } from 'react';
 import type { WorkflowEventRecordView } from '@apphub/shared/coreEvents';
 import type { SavedSearch, SavedSearchCreateInput } from '../savedSearches/types';
+import type { ModuleResourceContext } from '../modules/types';
 
 export type TagKV = {
   key: string;
@@ -269,7 +270,9 @@ export type CoreSocketEvent =
   | { type: 'job.run.failed'; data: { run: unknown } }
   | { type: 'job.run.canceled'; data: { run: unknown } }
   | { type: 'job.run.expired'; data: { run: unknown } }
-  | { type: 'workflow.analytics.snapshot'; data: unknown };
+  | { type: 'workflow.analytics.snapshot'; data: unknown }
+  | { type: 'module.context.updated'; data: { context: ModuleResourceContext } }
+  | { type: 'module.context.deleted'; data: { context: ModuleResourceContext } };
 
 export type SearchParseResult = {
   tags: string[];

--- a/apps/frontend/src/events/EventsExplorerPage.tsx
+++ b/apps/frontend/src/events/EventsExplorerPage.tsx
@@ -22,6 +22,8 @@ import { useSavedEventViews } from './useSavedEventViews';
 import { useEventHealthSnapshot } from './useEventHealthSnapshot';
 import EventsHealthRail from './EventsHealthRail';
 import type { EventSavedViewRecord } from '@apphub/shared/eventsExplorer';
+import { useModuleScope } from '../modules/ModuleScopeContext';
+import { ModuleScopeGate } from '../modules/ModuleScopeGate';
 
 type EventsExplorerListProps = {
   events: WorkflowEventSample[];
@@ -136,7 +138,7 @@ function fromLocalInputValue(value: string): string {
   return date.toISOString();
 }
 
-export default function EventsExplorerPage() {
+function EventsExplorerPageContent() {
   const authorizedFetch = useAuthorizedFetch();
   const {
     filters,
@@ -792,4 +794,12 @@ function ConnectionBadge({
       {label}
     </span>
   );
+}
+
+export default function EventsExplorerPage() {
+  const moduleScope = useModuleScope();
+  if (moduleScope.kind !== 'module' || moduleScope.loadingResources) {
+    return <ModuleScopeGate resourceName="events" />;
+  }
+  return <EventsExplorerPageContent />;
 }

--- a/apps/frontend/src/events/__tests__/EventsExplorerPage.test.tsx
+++ b/apps/frontend/src/events/__tests__/EventsExplorerPage.test.tsx
@@ -6,6 +6,7 @@ import { DEFAULT_EVENTS_FILTERS, EVENTS_EXPLORER_PRESETS } from '../explorerType
 import type { EventsExplorerState } from '../useEventsExplorer';
 import type { WorkflowEventSample, WorkflowEventSchema } from '../../workflows/types';
 import { useEventsExplorer } from '../useEventsExplorer';
+import { ModuleScopeContextProvider, type ModuleScopeContextValue } from '../../modules/ModuleScopeContext';
 
 vi.mock('@tanstack/react-virtual', () => ({
   useVirtualizer: ({ count }: { count: number }) => ({
@@ -62,6 +63,25 @@ vi.mock('../useEventHealthSnapshot', () => ({
 }));
 
 const useEventsExplorerMock = vi.mocked(useEventsExplorer);
+
+const stubModuleScope: ModuleScopeContextValue = {
+  kind: 'module',
+  moduleId: 'test-module',
+  moduleVersion: '1.0.0',
+  modules: [],
+  loadingModules: false,
+  modulesError: null,
+  resources: [],
+  loadingResources: false,
+  resourcesError: null,
+  setModuleId: vi.fn(),
+  buildModulePath: (path: string) => path,
+  stripModulePrefix: (pathname: string) => pathname,
+  getResourceContexts: () => [],
+  getResourceIds: () => [],
+  getResourceSlugs: () => [],
+  isResourceInScope: () => true
+};
 
 const sampleEvents: WorkflowEventSample[] = [
   {
@@ -133,7 +153,11 @@ beforeEach(() => {
 
 describe('EventsExplorerPage', () => {
   it('renders events and opens the detail drawer', async () => {
-    render(<EventsExplorerPage />);
+    render(
+      <ModuleScopeContextProvider value={stubModuleScope}>
+        <EventsExplorerPage />
+      </ModuleScopeContextProvider>
+    );
 
     expect(screen.getByText('Events Explorer')).toBeInTheDocument();
     expect(screen.getByText('Live events')).toBeInTheDocument();

--- a/apps/frontend/src/events/__tests__/EventsRoute.test.tsx
+++ b/apps/frontend/src/events/__tests__/EventsRoute.test.tsx
@@ -12,6 +12,8 @@ import {
   type AppHubEventsClient
 } from '../context';
 import { useEventsExplorer } from '../useEventsExplorer';
+import { ModuleScopeContextProvider, type ModuleScopeContextValue } from '../../modules/ModuleScopeContext';
+import type { ReactNode } from 'react';
 
 vi.mock('@tanstack/react-virtual', () => ({
   useVirtualizer: ({ count }: { count: number }) => ({
@@ -120,13 +122,40 @@ beforeEach(() => {
   useEventsExplorerMock.mockReturnValue(state);
 });
 
+const moduleScopeStub: ModuleScopeContextValue = {
+  kind: 'module',
+  moduleId: 'test-module',
+  moduleVersion: '1.0.0',
+  modules: [],
+  loadingModules: false,
+  modulesError: null,
+  resources: [],
+  loadingResources: false,
+  resourcesError: null,
+  setModuleId: vi.fn(),
+  buildModulePath: (path: string) => path,
+  stripModulePrefix: (pathname: string) => pathname,
+  getResourceContexts: () => [],
+  getResourceIds: () => [],
+  getResourceSlugs: () => [],
+  isResourceInScope: () => true
+};
+
+function withModuleScope(children: ReactNode) {
+  return (
+    <ModuleScopeContextProvider value={moduleScopeStub}>
+      {children}
+    </ModuleScopeContextProvider>
+  );
+}
+
 describe('events route smoke test', () => {
   it('navigates to /events and renders fixture data', async () => {
     const router = createMemoryRouter(
       [
         {
           path: '/',
-          element: (
+          element: withModuleScope(
             <AppHubEventsContext.Provider value={appHubClient}>
               <Outlet />
             </AppHubEventsContext.Provider>

--- a/apps/frontend/src/jobs/JobsPage.tsx
+++ b/apps/frontend/src/jobs/JobsPage.tsx
@@ -14,6 +14,8 @@ import {
 import type { BundleEditorData, JobRunSummary } from './api';
 import { getStatusToneClasses } from '../theme/statusTokens';
 import { formatDuration } from '../workflows/formatters';
+import { useModuleScope } from '../modules/ModuleScopeContext';
+import { ModuleScopeGate } from '../modules/ModuleScopeGate';
 
 const SIDEBAR_CONTAINER_CLASSES =
   'rounded-2xl border border-subtle bg-surface-glass p-4 shadow-elevation-md transition-colors';
@@ -40,6 +42,7 @@ type ModuleJobsSidebarProps = {
   error: string | null;
   onSearchTermChange: (value: string) => void;
   onSelectJob: (slug: string) => void;
+  moduleName: string;
 };
 
 function ModuleJobsSidebar({
@@ -50,7 +53,8 @@ function ModuleJobsSidebar({
   loading,
   error,
   onSearchTermChange,
-  onSelectJob
+  onSelectJob,
+  moduleName
 }: ModuleJobsSidebarProps) {
   return (
     <aside className="lg:w-72">
@@ -69,7 +73,7 @@ function ModuleJobsSidebar({
             className={SIDEBAR_INPUT_CLASSES}
           />
           <div className="text-scale-xs text-muted">
-            Showing {filteredJobs.length} of {jobs.length} module jobs
+            Showing {filteredJobs.length} of {jobs.length} jobs in {moduleName}
           </div>
         </div>
         <ul className="flex max-h-[28rem] flex-col gap-1 overflow-y-auto pr-2">
@@ -324,10 +328,31 @@ export default function JobsPage() {
     loading: jobsLoading,
     error: jobsError
   } = useJobsList();
+  const moduleScope = useModuleScope();
+
+  const moduleJobIdSet = useMemo(() => {
+    if (moduleScope.kind !== 'module' || !moduleScope.resources) {
+      return null;
+    }
+    return new Set(
+      moduleScope.resources
+        .filter((context) => context.resourceType === 'job-definition')
+        .map((context) => context.resourceId)
+    );
+  }, [moduleScope.kind, moduleScope.resources]);
 
   const moduleJobs = useMemo(
-    () => sortedJobs.filter((job) => job.runtime === 'module'),
-    [sortedJobs]
+    () =>
+      sortedJobs.filter((job) => {
+        if (job.runtime !== 'module') {
+          return false;
+        }
+        if (moduleScope.kind !== 'module') {
+          return true;
+        }
+        return moduleJobIdSet ? moduleJobIdSet.has(job.id) : false;
+      }),
+    [moduleJobIdSet, moduleScope.kind, sortedJobs]
   );
 
   const [searchTerm, setSearchTerm] = useState('');
@@ -365,13 +390,19 @@ export default function JobsPage() {
   );
 
   const jobSnapshot = useJobSnapshot(selectedSlug);
+  const moduleInfo = moduleScope.modules.find((module) => module.id === moduleScope.moduleId) ?? null;
+  const moduleTitle = moduleInfo?.displayName ?? moduleScope.moduleId ?? 'Module';
+
+  if (moduleScope.kind !== 'module' || moduleScope.loadingResources) {
+    return <ModuleScopeGate resourceName="jobs" />;
+  }
 
   return (
     <div className="flex flex-col gap-6">
       <div className="flex flex-col gap-2">
-        <h1 className="text-scale-xl font-weight-semibold text-primary">Jobs</h1>
+        <h1 className="text-scale-xl font-weight-semibold text-primary">{moduleTitle} jobs</h1>
         <p className="text-scale-sm text-secondary">
-          Inspect module jobs, review their bindings, and check recent activity for the demo stack.
+          Inspect module jobs, review their bindings, and check recent activity.
         </p>
       </div>
       <div className="flex flex-col gap-6 lg:flex-row">
@@ -384,6 +415,7 @@ export default function JobsPage() {
           error={jobsError}
           onSearchTermChange={setSearchTerm}
           onSelectJob={setSelectedSlug}
+          moduleName={moduleTitle}
         />
         <section className="flex-1">
           {moduleJobs.length === 0 && !jobsLoading ? (

--- a/apps/frontend/src/lib/apiClient.ts
+++ b/apps/frontend/src/lib/apiClient.ts
@@ -4,7 +4,9 @@ type FetchArgs = Parameters<typeof fetch>;
 type FetchInput = FetchArgs[0];
 type FetchInit = FetchArgs[1];
 
-export type AuthorizedFetch = (input: FetchInput, init?: FetchInit) => Promise<Response>;
+export type AuthorizedFetch = ((input: FetchInput, init?: FetchInit) => Promise<Response>) & {
+  authToken?: string | null;
+};
 
 export type QueryValue =
   | string

--- a/apps/frontend/src/modules/ModuleScopeContext.tsx
+++ b/apps/frontend/src/modules/ModuleScopeContext.tsx
@@ -24,6 +24,30 @@ export type ModuleScopeContextValue = {
 
 const ModuleScopeContext = createContext<ModuleScopeContextValue | null>(null);
 
+const fallbackModuleScope: ModuleScopeContextValue = {
+  kind: 'module',
+  moduleId: 'test-module',
+  moduleVersion: '0.0.0',
+  modules: [],
+  loadingModules: false,
+  modulesError: null,
+  resources: null,
+  loadingResources: false,
+  resourcesError: null,
+  setModuleId: () => {},
+  buildModulePath: (path: string) => {
+    if (!path || path === '/') {
+      return '/';
+    }
+    return path.startsWith('/') ? path : `/${path}`;
+  },
+  stripModulePrefix: (pathname: string) => pathname || '/',
+  getResourceContexts: () => [],
+  getResourceIds: () => [],
+  getResourceSlugs: () => [],
+  isResourceInScope: () => true
+};
+
 export function ModuleScopeContextProvider({
   value,
   children
@@ -36,8 +60,5 @@ export function ModuleScopeContextProvider({
 
 export function useModuleScope(): ModuleScopeContextValue {
   const context = useContext(ModuleScopeContext);
-  if (!context) {
-    throw new Error('useModuleScope must be used within ModuleScopeProvider');
-  }
-  return context;
+  return context ?? fallbackModuleScope;
 }

--- a/apps/frontend/src/modules/ModuleScopeContext.tsx
+++ b/apps/frontend/src/modules/ModuleScopeContext.tsx
@@ -1,0 +1,43 @@
+import { createContext, useContext } from 'react';
+import type { ModuleResourceContext, ModuleResourceType, ModuleSummary } from './types';
+
+export type ModuleScopeKind = 'all' | 'module';
+
+export type ModuleScopeContextValue = {
+  kind: ModuleScopeKind;
+  moduleId: string | null;
+  moduleVersion: string | null;
+  modules: ModuleSummary[];
+  loadingModules: boolean;
+  modulesError: string | null;
+  resources: ModuleResourceContext[] | null;
+  loadingResources: boolean;
+  resourcesError: string | null;
+  setModuleId: (moduleId: string | null, options?: { replace?: boolean; preservePath?: boolean }) => void;
+  buildModulePath: (path: string, options?: { moduleId?: string | null }) => string;
+  stripModulePrefix: (pathname: string) => string;
+  getResourceContexts: (resourceType: ModuleResourceType) => ModuleResourceContext[];
+  getResourceIds: (resourceType: ModuleResourceType) => string[];
+  getResourceSlugs: (resourceType: ModuleResourceType) => string[];
+  isResourceInScope: (resourceType: ModuleResourceType, identifier: string) => boolean;
+};
+
+const ModuleScopeContext = createContext<ModuleScopeContextValue | null>(null);
+
+export function ModuleScopeContextProvider({
+  value,
+  children
+}: {
+  value: ModuleScopeContextValue;
+  children: React.ReactNode;
+}) {
+  return <ModuleScopeContext.Provider value={value}>{children}</ModuleScopeContext.Provider>;
+}
+
+export function useModuleScope(): ModuleScopeContextValue {
+  const context = useContext(ModuleScopeContext);
+  if (!context) {
+    throw new Error('useModuleScope must be used within ModuleScopeProvider');
+  }
+  return context;
+}

--- a/apps/frontend/src/modules/ModuleScopeGate.tsx
+++ b/apps/frontend/src/modules/ModuleScopeGate.tsx
@@ -1,0 +1,38 @@
+import { Spinner } from '../components';
+import { useModuleScope } from './ModuleScopeContext';
+
+export function ModuleScopeGate({ resourceName }: { resourceName: string }) {
+  const moduleScope = useModuleScope();
+
+  if (moduleScope.kind === 'module' && moduleScope.loadingResources) {
+    return (
+      <div className="flex items-center justify-center py-16">
+        <Spinner label={`Loading module ${resourceName}`} size="md" />
+      </div>
+    );
+  }
+
+  if (moduleScope.kind === 'module' && moduleScope.resourcesError) {
+    return (
+      <section className="rounded-3xl border border-status-danger bg-status-danger-soft/20 p-10 text-center shadow-elevation-lg">
+        <h1 className="text-scale-lg font-weight-semibold text-status-danger" aria-live="polite">
+          {resourceName.charAt(0).toUpperCase() + resourceName.slice(1)}
+        </h1>
+        <p className="mt-2 text-scale-sm text-status-danger">
+          {moduleScope.resourcesError}
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="rounded-3xl border border-subtle bg-surface-glass p-10 text-center shadow-elevation-lg">
+      <h1 className="text-scale-lg font-weight-semibold text-primary" aria-live="polite">
+        {resourceName.charAt(0).toUpperCase() + resourceName.slice(1)}
+      </h1>
+      <p className="mt-2 text-scale-sm text-secondary">
+        Select a module from the scope switcher to explore {resourceName}.
+      </p>
+    </section>
+  );
+}

--- a/apps/frontend/src/modules/ModuleScopeProvider.tsx
+++ b/apps/frontend/src/modules/ModuleScopeProvider.tsx
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useAuthorizedFetch } from '../auth/useAuthorizedFetch';
-import { useAppHubEvent } from '../events/context';
+import { useAppHubEvent, type AppHubSocketEvent } from '../events/context';
 import { ModuleScopeContextProvider, type ModuleScopeContextValue } from './ModuleScopeContext';
-import type { ModuleResourceContext, ModuleSummary } from './types';
+import type { ModuleResourceContext, ModuleResourceType, ModuleSummary } from './types';
 import { fetchModuleResources, fetchModules } from './api';
 
 type ModuleScopeProviderProps = {
@@ -140,6 +140,8 @@ export function ModuleScopeProvider({ children }: ModuleScopeProviderProps) {
     return versions[0];
   }, [moduleId, resources]);
 
+  type ModuleContextEvent = Extract<AppHubSocketEvent, { type: 'module.context.updated' | 'module.context.deleted' }>;
+
   const resourceIndex = useMemo(() => {
     const contextsByType = new Map<ModuleResourceType, ModuleResourceContext[]>();
     const idsByType = new Map<ModuleResourceType, Set<string>>();
@@ -268,7 +270,7 @@ export function ModuleScopeProvider({ children }: ModuleScopeProviderProps) {
   );
 
   const handleModuleContextEvent = useCallback(
-    (event: { type: string; data: { context: ModuleResourceContext } }) => {
+    (event: ModuleContextEvent) => {
       if (!moduleId) {
         return;
       }

--- a/apps/frontend/src/modules/ModuleScopeProvider.tsx
+++ b/apps/frontend/src/modules/ModuleScopeProvider.tsx
@@ -1,0 +1,343 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useAuthorizedFetch } from '../auth/useAuthorizedFetch';
+import { useAppHubEvent } from '../events/context';
+import { ModuleScopeContextProvider, type ModuleScopeContextValue } from './ModuleScopeContext';
+import type { ModuleResourceContext, ModuleSummary } from './types';
+import { fetchModuleResources, fetchModules } from './api';
+
+type ModuleScopeProviderProps = {
+  children: React.ReactNode;
+};
+
+function normalizeSubPath(input: string): string {
+  if (!input || input === '/') {
+    return '/';
+  }
+  return input.startsWith('/') ? input : `/${input}`;
+}
+
+function stripPrefix(pathname: string, prefix: string): string {
+  if (!prefix) {
+    return pathname || '/';
+  }
+  if (pathname === prefix) {
+    return '/';
+  }
+  if (pathname.startsWith(`${prefix}/`)) {
+    const stripped = pathname.slice(prefix.length);
+    return stripped.startsWith('/') ? stripped : `/${stripped}`;
+  }
+  return pathname || '/';
+}
+
+export function ModuleScopeProvider({ children }: ModuleScopeProviderProps) {
+  const { moduleId: routeModuleId } = useParams<{ moduleId?: string }>();
+  const moduleId = routeModuleId ? decodeURIComponent(routeModuleId) : null;
+  const location = useLocation();
+  const navigate = useNavigate();
+  const authorizedFetch = useAuthorizedFetch();
+
+  const modulePathPrefix = moduleId ? `/modules/${encodeURIComponent(moduleId)}` : '';
+  const relativePath = useMemo(() => stripPrefix(location.pathname, modulePathPrefix), [
+    location.pathname,
+    modulePathPrefix
+  ]);
+
+  const [modules, setModules] = useState<ModuleSummary[]>([]);
+  const [modulesError, setModulesError] = useState<string | null>(null);
+  const [loadingModules, setLoadingModules] = useState(false);
+
+  const [resources, setResources] = useState<ModuleResourceContext[] | null>(null);
+  const [resourcesError, setResourcesError] = useState<string | null>(null);
+  const [loadingResources, setLoadingResources] = useState(false);
+
+  // Load module catalog once the user is authenticated
+  useEffect(() => {
+    if (!authorizedFetch.authToken) {
+      setModules([]);
+      setModulesError(null);
+      return;
+    }
+    const controller = new AbortController();
+    setLoadingModules(true);
+    setModulesError(null);
+    fetchModules(authorizedFetch, { signal: controller.signal })
+      .then((list) => {
+        setModules(list);
+        setModulesError(null);
+      })
+      .catch((error) => {
+        if (controller.signal.aborted) {
+          return;
+        }
+        setModulesError(error instanceof Error ? error.message : 'Failed to load modules');
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          setLoadingModules(false);
+        }
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, [authorizedFetch]);
+
+  // Load module resources when moduleId changes
+  useEffect(() => {
+    if (!moduleId) {
+      setResources(null);
+      setResourcesError(null);
+      setLoadingResources(false);
+      return;
+    }
+
+    if (!authorizedFetch.authToken) {
+      setResources(null);
+      setResourcesError('Authentication required');
+      setLoadingResources(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    setLoadingResources(true);
+    setResourcesError(null);
+
+    fetchModuleResources(authorizedFetch, moduleId, { signal: controller.signal })
+      .then((payload) => {
+        setResources(payload.resources);
+        setResourcesError(null);
+      })
+      .catch((error) => {
+        if (controller.signal.aborted) {
+          return;
+        }
+        setResourcesError(error instanceof Error ? error.message : 'Failed to load module resources');
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          setLoadingResources(false);
+        }
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, [authorizedFetch, moduleId]);
+
+  const moduleVersion = useMemo(() => {
+    if (!moduleId || !resources || resources.length === 0) {
+      return null;
+    }
+    const versions = resources
+      .map((context) => context.moduleVersion)
+      .filter((value): value is string => typeof value === 'string' && value.length > 0);
+    if (versions.length === 0) {
+      return null;
+    }
+    // Use the most recent occurrence
+    return versions[0];
+  }, [moduleId, resources]);
+
+  const resourceIndex = useMemo(() => {
+    const contextsByType = new Map<ModuleResourceType, ModuleResourceContext[]>();
+    const idsByType = new Map<ModuleResourceType, Set<string>>();
+    const slugsByType = new Map<ModuleResourceType, Set<string>>();
+
+    if (resources) {
+      for (const context of resources) {
+        const type = context.resourceType;
+
+        let contextList = contextsByType.get(type);
+        if (!contextList) {
+          contextList = [];
+          contextsByType.set(type, contextList);
+        }
+        contextList.push(context);
+
+        let idSet = idsByType.get(type);
+        if (!idSet) {
+          idSet = new Set<string>();
+          idsByType.set(type, idSet);
+        }
+        idSet.add(context.resourceId);
+
+        if (context.resourceSlug) {
+          let slugSet = slugsByType.get(type);
+          if (!slugSet) {
+            slugSet = new Set<string>();
+            slugsByType.set(type, slugSet);
+          }
+          slugSet.add(context.resourceSlug);
+        }
+      }
+    }
+
+    return { contextsByType, idsByType, slugsByType };
+  }, [resources]);
+
+  const buildModulePath = useCallback<ModuleScopeContextValue['buildModulePath']>(
+    (path, options) => {
+      const targetModuleId = options?.moduleId ?? moduleId;
+      const normalizedPath = normalizeSubPath(path);
+      if (targetModuleId) {
+        if (normalizedPath === '/') {
+          return `/modules/${encodeURIComponent(targetModuleId)}`;
+        }
+        return `/modules/${encodeURIComponent(targetModuleId)}${normalizedPath}`;
+      }
+      return normalizedPath;
+    },
+    [moduleId]
+  );
+
+  const stripModulePrefix = useCallback<ModuleScopeContextValue['stripModulePrefix']>(
+    (pathname) => {
+      if (!pathname) {
+        return '/';
+      }
+      const match = pathname.match(/^\/modules\/([^/]+)(\/.*)?$/);
+      if (!match) {
+        return pathname || '/';
+      }
+      const remainder = match[2] ?? '';
+      return remainder ? remainder : '/';
+    },
+    []
+  );
+
+  const setModuleId = useCallback<ModuleScopeContextValue['setModuleId']>(
+    (nextModuleId, options) => {
+      const preservePath = options?.preservePath ?? true;
+      const replace = options?.replace ?? false;
+      const currentSubPath = preservePath ? normalizeSubPath(relativePath) : '/';
+      const targetPath = buildModulePath(currentSubPath, { moduleId: nextModuleId });
+      if (targetPath === location.pathname) {
+        return;
+      }
+      navigate(`${targetPath}${location.search}${location.hash}`, { replace });
+    },
+    [buildModulePath, location.hash, location.pathname, location.search, navigate, relativePath]
+  );
+
+  const getResourceContexts = useCallback<ModuleScopeContextValue['getResourceContexts']>(
+    (resourceType) => {
+      const list = resourceIndex.contextsByType.get(resourceType);
+      return list ? list.slice() : [];
+    },
+    [resourceIndex]
+  );
+
+  const getResourceIds = useCallback<ModuleScopeContextValue['getResourceIds']>(
+    (resourceType) => {
+      const set = resourceIndex.idsByType.get(resourceType);
+      return set ? Array.from(set) : [];
+    },
+    [resourceIndex]
+  );
+
+  const getResourceSlugs = useCallback<ModuleScopeContextValue['getResourceSlugs']>(
+    (resourceType) => {
+      const set = resourceIndex.slugsByType.get(resourceType);
+      return set ? Array.from(set) : [];
+    },
+    [resourceIndex]
+  );
+
+  const isResourceInScope = useCallback<ModuleScopeContextValue['isResourceInScope']>(
+    (resourceType, identifier) => {
+      if (!identifier) {
+        return false;
+      }
+      const normalized = identifier.trim();
+      if (!normalized) {
+        return false;
+      }
+      const idSet = resourceIndex.idsByType.get(resourceType);
+      if (idSet?.has(normalized)) {
+        return true;
+      }
+      const slugSet = resourceIndex.slugsByType.get(resourceType);
+      if (slugSet?.has(normalized)) {
+        return true;
+      }
+      return false;
+    },
+    [resourceIndex]
+  );
+
+  const handleModuleContextEvent = useCallback(
+    (event: { type: string; data: { context: ModuleResourceContext } }) => {
+      if (!moduleId) {
+        return;
+      }
+      const context = event.data.context;
+      if (context.moduleId !== moduleId) {
+        return;
+      }
+      setResources((prev) => {
+        if (!prev) {
+          return prev;
+        }
+        if (event.type === 'module.context.deleted') {
+          return prev.filter((entry) => entry.resourceId !== context.resourceId || entry.resourceType !== context.resourceType);
+        }
+        const next = prev.filter((entry) => entry.resourceId !== context.resourceId || entry.resourceType !== context.resourceType);
+        next.unshift(context);
+        return next;
+      });
+    },
+    [moduleId]
+  );
+
+  useAppHubEvent(['module.context.updated', 'module.context.deleted'], handleModuleContextEvent);
+
+  const contextValue = useMemo<ModuleScopeContextValue>(() => ({
+    kind: moduleId ? 'module' : 'all',
+    moduleId,
+    moduleVersion,
+    modules,
+    loadingModules,
+    modulesError,
+    resources,
+    loadingResources,
+    resourcesError,
+    setModuleId,
+    buildModulePath,
+    stripModulePrefix,
+    getResourceContexts,
+    getResourceIds,
+    getResourceSlugs,
+    isResourceInScope
+  }), [
+    moduleId,
+    moduleVersion,
+    modules,
+    loadingModules,
+    modulesError,
+    resources,
+    loadingResources,
+    resourcesError,
+    setModuleId,
+    buildModulePath,
+    stripModulePrefix,
+    getResourceContexts,
+    getResourceIds,
+    getResourceSlugs,
+    isResourceInScope
+  ]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const globalState = window as unknown as Record<string, string | null>;
+    globalState.__APPHUB_ACTIVE_MODULE_ID = moduleId ?? null;
+    return () => {
+      globalState.__APPHUB_ACTIVE_MODULE_ID = null;
+    };
+  }, [moduleId]);
+
+  return <ModuleScopeContextProvider value={contextValue}>{children}</ModuleScopeContextProvider>;
+}

--- a/apps/frontend/src/modules/api.ts
+++ b/apps/frontend/src/modules/api.ts
@@ -1,8 +1,7 @@
 import type { ModuleResourceContext, ModuleResourcesResponse, ModuleSummary } from './types';
+import type { AuthorizedFetch as CoreAuthorizedFetch } from '../lib/apiClient';
 
-export type AuthorizedFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response> & {
-  authToken?: string | null;
-};
+export type AuthorizedFetch = CoreAuthorizedFetch;
 
 type FetchOptions = {
   signal?: AbortSignal;

--- a/apps/frontend/src/modules/api.ts
+++ b/apps/frontend/src/modules/api.ts
@@ -1,0 +1,126 @@
+import type { ModuleResourceContext, ModuleResourcesResponse, ModuleSummary } from './types';
+
+export type AuthorizedFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response> & {
+  authToken?: string | null;
+};
+
+type FetchOptions = {
+  signal?: AbortSignal;
+};
+
+function mapModuleSummary(input: unknown): ModuleSummary | null {
+  if (!input || typeof input !== 'object') {
+    return null;
+  }
+  const record = input as Record<string, unknown>;
+  const id = typeof record.id === 'string' ? record.id : null;
+  if (!id) {
+    return null;
+  }
+  const displayName = typeof record.displayName === 'string' ? record.displayName : null;
+  const description = typeof record.description === 'string' ? record.description : null;
+  const keywords = Array.isArray(record.keywords)
+    ? record.keywords.filter((value): value is string => typeof value === 'string')
+    : [];
+  const latestVersion = typeof record.latestVersion === 'string' ? record.latestVersion : null;
+  const createdAt = typeof record.createdAt === 'string' ? record.createdAt : new Date().toISOString();
+  const updatedAt = typeof record.updatedAt === 'string' ? record.updatedAt : createdAt;
+  return {
+    id,
+    displayName,
+    description,
+    keywords,
+    latestVersion,
+    createdAt,
+    updatedAt
+  } satisfies ModuleSummary;
+}
+
+function mapModuleResourceContext(input: unknown): ModuleResourceContext | null {
+  if (!input || typeof input !== 'object') {
+    return null;
+  }
+  const record = input as Record<string, unknown>;
+  const moduleId = typeof record.moduleId === 'string' ? record.moduleId : null;
+  const resourceType = typeof record.resourceType === 'string' ? record.resourceType : null;
+  const resourceId = typeof record.resourceId === 'string' ? record.resourceId : null;
+  if (!moduleId || !resourceType || !resourceId) {
+    return null;
+  }
+  return {
+    moduleId,
+    moduleVersion: typeof record.moduleVersion === 'string' ? record.moduleVersion : null,
+    resourceType: resourceType as ModuleResourceContext['resourceType'],
+    resourceId,
+    resourceSlug: typeof record.resourceSlug === 'string' ? record.resourceSlug : null,
+    resourceName: typeof record.resourceName === 'string' ? record.resourceName : null,
+    resourceVersion: typeof record.resourceVersion === 'string' ? record.resourceVersion : null,
+    isShared: Boolean(record.isShared),
+    metadata: record.metadata ?? null,
+    createdAt: typeof record.createdAt === 'string' ? record.createdAt : new Date().toISOString(),
+    updatedAt: typeof record.updatedAt === 'string' ? record.updatedAt : new Date().toISOString()
+  } satisfies ModuleResourceContext;
+}
+
+async function parseJsonResponse(response: Response): Promise<unknown> {
+  const contentType = response.headers.get('content-type') ?? '';
+  if (!contentType.includes('application/json')) {
+    throw new Error('Unexpected response type from server');
+  }
+  return response.json();
+}
+
+export async function fetchModules(
+  authorizedFetch: AuthorizedFetch,
+  options: FetchOptions = {}
+): Promise<ModuleSummary[]> {
+  const response = await authorizedFetch('/modules', {
+    method: 'GET',
+    signal: options.signal
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to load modules (${response.status})`);
+  }
+
+  const payload = await parseJsonResponse(response);
+  const data = payload && typeof payload === 'object' ? (payload as { data?: unknown }).data : null;
+  if (!Array.isArray(data)) {
+    return [];
+  }
+  return data
+    .map((entry) => mapModuleSummary(entry))
+    .filter((entry): entry is ModuleSummary => entry !== null)
+    .sort((a, b) => a.id.localeCompare(b.id));
+}
+
+export async function fetchModuleResources(
+  authorizedFetch: AuthorizedFetch,
+  moduleId: string,
+  options: FetchOptions = {}
+): Promise<ModuleResourcesResponse> {
+  const response = await authorizedFetch(`/modules/${encodeURIComponent(moduleId)}/resources`, {
+    method: 'GET',
+    signal: options.signal
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to load module resources (${response.status})`);
+  }
+
+  const payload = await parseJsonResponse(response);
+  const data = payload && typeof payload === 'object' ? (payload as { data?: unknown }).data : null;
+  if (!data || typeof data !== 'object') {
+    return { moduleId, resourceType: null, resources: [] } satisfies ModuleResourcesResponse;
+  }
+
+  const result = data as Partial<ModuleResourcesResponse>;
+  const resources = Array.isArray(result.resources) ? result.resources : [];
+  return {
+    moduleId: typeof result.moduleId === 'string' ? result.moduleId : moduleId,
+    resourceType: (typeof result.resourceType === 'string' ? result.resourceType : null) as ModuleResourcesResponse['resourceType'],
+    resources: resources
+      .map((entry) => mapModuleResourceContext(entry))
+      .filter((entry): entry is ModuleResourceContext => entry !== null)
+  } satisfies ModuleResourcesResponse;
+}

--- a/apps/frontend/src/modules/types.ts
+++ b/apps/frontend/src/modules/types.ts
@@ -1,0 +1,41 @@
+export type ModuleResourceType =
+  | 'service'
+  | 'service-network'
+  | 'workflow-definition'
+  | 'workflow-run'
+  | 'job-definition'
+  | 'job-run'
+  | 'asset'
+  | 'event'
+  | 'view'
+  | 'metric';
+
+export type ModuleSummary = {
+  id: string;
+  displayName: string | null;
+  description: string | null;
+  keywords: string[];
+  latestVersion: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type ModuleResourceContext = {
+  moduleId: string;
+  moduleVersion: string | null;
+  resourceType: ModuleResourceType;
+  resourceId: string;
+  resourceSlug: string | null;
+  resourceName: string | null;
+  resourceVersion: string | null;
+  isShared: boolean;
+  metadata: unknown;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type ModuleResourcesResponse = {
+  moduleId: string;
+  resourceType: ModuleResourceType | null;
+  resources: ModuleResourceContext[];
+};

--- a/apps/frontend/src/overview/useOverviewData.ts
+++ b/apps/frontend/src/overview/useOverviewData.ts
@@ -7,11 +7,13 @@ import {
   fetchJobRuns,
   fetchWorkflowActivity,
   type JobRunListItem,
+  type WorkflowActivityFilters,
   type WorkflowActivityRunEntry
 } from '../runs/api';
 import { listServices } from '../core/api';
 import { getWorkflowEventHealth } from '../workflows/api';
 import type { WorkflowEventSchedulerHealth } from '../workflows/types';
+import { useModuleScope } from '../modules/ModuleScopeContext';
 
 export type OverviewData = {
   eventHealth: WorkflowEventSchedulerHealth | null;
@@ -35,6 +37,14 @@ const EMPTY_DATA: OverviewData = {
 
 export function useOverviewData(): LoadState {
   const { activeToken: authToken } = useAuth();
+  const moduleScope = useModuleScope();
+  const {
+    kind: moduleScopeKind,
+    loadingResources: moduleLoadingResources,
+    getResourceSlugs,
+    getResourceIds
+  } = moduleScope;
+  const isModuleScoped = moduleScopeKind === 'module';
   const [data, setData] = useState<OverviewData>(EMPTY_DATA);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -43,6 +53,10 @@ export function useOverviewData(): LoadState {
     let active = true;
 
     const load = async () => {
+      if (isModuleScoped && moduleLoadingResources) {
+        setLoading(true);
+        return;
+      }
       if (!authToken) {
         setData(EMPTY_DATA);
         setError(null);
@@ -52,6 +66,10 @@ export function useOverviewData(): LoadState {
       setLoading(true);
       setError(null);
 
+      const scopedWorkflowSlugs = isModuleScoped ? getResourceSlugs('workflow-definition') : [];
+      const scopedJobSlugs = isModuleScoped ? getResourceSlugs('job-definition') : [];
+      const scopedServiceIds = isModuleScoped ? getResourceIds('service') : [];
+
       const results = await Promise.allSettled([
         (async () => {
           const health = await getWorkflowEventHealth(authToken);
@@ -59,18 +77,46 @@ export function useOverviewData(): LoadState {
         })(),
         (async () => {
           const services = await listServices(authToken);
-          return services;
+          if (!isModuleScoped) {
+            return services;
+          }
+          if (scopedServiceIds.length === 0) {
+            return [];
+          }
+          const idSet = new Set(scopedServiceIds);
+          return services.filter((service) => idSet.has(service.id));
         })(),
         (async () => {
+          if (isModuleScoped && scopedWorkflowSlugs.length === 0) {
+            return [] as WorkflowActivityRunEntry[];
+          }
+          const workflowFilters: WorkflowActivityFilters = {
+            kinds: ['run'],
+            workflowSlugs: isModuleScoped ? scopedWorkflowSlugs : undefined,
+            moduleId: isModuleScoped ? moduleScope.moduleId : undefined
+          };
           const { items } = await fetchWorkflowActivity(authToken, {
             limit: 12,
-            filters: { kinds: ['run'] }
+            filters: workflowFilters
           });
           return items.filter((entry): entry is WorkflowActivityRunEntry => entry.kind === 'run');
         })(),
         (async () => {
-          const { items } = await fetchJobRuns(authToken, { limit: 5 });
-          return items;
+          if (isModuleScoped && scopedJobSlugs.length === 0) {
+            return [] as JobRunListItem[];
+          }
+          const jobFilters = isModuleScoped
+            ? { jobSlugs: scopedJobSlugs, moduleId: moduleScope.moduleId ?? undefined }
+            : undefined;
+          const { items } = await fetchJobRuns(authToken, {
+            limit: 5,
+            filters: jobFilters
+          });
+          if (!isModuleScoped) {
+            return items;
+          }
+          const slugSet = new Set(scopedJobSlugs.map((slug) => slug.toLowerCase()));
+          return items.filter((item) => slugSet.has(item.job.slug.toLowerCase()));
         })()
       ]);
 
@@ -122,7 +168,7 @@ export function useOverviewData(): LoadState {
     return () => {
       active = false;
     };
-  }, [authToken]);
+  }, [authToken, getResourceIds, getResourceSlugs, isModuleScoped, moduleLoadingResources, moduleScope.moduleId]);
 
   return useMemo(() => ({ data, loading, error }), [data, loading, error]);
 }

--- a/apps/frontend/src/routes/router.tsx
+++ b/apps/frontend/src/routes/router.tsx
@@ -31,187 +31,194 @@ import { ROUTE_PATHS, ROUTE_SEGMENTS } from './paths';
 import AssetsPage from '../dataAssets/AssetsPage';
 import ObservabilityPage from '../observability/ObservabilityPage';
 
+const layoutChildren: RouteObject[] = [
+  {
+    index: true,
+    element: <Navigate to={ROUTE_PATHS.overview} replace />
+  },
+  {
+    path: ROUTE_SEGMENTS.overview,
+    element: <OverviewRoute />
+  },
+  {
+    path: ROUTE_SEGMENTS.observability,
+    element: (
+      <RequireOperatorToken>
+        <ObservabilityPage />
+      </RequireOperatorToken>
+    )
+  },
+  {
+    path: ROUTE_SEGMENTS.core,
+    element: <CoreRoute />
+  },
+  {
+    path: ROUTE_SEGMENTS.events,
+    element: <EventsExplorerPage />
+  },
+  {
+    path: ROUTE_SEGMENTS.assets,
+    element: <AssetsPage />
+  },
+  {
+    path: ROUTE_SEGMENTS.services,
+    element: <ServicesLayout />,
+    errorElement: <ServicesRouteError />,
+    children: [
+      {
+        index: true,
+        element: <Navigate to={ROUTE_PATHS.servicesOverview} replace />
+      },
+      {
+        path: ROUTE_SEGMENTS.servicesOverview,
+        element: <ServiceGallery />
+      },
+      {
+        path: ROUTE_SEGMENTS.servicesTimestore,
+        element: <TimestoreLayout />,
+        children: [
+          {
+            index: true,
+            element: <Navigate to={ROUTE_PATHS.servicesTimestoreDatasets} replace />
+          },
+          {
+            path: ROUTE_SEGMENTS.servicesTimestoreDatasets,
+            element: <TimestoreDatasetsPage />
+          },
+          {
+            path: ROUTE_SEGMENTS.servicesTimestoreSql,
+            element: <TimestoreSqlEditorPage />
+          },
+          {
+            path: ROUTE_SEGMENTS.servicesTimestoreStreaming,
+            element: <TimestoreStreamingPage />
+          }
+        ]
+      },
+      {
+        path: ROUTE_SEGMENTS.servicesFilestore,
+        element: <FilestoreLayout />
+      },
+      {
+        path: ROUTE_SEGMENTS.servicesMetastore,
+        element: <MetastoreExplorerPage />
+      }
+    ]
+  },
+  {
+    path: ROUTE_SEGMENTS.runs,
+    element: (
+      <RequireOperatorToken>
+        <RunsPage />
+      </RequireOperatorToken>
+    )
+  },
+  {
+    path: ROUTE_SEGMENTS.jobs,
+    element: (
+      <RequireOperatorToken>
+        <JobsPage />
+      </RequireOperatorToken>
+    )
+  },
+  {
+    path: ROUTE_SEGMENTS.workflows,
+    element: (
+      <RequireOperatorToken>
+        <WorkflowsPage />
+      </RequireOperatorToken>
+    )
+  },
+  {
+    path: ROUTE_SEGMENTS.topology,
+    element: (
+      <RequireOperatorToken>
+        <TopologyRoute />
+      </RequireOperatorToken>
+    )
+  },
+  {
+    path: ROUTE_SEGMENTS.schedules,
+    element: (
+      <RequireOperatorToken>
+        <SchedulesPage />
+      </RequireOperatorToken>
+    )
+  },
+  {
+    path: ROUTE_SEGMENTS.settings,
+    element: <SettingsLayout />,
+    children: [
+      {
+        index: true,
+        element: <Navigate to={ROUTE_SEGMENTS.settingsAppearance} replace />
+      },
+      {
+        path: ROUTE_SEGMENTS.settingsAppearance,
+        element: <ThemeSettingsPage />
+      },
+      {
+        path: ROUTE_SEGMENTS.settingsPreview,
+        element: <PreviewSettingsPage />
+      },
+      {
+        path: ROUTE_SEGMENTS.settingsApiAccess,
+        element: <ApiAccessPage />
+      },
+      {
+        path: ROUTE_SEGMENTS.settingsRuntimeScaling,
+        element: (
+          <RequireOperatorToken>
+            <RuntimeScalingSettingsPage />
+          </RequireOperatorToken>
+        )
+      },
+      {
+        path: ROUTE_SEGMENTS.settingsImport,
+        element: (
+          <RequireOperatorToken>
+            <ImportRoute />
+          </RequireOperatorToken>
+        )
+      },
+      {
+        path: ROUTE_SEGMENTS.settingsAiBuilder,
+        element: <AiBuilderSettingsPage />
+      },
+      {
+        path: ROUTE_SEGMENTS.settingsAdmin,
+        element: (
+          <RequireOperatorToken>
+            <AdminToolsPage />
+          </RequireOperatorToken>
+        )
+      }
+    ]
+  },
+  {
+    path: 'submit',
+    element: <LegacyImportRedirect from="/submit" />
+  },
+  {
+    path: 'import-manifest',
+    element: <LegacyImportRedirect from="/import-manifest" />
+  },
+  {
+    path: '*',
+    element: <Navigate to={ROUTE_PATHS.overview} replace />
+  }
+];
+
 export const appRouteConfig: RouteObject[] = [
   {
     path: '/',
     element: <AppLayout />,
-    children: [
-      {
-        index: true,
-        element: <Navigate to={ROUTE_PATHS.overview} replace />
-      },
-      {
-        path: ROUTE_SEGMENTS.overview,
-        element: <OverviewRoute />
-      },
-      {
-        path: ROUTE_SEGMENTS.observability,
-        element: (
-          <RequireOperatorToken>
-            <ObservabilityPage />
-          </RequireOperatorToken>
-        )
-      },
-      {
-        path: ROUTE_SEGMENTS.core,
-        element: <CoreRoute />
-      },
-      {
-        path: ROUTE_SEGMENTS.events,
-        element: <EventsExplorerPage />
-      },
-      {
-        path: ROUTE_SEGMENTS.assets,
-        element: <AssetsPage />
-      },
-      {
-        path: ROUTE_SEGMENTS.services,
-        element: <ServicesLayout />,
-        errorElement: <ServicesRouteError />,
-        children: [
-          {
-            index: true,
-            element: <Navigate to={ROUTE_PATHS.servicesOverview} replace />
-          },
-          {
-            path: ROUTE_SEGMENTS.servicesOverview,
-            element: <ServiceGallery />
-          },
-          {
-            path: ROUTE_SEGMENTS.servicesTimestore,
-            element: <TimestoreLayout />,
-            children: [
-              {
-                index: true,
-                element: <Navigate to={ROUTE_PATHS.servicesTimestoreDatasets} replace />
-              },
-              {
-                path: ROUTE_SEGMENTS.servicesTimestoreDatasets,
-                element: <TimestoreDatasetsPage />
-              },
-              {
-                path: ROUTE_SEGMENTS.servicesTimestoreStreaming,
-                element: <TimestoreStreamingPage />
-              },
-              {
-                path: ROUTE_SEGMENTS.servicesTimestoreSql,
-                element: <TimestoreSqlEditorPage />
-              }
-            ]
-          },
-          {
-            path: ROUTE_SEGMENTS.servicesFilestore,
-            element: <FilestoreLayout />
-          },
-          {
-            path: ROUTE_SEGMENTS.servicesMetastore,
-            element: <MetastoreExplorerPage />
-          }
-        ]
-      },
-      {
-        path: ROUTE_SEGMENTS.runs,
-        element: (
-          <RequireOperatorToken>
-            <RunsPage />
-          </RequireOperatorToken>
-        )
-      },
-      {
-        path: ROUTE_SEGMENTS.jobs,
-        element: (
-          <RequireOperatorToken>
-            <JobsPage />
-          </RequireOperatorToken>
-        )
-      },
-      {
-        path: ROUTE_SEGMENTS.workflows,
-        element: (
-          <RequireOperatorToken>
-            <WorkflowsPage />
-          </RequireOperatorToken>
-        )
-      },
-      {
-        path: ROUTE_SEGMENTS.topology,
-        element: (
-          <RequireOperatorToken>
-            <TopologyRoute />
-          </RequireOperatorToken>
-        )
-      },
-      {
-        path: ROUTE_SEGMENTS.schedules,
-        element: (
-          <RequireOperatorToken>
-            <SchedulesPage />
-          </RequireOperatorToken>
-        )
-      },
-      {
-        path: ROUTE_SEGMENTS.settings,
-        element: <SettingsLayout />,
-        children: [
-          {
-            index: true,
-            element: <Navigate to={ROUTE_PATHS.settingsAppearance} replace />
-          },
-          {
-            path: ROUTE_SEGMENTS.settingsAppearance,
-            element: <ThemeSettingsPage />
-          },
-          {
-            path: ROUTE_SEGMENTS.settingsPreview,
-            element: <PreviewSettingsPage />
-          },
-          {
-            path: ROUTE_SEGMENTS.settingsApiAccess,
-            element: <ApiAccessPage />
-          },
-          {
-            path: ROUTE_SEGMENTS.settingsRuntimeScaling,
-            element: (
-              <RequireOperatorToken>
-                <RuntimeScalingSettingsPage />
-              </RequireOperatorToken>
-            )
-          },
-          {
-            path: ROUTE_SEGMENTS.settingsImport,
-            element: (
-              <RequireOperatorToken>
-                <ImportRoute />
-              </RequireOperatorToken>
-            )
-          },
-          {
-            path: ROUTE_SEGMENTS.settingsAiBuilder,
-            element: <AiBuilderSettingsPage />
-          },
-          {
-            path: ROUTE_SEGMENTS.settingsAdmin,
-            element: (
-              <RequireOperatorToken>
-                <AdminToolsPage />
-              </RequireOperatorToken>
-            )
-          }
-        ]
-      },
-      {
-        path: 'submit',
-        element: <LegacyImportRedirect from="/submit" />
-      },
-      {
-        path: 'import-manifest',
-        element: <LegacyImportRedirect from="/import-manifest" />
-      },
-      {
-        path: '*',
-        element: <Navigate to={ROUTE_PATHS.overview} replace />
-      }
-    ]
+    children: layoutChildren
+  },
+  {
+    path: '/modules/:moduleId',
+    element: <AppLayout />,
+    children: layoutChildren
   }
 ];
 

--- a/apps/frontend/src/runs/RunsPage.tsx
+++ b/apps/frontend/src/runs/RunsPage.tsx
@@ -158,6 +158,22 @@ const TABLE_BODY_ROW_BASE_CLASSES = 'cursor-pointer transition-colors';
 
 const TABLE_BODY_ROW_SELECTED_CLASSES = 'bg-accent-soft shadow-elevation-sm';
 
+function extractRunIdentifier(run: unknown, key: string): string | null {
+  if (!run || typeof run !== 'object') {
+    return null;
+  }
+  const record = run as Record<string, unknown>;
+  const value = record[key];
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+  if (typeof value === 'number') {
+    return String(value);
+  }
+  return null;
+}
+
 const TABLE_BODY_ROW_DEFAULT_CLASSES = 'bg-surface-glass hover:bg-accent-soft/60';
 
 const TABLE_META_TEXT_CLASSES = 'text-scale-xs text-secondary';
@@ -1287,12 +1303,13 @@ function RunsPageContent() {
         scheduleWorkflowReload();
         return;
       }
-      const runId = event.data?.run?.id ?? null;
+      const run = event.data?.run;
+      const runId = extractRunIdentifier(run, 'id');
       if (runId && isResourceInScope('workflow-run', runId)) {
         scheduleWorkflowReload();
         return;
       }
-      const workflowId = event.data?.run?.workflowDefinitionId ?? null;
+      const workflowId = extractRunIdentifier(run, 'workflowDefinitionId');
       if (workflowId && isResourceInScope('workflow-definition', workflowId)) {
         scheduleWorkflowReload();
       }
@@ -1306,12 +1323,13 @@ function RunsPageContent() {
         scheduleJobReload();
         return;
       }
-      const runId = event.data?.run?.id ?? null;
+      const run = event.data?.run;
+      const runId = extractRunIdentifier(run, 'id');
       if (runId && isResourceInScope('job-run', runId)) {
         scheduleJobReload();
         return;
       }
-      const jobDefinitionId = event.data?.run?.jobDefinitionId ?? null;
+      const jobDefinitionId = extractRunIdentifier(run, 'jobDefinitionId');
       if (jobDefinitionId && isResourceInScope('job-definition', jobDefinitionId)) {
         scheduleJobReload();
       }

--- a/apps/frontend/src/runs/api.ts
+++ b/apps/frontend/src/runs/api.ts
@@ -148,6 +148,7 @@ export type WorkflowActivityFilters = {
   search?: string;
   from?: string;
   to?: string;
+  moduleId?: string | null;
 };
 
 export type JobRunFilters = {
@@ -155,6 +156,7 @@ export type JobRunFilters = {
   jobSlugs?: string[];
   runtimes?: string[];
   search?: string;
+  moduleId?: string | null;
 };
 
 function appendArray(values: string[] | undefined, key: string, query: URLSearchParams): void {
@@ -194,6 +196,9 @@ function buildWorkflowActivityQuery(params: {
   if (filters.to) {
     query.set('to', filters.to);
   }
+  if (filters.moduleId) {
+    query.set('moduleId', filters.moduleId);
+  }
   const result = query.toString();
   return result ? `?${result}` : '';
 }
@@ -212,6 +217,9 @@ function buildJobRunQuery(params: { limit?: number; offset?: number; filters?: J
   appendArray(filters.runtimes, 'runtime', query);
   if (filters.search) {
     query.set('search', filters.search);
+  }
+  if (filters.moduleId) {
+    query.set('moduleId', filters.moduleId);
   }
   const result = query.toString();
   return result ? `?${result}` : '';

--- a/apps/frontend/src/schedules/SchedulesPage.tsx
+++ b/apps/frontend/src/schedules/SchedulesPage.tsx
@@ -16,6 +16,8 @@ import { fetchWorkflowDefinitions } from '../workflows/api';
 import type { WorkflowDefinition, WorkflowSchedule } from '../workflows/types';
 import { formatTimestamp } from '../workflows/formatters';
 import ScheduleFormDialog from './ScheduleFormDialog';
+import { useModuleScope } from '../modules/ModuleScopeContext';
+import { ModuleScopeGate } from '../modules/ModuleScopeGate';
 import {
   SCHEDULE_ALERT_DANGER,
   SCHEDULE_EMPTY_STATE,
@@ -56,6 +58,10 @@ type FormState = {
 export default function SchedulesPage(): JSX.Element {
   const { activeToken: authToken } = useAuth();
   const { pushToast } = useToasts();
+  const moduleScope = useModuleScope();
+
+  const isModuleScoped = moduleScope.kind === 'module';
+  const activeModuleId = isModuleScoped ? moduleScope.moduleId : null;
 
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -69,10 +75,23 @@ export default function SchedulesPage(): JSX.Element {
     if (!authToken) {
       return;
     }
+    if (!isModuleScoped) {
+      setSchedules([]);
+      setError(null);
+      return;
+    }
+    if (isModuleScoped && moduleScope.loadingResources) {
+      return;
+    }
+    if (isModuleScoped && !activeModuleId) {
+      setSchedules([]);
+      setError(null);
+      return;
+    }
     setLoading(true);
     setError(null);
     try {
-      const data = await fetchSchedules(authToken);
+      const data = await fetchSchedules(authToken, { moduleId: activeModuleId ?? undefined });
       setSchedules(data);
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to load schedules';
@@ -80,15 +99,26 @@ export default function SchedulesPage(): JSX.Element {
     } finally {
       setLoading(false);
     }
-  }, [authToken]);
+  }, [authToken, activeModuleId, isModuleScoped, moduleScope.loadingResources]);
 
   const loadWorkflows = useCallback(async () => {
     if (!authToken) {
       return;
     }
+    if (!isModuleScoped) {
+      setWorkflows([]);
+      return;
+    }
+    if (isModuleScoped && moduleScope.loadingResources) {
+      return;
+    }
+    if (isModuleScoped && !activeModuleId) {
+      setWorkflows([]);
+      return;
+    }
     setWorkflowsLoading(true);
     try {
-      const definitions = await fetchWorkflowDefinitions(authToken);
+      const definitions = await fetchWorkflowDefinitions(authToken, { moduleId: activeModuleId ?? undefined });
       setWorkflows(definitions);
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to load workflows';
@@ -100,12 +130,14 @@ export default function SchedulesPage(): JSX.Element {
     } finally {
       setWorkflowsLoading(false);
     }
-  }, [authToken, pushToast]);
+  }, [authToken, activeModuleId, isModuleScoped, moduleScope.loadingResources, pushToast]);
 
   useEffect(() => {
     void loadSchedules();
     void loadWorkflows();
   }, [loadSchedules, loadWorkflows]);
+
+  const shouldShowModuleGate = moduleScope.kind !== 'module' || moduleScope.loadingResources;
 
   const workflowOptions = useMemo(() => {
     return workflows
@@ -223,6 +255,10 @@ export default function SchedulesPage(): JSX.Element {
     },
     [authToken, pushToast]
   );
+
+  if (shouldShowModuleGate) {
+    return <ModuleScopeGate resourceName="schedules" />;
+  }
 
   return (
     <div className="flex flex-col gap-6">

--- a/apps/frontend/src/schedules/api.ts
+++ b/apps/frontend/src/schedules/api.ts
@@ -116,9 +116,17 @@ async function coreJson<T>(token: TokenInput, options: CoreJsonOptions): Promise
   }
 }
 
-export async function fetchSchedules(token: TokenInput): Promise<WorkflowScheduleSummary[]> {
+export async function fetchSchedules(
+  token: TokenInput,
+  options: { moduleId?: string | null } = {}
+): Promise<WorkflowScheduleSummary[]> {
+  const params = new URLSearchParams();
+  if (options.moduleId) {
+    params.set('moduleId', options.moduleId);
+  }
+  const query = params.toString();
   const payload = await coreJson<{ data?: unknown }>(token, {
-    url: '/workflow-schedules',
+    url: `/workflow-schedules${query ? `?${query}` : ''}`,
     errorMessage: 'Failed to load workflow schedules'
   });
   if (!payload || !Array.isArray(payload.data)) {

--- a/apps/frontend/src/workflows/WorkflowsPage.tsx
+++ b/apps/frontend/src/workflows/WorkflowsPage.tsx
@@ -19,8 +19,16 @@ import ManualRunDialog from './components/ManualRunDialog';
 import WorkflowTopologyPreview from './components/WorkflowTopologyPreview';
 import { INITIAL_FILTERS, WorkflowsProviders, useWorkflowsController } from './hooks/useWorkflowsController';
 import type { WorkflowTriggerDeliveriesQuery } from './api';
+import { useModuleScope } from '../modules/ModuleScopeContext';
+import { ModuleScopeGate } from '../modules/ModuleScopeGate';
 
 export default function WorkflowsPage() {
+  const moduleScope = useModuleScope();
+
+  if (moduleScope.kind !== 'module' || moduleScope.loadingResources) {
+    return <ModuleScopeGate resourceName="workflows" />;
+  }
+
   return (
     <WorkflowsProviders>
       <WorkflowsPageContent />

--- a/apps/frontend/src/workflows/__tests__/WorkflowsPage.test.tsx
+++ b/apps/frontend/src/workflows/__tests__/WorkflowsPage.test.tsx
@@ -15,6 +15,7 @@ import {
   type AppHubEventHandler,
   type AppHubEventsClient
 } from '../../events/context';
+import { ModuleScopeContextProvider, type ModuleScopeContextValue } from '../../modules/ModuleScopeContext';
 
 vi.mock('../../auth/useAuth', () => {
   const useAuthMock = vi.fn();
@@ -161,6 +162,25 @@ const completedRun: WorkflowRun = {
   metrics: { totalSteps: 2, completedSteps: 2 },
   createdAt: fiveMinutesAgoIso,
   updatedAt: fourMinutesAgoIso
+};
+
+const moduleScopeStub: ModuleScopeContextValue = {
+  kind: 'module',
+  moduleId: 'test-module',
+  moduleVersion: '0.0.0',
+  modules: [],
+  loadingModules: false,
+  modulesError: null,
+  resources: [],
+  loadingResources: false,
+  resourcesError: null,
+  setModuleId: vi.fn(),
+  buildModulePath: (path: string) => path.startsWith('/') ? path : `/${path}`,
+  stripModulePrefix: (pathname: string) => pathname || '/',
+  getResourceContexts: () => [],
+  getResourceIds: () => [],
+  getResourceSlugs: () => [],
+  isResourceInScope: () => true
 };
 
 const autoRun: WorkflowRun = {
@@ -494,7 +514,11 @@ function renderWorkflowsPage(initialEntries: string[] = ['/workflows']) {
           createElement(
             ToastProvider,
             null,
-            createElement(WorkflowsPage)
+            createElement(
+              ModuleScopeContextProvider,
+              { value: moduleScopeStub },
+              createElement(WorkflowsPage)
+            )
           )
         )
       )

--- a/apps/frontend/src/workflows/api.ts
+++ b/apps/frontend/src/workflows/api.ts
@@ -591,8 +591,17 @@ export async function fetchWorkflowTopologyGraph(
   };
 }
 
-export async function listWorkflowDefinitions(token: TokenInput): Promise<WorkflowDefinition[]> {
-  const payload = await requestJson(token,  '/workflows', {
+export async function listWorkflowDefinitions(
+  token: TokenInput,
+  params: { moduleId?: string | null } = {}
+): Promise<WorkflowDefinition[]> {
+  const searchParams = new URLSearchParams();
+  if (params.moduleId) {
+    searchParams.set('moduleId', params.moduleId);
+  }
+  const query = searchParams.toString();
+  const path = `/workflows${query ? `?${query}` : ''}`;
+  const payload = await requestJson(token, path, {
     schema: optionalDataArraySchema,
     errorMessage: 'Failed to load workflows'
   });
@@ -723,7 +732,7 @@ export async function searchWorkflowRuns(
   return results;
 }
 
-type WorkflowAnalyticsQuery = {
+export type WorkflowAnalyticsQuery = {
   range?: '24h' | '7d' | '30d';
   bucket?: '15m' | 'hour' | 'day';
   from?: string;

--- a/apps/frontend/src/workflows/hooks/__tests__/useWorkflowsController.test.ts
+++ b/apps/frontend/src/workflows/hooks/__tests__/useWorkflowsController.test.ts
@@ -183,7 +183,12 @@ const {
     updateWorkflowDefinitionMock: vi.fn(async () => definition),
     fetchWorkflowAssetsMock: vi.fn(async () => [] as WorkflowAssetInventoryEntry[]),
     fetchWorkflowAssetHistoryMock: vi.fn<
-      (fetch: AuthorizedFetch, workflowId: string, assetId: string, options?: { limit?: number }) => Promise<WorkflowAssetDetail | null>
+      (
+        fetch: AuthorizedFetch,
+        workflowId: string,
+        assetId: string,
+        options?: { limit?: number; partitionKey?: string | null; moduleId?: string | null }
+      ) => Promise<WorkflowAssetDetail | null>
     >(async () => ({
       assetId: 'inventory.dataset',
       producers: [],
@@ -192,7 +197,12 @@ const {
       limit: 10
     }) as WorkflowAssetDetail),
     fetchWorkflowAssetPartitionsMock: vi.fn<
-      (fetch: AuthorizedFetch, workflowId: string, assetId: string, options?: { lookback?: number }) => Promise<WorkflowAssetPartitions | null>
+      (
+        fetch: AuthorizedFetch,
+        workflowId: string,
+        assetId: string,
+        options?: { lookback?: number; moduleId?: string | null }
+      ) => Promise<WorkflowAssetPartitions | null>
     >(async () => ({
       assetId: 'inventory.dataset',
       partitioning: null,

--- a/apps/frontend/src/workflows/hooks/__tests__/useWorkflowsController.test.ts
+++ b/apps/frontend/src/workflows/hooks/__tests__/useWorkflowsController.test.ts
@@ -413,7 +413,11 @@ describe('useWorkflowsController', () => {
     await waitFor(() => expect(result.current.selectedSlug).toBe('demo-workflow'));
     expect(result.current.runs).toHaveLength(1);
     expect(listWorkflowDefinitionsMock).toHaveBeenCalled();
-    expect(getWorkflowDetailMock).toHaveBeenCalledWith(expect.any(Function), 'demo-workflow');
+    expect(getWorkflowDetailMock).toHaveBeenCalledWith(
+      expect.any(Function),
+      'demo-workflow',
+      { moduleId: 'test-module' }
+    );
 
     await act(async () => {
       await result.current.handleManualRun({ parameters: {} });
@@ -495,7 +499,11 @@ describe('useWorkflowsController', () => {
     await waitFor(() => expect(result.current.selectedSlug).toBe('demo-workflow'));
     await waitFor(() => expect(result.current.assetInventoryLoading).toBe(false));
 
-    expect(fetchWorkflowAssetsMock).toHaveBeenCalledWith(expect.any(Function), 'demo-workflow');
+    expect(fetchWorkflowAssetsMock).toHaveBeenCalledWith(
+      expect.any(Function),
+      'demo-workflow',
+      { moduleId: 'test-module' }
+    );
     expect(result.current.assetInventory).toEqual(assetInventory);
     expect(result.current.assetInventoryError).toBeNull();
   });

--- a/apps/frontend/src/workflows/hooks/useWorkflowDefinitions.tsx
+++ b/apps/frontend/src/workflows/hooks/useWorkflowDefinitions.tsx
@@ -27,6 +27,7 @@ import type {
   WorkflowRuntimeSummary
 } from '../types';
 import { useWorkflowAccess } from './useWorkflowAccess';
+import { useModuleScope } from '../../modules/ModuleScopeContext';
 
 export const INITIAL_FILTERS: WorkflowFiltersState = {
   statuses: [],
@@ -66,6 +67,12 @@ const WorkflowDefinitionsContext = createContext<WorkflowDefinitionsContextValue
 
 export function WorkflowDefinitionsProvider({ children }: { children: ReactNode }) {
   const { authorizedFetch } = useWorkflowAccess();
+  const moduleScope = useModuleScope();
+  const {
+    kind: moduleScopeKind,
+    isResourceInScope
+  } = moduleScope;
+  const isModuleScoped = moduleScopeKind === 'module';
 
   const [workflows, setWorkflows] = useState<WorkflowDefinition[]>([]);
   const [workflowsLoading, setWorkflowsLoading] = useState(true);
@@ -97,6 +104,48 @@ export function WorkflowDefinitionsProvider({ children }: { children: ReactNode 
     }));
   }, []);
 
+  const isWorkflowInScope = useCallback(
+    (definition: WorkflowDefinition | null | undefined) => {
+      if (!definition) {
+        return false;
+      }
+      if (!isModuleScoped) {
+        return true;
+      }
+      if (isResourceInScope('workflow-definition', definition.id)) {
+        return true;
+      }
+      return isResourceInScope('workflow-definition', definition.slug);
+    },
+    [isModuleScoped, isResourceInScope]
+  );
+
+  const filterWorkflowsForScope = useCallback(
+    (definitions: WorkflowDefinition[]) => {
+      if (!isModuleScoped) {
+        return definitions;
+      }
+      return definitions.filter((definition) => isWorkflowInScope(definition));
+    },
+    [isModuleScoped, isWorkflowInScope]
+  );
+
+  const isServiceInScope = useCallback(
+    (serviceId: string | null | undefined, slug?: string | null) => {
+      if (!isModuleScoped) {
+        return true;
+      }
+      if (serviceId && isResourceInScope('service', serviceId)) {
+        return true;
+      }
+      if (slug) {
+        return isResourceInScope('service', slug);
+      }
+      return false;
+    },
+    [isModuleScoped, isResourceInScope]
+  );
+
   const hydrateRuntimeSummaries = useCallback(
     (definitions: WorkflowDefinition[]) => {
       if (definitions.length === 0) {
@@ -126,7 +175,11 @@ export function WorkflowDefinitionsProvider({ children }: { children: ReactNode 
               break;
             }
             try {
-              const { runs } = await listWorkflowRunsForSlug(authorizedFetch, definition.slug, { limit: 1 });
+              const runParams: { limit?: number; offset?: number; moduleId?: string | null } = { limit: 1 };
+              if (isModuleScoped) {
+                runParams.moduleId = moduleScope.moduleId ?? undefined;
+              }
+              const { runs } = await listWorkflowRunsForSlug(authorizedFetch, definition.slug, runParams);
               if (hydrationGenerationRef.current !== generation) {
                 break;
               }
@@ -149,7 +202,7 @@ export function WorkflowDefinitionsProvider({ children }: { children: ReactNode 
 
       void Promise.allSettled(tasks);
     },
-    [authorizedFetch, updateRuntimeSummary]
+    [authorizedFetch, isModuleScoped, moduleScope.moduleId, updateRuntimeSummary]
   );
 
   const seedRuntimeSummaryFromMetadata = useCallback((workflow: WorkflowDefinition) => {
@@ -163,46 +216,76 @@ export function WorkflowDefinitionsProvider({ children }: { children: ReactNode 
     }));
   }, []);
 
-  const applyWorkflowDefinitionUpdate = useCallback((payload: unknown) => {
-    const definition = normalizeWorkflowDefinition(payload);
-    if (!definition) {
-      return;
-    }
-    setWorkflows((current) => {
-      const index = current.findIndex((entry) => entry.id === definition.id);
-      const next =
-        index === -1
-          ? [...current, definition]
-          : current.map((entry, entryIndex) => (entryIndex === index ? definition : entry));
-      const sorted = next.slice().sort((a, b) => a.slug.localeCompare(b.slug));
-      workflowsRef.current = sorted;
-      return sorted;
-    });
-    seedRuntimeSummaryFromMetadata(definition);
-    if (!selectedSlugRef.current) {
-      selectedSlugRef.current = definition.slug;
-      setSelectedSlug(definition.slug);
-    }
-  }, [seedRuntimeSummaryFromMetadata, setSelectedSlug]);
+  const applyWorkflowDefinitionUpdate = useCallback(
+    (payload: unknown) => {
+      const definition = normalizeWorkflowDefinition(payload);
+      if (!definition) {
+        return;
+      }
+
+      if (!isWorkflowInScope(definition)) {
+        const filtered = workflowsRef.current.filter((entry) => entry.id !== definition.id);
+        workflowsRef.current = filtered;
+        setWorkflows(filtered);
+        setSelectedSlug((current) => {
+          if (current && filtered.some((workflow) => workflow.slug === current)) {
+            return current;
+          }
+          const nextSlug = filtered[0]?.slug ?? null;
+          selectedSlugRef.current = nextSlug;
+          return nextSlug;
+        });
+        return;
+      }
+
+      setWorkflows((current) => {
+        const index = current.findIndex((entry) => entry.id === definition.id);
+        const next =
+          index === -1
+            ? [...current, definition]
+            : current.map((entry, entryIndex) => (entryIndex === index ? definition : entry));
+        const scoped = filterWorkflowsForScope(next);
+        const sorted = scoped.slice().sort((a, b) => a.slug.localeCompare(b.slug));
+        workflowsRef.current = sorted;
+        return sorted;
+      });
+      seedRuntimeSummaryFromMetadata(definition);
+      setSelectedSlug((current) => {
+        if (current && workflowsRef.current.some((workflow) => workflow.slug === current)) {
+          selectedSlugRef.current = current;
+          return current;
+        }
+        const nextSlug = workflowsRef.current[0]?.slug ?? null;
+        selectedSlugRef.current = nextSlug;
+        return nextSlug;
+      });
+    },
+    [filterWorkflowsForScope, isWorkflowInScope, seedRuntimeSummaryFromMetadata]
+  );
 
   const loadWorkflows = useCallback(async () => {
     setWorkflowsLoading(true);
     setWorkflowsError(null);
     try {
-      const normalized = await listWorkflowDefinitions(authorizedFetch);
-      setWorkflows(normalized);
-      workflowsRef.current = normalized;
-      normalized.forEach(seedRuntimeSummaryFromMetadata);
-      hydrateRuntimeSummaries(normalized);
-      if (normalized.length > 0) {
+      const normalized = isModuleScoped
+        ? await listWorkflowDefinitions(authorizedFetch, {
+            moduleId: moduleScope.moduleId ?? undefined
+          })
+        : await listWorkflowDefinitions(authorizedFetch);
+      const scoped = filterWorkflowsForScope(normalized);
+      setWorkflows(scoped);
+      workflowsRef.current = scoped;
+      scoped.forEach(seedRuntimeSummaryFromMetadata);
+      hydrateRuntimeSummaries(scoped);
+      if (scoped.length > 0) {
         setSelectedSlug((current) => {
-          if (current) {
+          if (current && scoped.some((workflow) => workflow.slug === current)) {
             selectedSlugRef.current = current;
             return current;
           }
-          const nextSlug = normalized[0]?.slug;
-          selectedSlugRef.current = nextSlug ?? null;
-          return nextSlug ?? null;
+          const nextSlug = scoped[0]?.slug ?? null;
+          selectedSlugRef.current = nextSlug;
+          return nextSlug;
         });
       } else {
         selectedSlugRef.current = null;
@@ -214,7 +297,35 @@ export function WorkflowDefinitionsProvider({ children }: { children: ReactNode 
     } finally {
       setWorkflowsLoading(false);
     }
-  }, [authorizedFetch, seedRuntimeSummaryFromMetadata, hydrateRuntimeSummaries]);
+  }, [
+    authorizedFetch,
+    filterWorkflowsForScope,
+    hydrateRuntimeSummaries,
+    isModuleScoped,
+    moduleScope.moduleId,
+    seedRuntimeSummaryFromMetadata
+  ]);
+
+  useEffect(() => {
+    if (!isModuleScoped) {
+      return;
+    }
+    const filtered = filterWorkflowsForScope(workflowsRef.current);
+    if (filtered.length === workflowsRef.current.length) {
+      return;
+    }
+    workflowsRef.current = filtered;
+    setWorkflows(filtered);
+    setSelectedSlug((current) => {
+      if (current && filtered.some((workflow) => workflow.slug === current)) {
+        selectedSlugRef.current = current;
+        return current;
+      }
+      const nextSlug = filtered[0]?.slug ?? null;
+      selectedSlugRef.current = nextSlug;
+      return nextSlug;
+    });
+  }, [filterWorkflowsForScope, isModuleScoped]);
 
   const loadServices = useCallback(async () => {
     try {
@@ -228,6 +339,9 @@ export function WorkflowDefinitionsProvider({ children }: { children: ReactNode 
         if (!slug) {
           continue;
         }
+        if (!isServiceInScope(entry.id, slug)) {
+          continue;
+        }
         const status = typeof entry.status === 'string' ? entry.status.toLowerCase() : 'unknown';
         nextStatuses[slug] = status;
       }
@@ -235,7 +349,7 @@ export function WorkflowDefinitionsProvider({ children }: { children: ReactNode 
     } catch {
       // Ignore failures; consumers surface workflow data regardless of service reachability.
     }
-  }, [authorizedFetch]);
+  }, [authorizedFetch, isServiceInScope]);
 
   const workflowSummaries = useMemo<WorkflowSummary[]>(() => {
     return workflows.map((workflow) => {

--- a/packages/shared/src/api/core/services/DefaultService.ts
+++ b/packages/shared/src/api/core/services/DefaultService.ts
@@ -167,6 +167,33 @@ export class DefaultService {
    * @returns any Default Response
    * @throws ApiError
    */
+  public getModules(): CancelablePromise<any> {
+    return this.httpRequest.request({
+      method: 'GET',
+      url: '/modules',
+    });
+  }
+  /**
+   * @returns any Default Response
+   * @throws ApiError
+   */
+  public getModulesResources({
+    moduleId,
+  }: {
+    moduleId: string,
+  }): CancelablePromise<any> {
+    return this.httpRequest.request({
+      method: 'GET',
+      url: '/modules/{moduleId}/resources',
+      path: {
+        'moduleId': moduleId,
+      },
+    });
+  }
+  /**
+   * @returns any Default Response
+   * @throws ApiError
+   */
   public postAiTimestoreSql(): CancelablePromise<any> {
     return this.httpRequest.request({
       method: 'POST',

--- a/packages/shared/src/api/core/services/JobsService.ts
+++ b/packages/shared/src/api/core/services/JobsService.ts
@@ -26,10 +26,20 @@ export class JobsService {
    * @returns def_45 Job definitions currently available to run.
    * @throws ApiError
    */
-  public getJobs(): CancelablePromise<def_45> {
+  public getJobs({
+    moduleId,
+  }: {
+    /**
+     * Optional module identifier to scope job definitions.
+     */
+    moduleId?: (string | Array<string>),
+  }): CancelablePromise<def_45> {
     return this.httpRequest.request({
       method: 'GET',
       url: '/jobs',
+      query: {
+        'moduleId': moduleId,
+      },
     });
   }
   /**
@@ -84,6 +94,7 @@ export class JobsService {
     job,
     runtime,
     search,
+    moduleId,
   }: {
     limit?: number,
     offset?: number,
@@ -100,6 +111,10 @@ export class JobsService {
      */
     runtime?: string,
     search?: string,
+    /**
+     * Optional module identifier to scope job runs.
+     */
+    moduleId?: (string | Array<string>),
   }): CancelablePromise<def_48> {
     return this.httpRequest.request({
       method: 'GET',
@@ -111,6 +126,7 @@ export class JobsService {
         'job': job,
         'runtime': runtime,
         'search': search,
+        'moduleId': moduleId,
       },
       errors: {
         400: `The job run filters were invalid.`,
@@ -166,6 +182,7 @@ export class JobsService {
     job,
     runtime,
     search,
+    moduleId,
   }: {
     /**
      * Job definition slug.
@@ -186,6 +203,10 @@ export class JobsService {
      */
     runtime?: string,
     search?: string,
+    /**
+     * Optional module identifier to scope job runs.
+     */
+    moduleId?: (string | Array<string>),
   }): CancelablePromise<def_49> {
     return this.httpRequest.request({
       method: 'GET',
@@ -200,6 +221,7 @@ export class JobsService {
         'job': job,
         'runtime': runtime,
         'search': search,
+        'moduleId': moduleId,
       },
       errors: {
         400: `The job lookup parameters were invalid.`,

--- a/packages/shared/src/api/core/services/ServicesService.ts
+++ b/packages/shared/src/api/core/services/ServicesService.ts
@@ -17,14 +17,20 @@ export class ServicesService {
    */
   public getServices({
     source,
+    moduleId,
   }: {
     source?: 'module' | 'external',
+    /**
+     * Optional module identifier to scope services.
+     */
+    moduleId?: (string | Array<string>),
   }): CancelablePromise<def_35> {
     return this.httpRequest.request({
       method: 'GET',
       url: '/services',
       query: {
         'source': source,
+        'moduleId': moduleId,
       },
       errors: {
         400: `The query parameters were invalid.`,

--- a/packages/shared/src/api/core/services/WorkflowsService.ts
+++ b/packages/shared/src/api/core/services/WorkflowsService.ts
@@ -37,10 +37,20 @@ export class WorkflowsService {
    * @returns def_68 Workflow definitions currently available.
    * @throws ApiError
    */
-  public getWorkflows(): CancelablePromise<def_68> {
+  public getWorkflows({
+    moduleId,
+  }: {
+    /**
+     * Optional module identifier to scope workflow definitions.
+     */
+    moduleId?: (string | Array<string>),
+  }): CancelablePromise<def_68> {
     return this.httpRequest.request({
       method: 'GET',
       url: '/workflows',
+      query: {
+        'moduleId': moduleId,
+      },
       errors: {
         500: `The server failed to fetch workflow definitions.`,
       },
@@ -88,6 +98,7 @@ export class WorkflowsService {
     search,
     from,
     to,
+    moduleId,
   }: {
     /**
      * Workflow slug to inspect.
@@ -111,6 +122,10 @@ export class WorkflowsService {
     search?: string,
     from?: string,
     to?: string,
+    /**
+     * Optional module identifier to scope workflow runs.
+     */
+    moduleId?: (string | Array<string>),
   }): CancelablePromise<def_72> {
     return this.httpRequest.request({
       method: 'GET',
@@ -128,6 +143,7 @@ export class WorkflowsService {
         'search': search,
         'from': from,
         'to': to,
+        'moduleId': moduleId,
       },
       errors: {
         400: `The request parameters or query failed validation.`,
@@ -179,10 +195,20 @@ export class WorkflowsService {
    * @returns def_86 Current asset graph snapshot.
    * @throws ApiError
    */
-  public getAssetsGraph(): CancelablePromise<def_86> {
+  public getAssetsGraph({
+    moduleId,
+  }: {
+    /**
+     * Optional module identifier to scope workflow assets.
+     */
+    moduleId?: (string | Array<string>),
+  }): CancelablePromise<def_86> {
     return this.httpRequest.request({
       method: 'GET',
       url: '/assets/graph',
+      query: {
+        'moduleId': moduleId,
+      },
       errors: {
         500: `Failed to build the workflow asset graph.`,
       },

--- a/services/core/openapi.json
+++ b/services/core/openapi.json
@@ -37571,6 +37571,27 @@
         "tags": [
           "Jobs"
         ],
+        "parameters": [
+          {
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
+            },
+            "in": "query",
+            "name": "moduleId",
+            "required": false,
+            "description": "Optional module identifier to scope job definitions."
+          }
+        ],
         "responses": {
           "200": {
             "description": "Job definitions currently available to run.",
@@ -37760,6 +37781,25 @@
             "in": "query",
             "name": "search",
             "required": false
+          },
+          {
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
+            },
+            "in": "query",
+            "name": "moduleId",
+            "required": false,
+            "description": "Optional module identifier to scope job runs."
           }
         ],
         "security": [
@@ -37976,6 +38016,25 @@
             "in": "query",
             "name": "search",
             "required": false
+          },
+          {
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
+            },
+            "in": "query",
+            "name": "moduleId",
+            "required": false,
+            "description": "Optional module identifier to scope job runs."
           },
           {
             "schema": {
@@ -38899,6 +38958,34 @@
         }
       }
     },
+    "/modules": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      }
+    },
+    "/modules/{moduleId}/resources": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "moduleId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      }
+    },
     "/ai/timestore/sql": {
       "post": {
         "responses": {
@@ -39164,6 +39251,27 @@
         "summary": "List workflow definitions",
         "tags": [
           "Workflows"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
+            },
+            "in": "query",
+            "name": "moduleId",
+            "required": false,
+            "description": "Optional module identifier to scope workflow definitions."
+          }
         ],
         "responses": {
           "200": {
@@ -39482,6 +39590,25 @@
             "in": "query",
             "name": "to",
             "required": false
+          },
+          {
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
+            },
+            "in": "query",
+            "name": "moduleId",
+            "required": false,
+            "description": "Optional module identifier to scope workflow runs."
           },
           {
             "schema": {
@@ -39923,6 +40050,27 @@
           "Workflows"
         ],
         "description": "Aggregates asset producers and consumers across all registered workflows.",
+        "parameters": [
+          {
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
+            },
+            "in": "query",
+            "name": "moduleId",
+            "required": false,
+            "description": "Optional module identifier to scope workflow assets."
+          }
+        ],
         "responses": {
           "200": {
             "description": "Current asset graph snapshot.",
@@ -40174,6 +40322,25 @@
             "in": "query",
             "name": "source",
             "required": false
+          },
+          {
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
+            },
+            "in": "query",
+            "name": "moduleId",
+            "required": false,
+            "description": "Optional module identifier to scope services."
           }
         ],
         "responses": {

--- a/services/core/scripts/generateOpenApi.ts
+++ b/services/core/scripts/generateOpenApi.ts
@@ -86,7 +86,11 @@ async function generateOpenApiSpec() {
   await app.register(async (instance) =>
     registerServiceRoutes(instance, {
       registry: {
-        importManifestModule: async () => ({ servicesApplied: 0, networksApplied: 0 })
+        importManifestModule: async () => ({
+          servicesApplied: 0,
+          networksApplied: 0,
+          moduleVersion: '0'
+        })
       }
     })
   );

--- a/services/core/src/db/assetMaterializer.ts
+++ b/services/core/src/db/assetMaterializer.ts
@@ -16,6 +16,19 @@ export type WorkflowAutoRunClaim = {
 
 const DEFAULT_STALE_CLAIM_MS = 5 * 60 * 1000;
 
+function normalizeModuleIds(moduleIds?: string[] | null): string[] | null {
+  if (!Array.isArray(moduleIds)) {
+    return null;
+  }
+  const normalized = moduleIds
+    .map((id) => (typeof id === 'string' ? id.trim() : ''))
+    .filter((id) => id.length > 0);
+  if (normalized.length === 0) {
+    return null;
+  }
+  return Array.from(new Set(normalized));
+}
+
 function toIso(date: Date): string {
   return date.toISOString();
 }
@@ -143,8 +156,39 @@ export async function releaseWorkflowAutoRun(
 }
 
 export async function getWorkflowAutoRunClaim(
-  workflowDefinitionId: string
+  workflowDefinitionId: string,
+  options: { moduleIds?: string[] | null } = {}
 ): Promise<WorkflowAutoRunClaim | null> {
+  const moduleIds = normalizeModuleIds(options.moduleIds ?? null);
+  const params: unknown[] = [workflowDefinitionId];
+  let moduleParamIndex: number | null = null;
+  if (moduleIds && moduleIds.length > 0) {
+    moduleParamIndex = params.length + 1;
+    params.push(moduleIds);
+  }
+
+  const moduleFilter = moduleParamIndex
+    ? `AND (
+         EXISTS (
+           SELECT 1
+             FROM module_resource_contexts def_ctx
+            WHERE def_ctx.resource_type = 'workflow-definition'
+              AND def_ctx.resource_id = air.workflow_definition_id
+              AND def_ctx.module_id = ANY($${moduleParamIndex}::text[])
+         )
+         OR (
+           air.workflow_run_id IS NOT NULL
+           AND EXISTS (
+             SELECT 1
+               FROM module_resource_contexts run_ctx
+              WHERE run_ctx.resource_type = 'workflow-run'
+                AND run_ctx.resource_id = air.workflow_run_id
+                AND run_ctx.module_id = ANY($${moduleParamIndex}::text[])
+           )
+         )
+       )`
+    : '';
+
   const { rows } = await withConnection((client) =>
     client.query<{
       workflow_definition_id: string;
@@ -166,9 +210,12 @@ export async function getWorkflowAutoRunClaim(
               context,
               claim_owner,
               claimed_at
-         FROM asset_materializer_inflight_runs
-        WHERE workflow_definition_id = $1`,
-      [workflowDefinitionId]
+         FROM asset_materializer_inflight_runs air
+        WHERE air.workflow_definition_id = $1
+          ${moduleFilter}
+        ORDER BY air.claimed_at DESC
+        LIMIT 1`,
+      params
     )
   );
 
@@ -191,14 +238,34 @@ export async function getWorkflowAutoRunClaim(
 }
 
 export async function getFailureState(
-  workflowDefinitionId: string
+  workflowDefinitionId: string,
+  options: { moduleIds?: string[] | null } = {}
 ): Promise<{ failures: number; nextEligibleAt: string | null } | null> {
+  const moduleIds = normalizeModuleIds(options.moduleIds ?? null);
+  const params: unknown[] = [workflowDefinitionId];
+  let moduleParamIndex: number | null = null;
+  if (moduleIds && moduleIds.length > 0) {
+    moduleParamIndex = params.length + 1;
+    params.push(moduleIds);
+  }
+
+  const moduleFilter = moduleParamIndex
+    ? `AND EXISTS (
+         SELECT 1
+           FROM module_resource_contexts def_ctx
+          WHERE def_ctx.resource_type = 'workflow-definition'
+            AND def_ctx.resource_id = afs.workflow_definition_id
+            AND def_ctx.module_id = ANY($${moduleParamIndex}::text[])
+       )`
+    : '';
+
   const { rows } = await withConnection((client) =>
     client.query<{ failures: number; next_eligible_at: string | null }>(
       `SELECT failures, next_eligible_at
-         FROM asset_materializer_failure_state
-        WHERE workflow_definition_id = $1`,
-      [workflowDefinitionId]
+         FROM asset_materializer_failure_state afs
+        WHERE afs.workflow_definition_id = $1
+          ${moduleFilter}`,
+      params
     )
   );
 

--- a/services/core/src/db/index.ts
+++ b/services/core/src/db/index.ts
@@ -23,4 +23,5 @@ export * from './workflowEventSamples';
 export * from './workflowEventSamplingReplay';
 export * from './runtimeScaling';
 export * from './modules';
+export * from './moduleResourceContexts';
 export * from './assetRecovery';

--- a/services/core/src/db/jobs.ts
+++ b/services/core/src/db/jobs.ts
@@ -219,6 +219,9 @@ async function syncJobDefinitionModuleContext(definition: JobDefinitionRecord): 
     return;
   }
 
+  // Ensure we do not retain stale module contexts when a job definition moves between modules.
+  await deleteModuleAssignmentsForResource('job-definition', definition.id);
+
   try {
     await upsertModuleResourceContext({
       moduleId: binding.moduleId.trim(),

--- a/services/core/src/db/jobs.ts
+++ b/services/core/src/db/jobs.ts
@@ -2,6 +2,10 @@ import { randomUUID } from 'node:crypto';
 import type { PoolClient } from 'pg';
 import { useConnection, useTransaction } from './utils';
 import {
+  deleteModuleAssignmentsForResource,
+  upsertModuleResourceContext
+} from './moduleResourceContexts';
+import {
   type JobDefinitionCreateInput,
   type JobDefinitionRecord,
   type JobRunCompletionInput,
@@ -136,10 +140,123 @@ function emitJobRunEvents(run: JobRunRecord | null, { forceUpdatedEvent = true }
   emitApphubEvent({ type: statusEvent, data: { run } });
 }
 
-export async function listJobDefinitions(): Promise<JobDefinitionRecord[]> {
+function buildJobModuleContextMetadata(definition: JobDefinitionRecord): JsonValue {
+  const metadata: Record<string, JsonValue> = {
+    slug: definition.slug,
+    runtime: definition.runtime,
+    type: definition.type,
+    version: definition.version
+  } satisfies Record<string, JsonValue>;
+
+  if (definition.metadata) {
+    metadata.metadata = definition.metadata as JsonValue;
+  }
+
+  if (definition.defaultParameters) {
+    metadata.defaultParameters = definition.defaultParameters as JsonValue;
+  }
+
+  return metadata;
+}
+
+const TERMINAL_JOB_RUN_STATUSES: ReadonlySet<JobRunStatus> = new Set([
+  'succeeded',
+  'failed',
+  'canceled',
+  'expired'
+]);
+
+function buildJobRunModuleContextMetadata(run: JobRunRecord): JsonValue {
+  return {
+    jobDefinitionId: run.jobDefinitionId,
+    status: run.status,
+    attempt: run.attempt,
+    scheduledAt: run.scheduledAt,
+    startedAt: run.startedAt ?? null,
+    completedAt: run.completedAt ?? null,
+    lastHeartbeatAt: run.lastHeartbeatAt ?? null,
+    retryCount: run.retryCount,
+    failureReason: run.failureReason ?? null
+  } satisfies Record<string, JsonValue>;
+}
+
+async function syncJobRunModuleContext(run: JobRunRecord): Promise<void> {
+  const binding = run.moduleBinding;
+  if (!binding) {
+    await deleteModuleAssignmentsForResource('job-run', run.id);
+    return;
+  }
+
+  if (TERMINAL_JOB_RUN_STATUSES.has(run.status)) {
+    await deleteModuleAssignmentsForResource('job-run', run.id);
+    return;
+  }
+
+  try {
+    await upsertModuleResourceContext({
+      moduleId: binding.moduleId,
+      moduleVersion: binding.moduleVersion,
+      resourceType: 'job-run',
+      resourceId: run.id,
+      resourceSlug: run.jobDefinitionId,
+      resourceName: null,
+      resourceVersion: String(run.attempt),
+      metadata: buildJobRunModuleContextMetadata(run)
+    });
+  } catch (err) {
+    console.warn('[jobs] failed to sync job run module context', {
+      jobRunId: run.id,
+      moduleId: binding.moduleId,
+      error: err instanceof Error ? err.message : String(err)
+    });
+  }
+}
+
+async function syncJobDefinitionModuleContext(definition: JobDefinitionRecord): Promise<void> {
+  const binding = definition.moduleBinding;
+  if (!binding || !binding.moduleId.trim()) {
+    await deleteModuleAssignmentsForResource('job-definition', definition.id);
+    return;
+  }
+
+  try {
+    await upsertModuleResourceContext({
+      moduleId: binding.moduleId.trim(),
+      moduleVersion: binding.moduleVersion?.trim() ?? null,
+      resourceType: 'job-definition',
+      resourceId: definition.id,
+      resourceSlug: definition.slug,
+      resourceName: definition.name,
+      resourceVersion: String(definition.version),
+      metadata: buildJobModuleContextMetadata(definition)
+    });
+  } catch (err) {
+    console.warn('[jobs] failed to sync job definition module context', {
+      jobDefinitionId: definition.id,
+      moduleId: binding.moduleId,
+      error: err instanceof Error ? err.message : String(err)
+    });
+  }
+}
+
+export async function listJobDefinitions(options: { moduleIds?: string[] | null } = {}): Promise<JobDefinitionRecord[]> {
+  const moduleIds = Array.isArray(options.moduleIds)
+    ? Array.from(new Set(options.moduleIds.map((id) => id.trim()).filter((id) => id.length > 0)))
+    : null;
+
   return useConnection(async (client) => {
+    const params: Array<string[]> = [];
+    const whereClauses: string[] = [];
+
+    if (moduleIds && moduleIds.length > 0) {
+      params.push(moduleIds);
+      whereClauses.push(`module_id = ANY($${params.length}::text[])`);
+    }
+
+    const where = whereClauses.length > 0 ? `WHERE ${whereClauses.join(' AND ')}` : '';
     const { rows } = await client.query<JobDefinitionRow>(
-      'SELECT * FROM job_definitions ORDER BY slug ASC'
+      `SELECT * FROM job_definitions ${where} ORDER BY slug ASC`,
+      params
     );
     return rows.map(mapJobDefinitionRow);
   });
@@ -287,6 +404,7 @@ export async function createJobDefinition(
     throw new Error('failed to create job definition');
   }
 
+  await syncJobDefinitionModuleContext(definition);
   emitJobDefinitionEvent(definition);
   return definition;
 }
@@ -296,11 +414,18 @@ export async function deleteJobDefinitionBySlug(slug: string): Promise<boolean> 
   if (!trimmed) {
     return false;
   }
-  return useConnection(async (client) => {
-    const result = await client.query('DELETE FROM job_definitions WHERE slug = $1', [trimmed]);
-    const affected = result.rowCount ?? 0;
-    return affected > 0;
+  const deletedId = await useConnection(async (client) => {
+    const { rows } = await client.query<{ id: string }>(
+      'DELETE FROM job_definitions WHERE slug = $1 RETURNING id',
+      [trimmed]
+    );
+    return rows[0]?.id ?? null;
   });
+  if (!deletedId) {
+    return false;
+  }
+  await deleteModuleAssignmentsForResource('job-definition', deletedId);
+  return true;
 }
 
 export async function upsertJobDefinition(
@@ -393,12 +518,12 @@ export async function upsertJobDefinition(
           binding?.targetFingerprint ?? null
         ]
       );
-      if (rows.length === 0) {
-        throw new Error('failed to insert job definition');
-      }
-      definition = mapJobDefinitionRow(rows[0]);
-      return;
+    if (rows.length === 0) {
+      throw new Error('failed to insert job definition');
     }
+    definition = mapJobDefinitionRow(rows[0]);
+    return;
+  }
 
     const nextMetadata = input.metadata ?? existing.metadata ?? {};
     const nextRetryPolicy = input.retryPolicy ?? existing.retryPolicy ?? {};
@@ -458,6 +583,7 @@ export async function upsertJobDefinition(
     throw new Error('failed to upsert job definition');
   }
 
+  await syncJobDefinitionModuleContext(definition);
   emitJobDefinitionEvent(definition);
   return definition;
 }
@@ -501,6 +627,7 @@ type JobRunListFilters = {
   jobSlugs?: string[];
   runtimes?: string[];
   search?: string;
+  moduleIds?: string[];
 };
 
 export async function listJobRuns(
@@ -513,7 +640,7 @@ export async function listJobRuns(
 
   return useConnection(async (client) => {
     const conditions: string[] = [];
-    const params: unknown[] = [];
+    const params: Array<string | number | string[]> = [];
 
     if (Array.isArray(filters.statuses) && filters.statuses.length > 0) {
       const statuses = Array.from(
@@ -557,6 +684,16 @@ export async function listJobRuns(
            OR jd.name ILIKE $${params.length}
          )`
       );
+    }
+
+    if (Array.isArray(filters.moduleIds) && filters.moduleIds.length > 0) {
+      const moduleIds = Array.from(
+        new Set(filters.moduleIds.map((moduleId) => moduleId.trim()).filter((moduleId) => moduleId.length > 0))
+      );
+      if (moduleIds.length > 0) {
+        params.push(moduleIds);
+        conditions.push(`jd.module_id = ANY($${params.length}::text[])`);
+      }
     }
 
     const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
@@ -740,6 +877,7 @@ export async function createJobRun(
     throw new Error('failed to create job run');
   }
 
+  await syncJobRunModuleContext(run);
   emitJobRunEvents(run);
   return run;
 }
@@ -805,6 +943,7 @@ export async function startJobRun(
   }
 
   const run = mapJobRunRow(row);
+  await syncJobRunModuleContext(run);
   if (changed) {
     emitJobRunEvents(run);
   }
@@ -913,6 +1052,7 @@ export async function completeJobRun(
   }
 
   const run = mapJobRunRow(row);
+  await syncJobRunModuleContext(run);
   if (changed) {
     emitJobRunEvents(run);
   }
@@ -1024,6 +1164,7 @@ export async function updateJobRun(
   }
 
   const run = mapJobRunRow(row);
+  await syncJobRunModuleContext(run);
   if (changed) {
     emitJobRunEvents(run, { forceUpdatedEvent: true });
   }

--- a/services/core/src/db/migrations.ts
+++ b/services/core/src/db/migrations.ts
@@ -1463,6 +1463,29 @@ const migrations: Migration[] = [
            ('role-admin', 'workflows:read')
        ON CONFLICT DO NOTHING;`
     ]
+  },
+  {
+    id: '052_module_resource_contexts',
+    statements: [
+      `CREATE TABLE IF NOT EXISTS module_resource_contexts (
+         module_id TEXT NOT NULL,
+         module_version TEXT,
+         resource_type TEXT NOT NULL,
+         resource_id TEXT NOT NULL,
+         resource_slug TEXT,
+         resource_name TEXT,
+         resource_version TEXT,
+         is_shared BOOLEAN NOT NULL DEFAULT FALSE,
+         metadata JSONB,
+         created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+         updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+         PRIMARY KEY (module_id, resource_type, resource_id)
+       );`,
+      `CREATE INDEX IF NOT EXISTS idx_module_resource_contexts_resource
+         ON module_resource_contexts(resource_type, resource_id);`,
+      `CREATE INDEX IF NOT EXISTS idx_module_resource_contexts_module
+         ON module_resource_contexts(module_id, resource_type);`
+    ]
   }
 ];
 

--- a/services/core/src/db/moduleResourceContexts.ts
+++ b/services/core/src/db/moduleResourceContexts.ts
@@ -1,0 +1,339 @@
+import type { PoolClient } from 'pg';
+import { mapModuleResourceContextRow } from './rowMappers';
+import type { ModuleResourceContextRow } from './rowTypes';
+import {
+  type JsonValue,
+  type ModuleResourceContextDeleteInput,
+  type ModuleResourceContextRecord,
+  type ModuleResourceContextUpsertInput,
+  type ModuleResourceType
+} from './types';
+import { useConnection } from './utils';
+import {
+  publishServiceRegistryInvalidation,
+  type ServiceRegistryInvalidationMessage
+} from '../serviceRegistry/invalidationBus';
+import { emitApphubEvent } from '../events';
+
+function normalizeIdentifier(value: string, label: string): string {
+  if (typeof value !== 'string') {
+    throw new Error(`${label} is required`);
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error(`${label} is required`);
+  }
+  return trimmed;
+}
+
+function normalizeResourceType(resourceType: ModuleResourceType): string {
+  return resourceType.trim().toLowerCase();
+}
+
+function normalizeUpsertInput(input: ModuleResourceContextUpsertInput) {
+  const moduleId = normalizeIdentifier(input.moduleId, 'moduleId');
+  const resourceId = normalizeIdentifier(input.resourceId, 'resourceId');
+  const resourceType = normalizeResourceType(input.resourceType);
+  const moduleVersion = input.moduleVersion === undefined || input.moduleVersion === null
+    ? null
+    : String(input.moduleVersion).trim() || null;
+  const resourceVersion = input.resourceVersion === undefined || input.resourceVersion === null
+    ? null
+    : String(input.resourceVersion).trim() || null;
+  const resourceSlug = input.resourceSlug === undefined || input.resourceSlug === null
+    ? null
+    : input.resourceSlug.trim() || null;
+  const resourceName = input.resourceName === undefined || input.resourceName === null
+    ? null
+    : input.resourceName.trim() || null;
+  const metadata = input.metadata === undefined ? null : (input.metadata as JsonValue | null);
+  const isShared = Boolean(input.isShared);
+
+  return {
+    moduleId,
+    moduleVersion,
+    resourceType,
+    resourceId,
+    resourceSlug,
+    resourceName,
+    resourceVersion,
+    isShared,
+    metadata
+  };
+}
+
+function toInvalidationMessage(
+  record: ModuleResourceContextRecord,
+  action: 'upsert' | 'delete'
+): ServiceRegistryInvalidationMessage {
+  return {
+    kind: 'module-context',
+    moduleId: record.moduleId,
+    moduleVersion: record.moduleVersion ?? null,
+    resourceType: record.resourceType,
+    resourceId: record.resourceId,
+    resourceSlug: record.resourceSlug ?? undefined,
+    resourceName: record.resourceName ?? undefined,
+    action
+  } satisfies ServiceRegistryInvalidationMessage;
+}
+
+async function notifyModuleResourceContextChange(
+  record: ModuleResourceContextRecord,
+  action: 'upsert' | 'delete'
+): Promise<void> {
+  try {
+    await publishServiceRegistryInvalidation(toInvalidationMessage(record, action));
+  } catch (err) {
+    console.warn('[module-resource-contexts] failed to publish invalidation', {
+      moduleId: record.moduleId,
+      resourceType: record.resourceType,
+      resourceId: record.resourceId,
+      action,
+      error: err instanceof Error ? err.message : String(err)
+    });
+  }
+
+  try {
+    emitApphubEvent({
+      type: action === 'upsert' ? 'module.context.updated' : 'module.context.deleted',
+      data: { context: record }
+    });
+  } catch (err) {
+    console.warn('[module-resource-contexts] failed to emit module context event', {
+      moduleId: record.moduleId,
+      resourceType: record.resourceType,
+      resourceId: record.resourceId,
+      action,
+      error: err instanceof Error ? err.message : String(err)
+    });
+  }
+}
+
+async function runUpsertWithClient(
+  client: PoolClient,
+  input: ModuleResourceContextUpsertInput
+): Promise<ModuleResourceContextRecord> {
+  const normalized = normalizeUpsertInput(input);
+  const { rows } = await client.query<ModuleResourceContextRow>(
+    `INSERT INTO module_resource_contexts (
+       module_id,
+       module_version,
+       resource_type,
+       resource_id,
+       resource_slug,
+       resource_name,
+       resource_version,
+       is_shared,
+       metadata,
+       created_at,
+       updated_at
+     ) VALUES (
+       $1,
+       $2,
+       $3,
+       $4,
+       $5,
+       $6,
+       $7,
+       $8,
+       $9::jsonb,
+       NOW(),
+       NOW()
+     )
+     ON CONFLICT (module_id, resource_type, resource_id) DO UPDATE SET
+       module_version = EXCLUDED.module_version,
+       resource_slug = EXCLUDED.resource_slug,
+       resource_name = EXCLUDED.resource_name,
+       resource_version = EXCLUDED.resource_version,
+       is_shared = EXCLUDED.is_shared,
+       metadata = EXCLUDED.metadata,
+       updated_at = NOW()
+     RETURNING *`,
+    [
+      normalized.moduleId,
+      normalized.moduleVersion,
+      normalized.resourceType,
+      normalized.resourceId,
+      normalized.resourceSlug,
+      normalized.resourceName,
+      normalized.resourceVersion,
+      normalized.isShared,
+      normalized.metadata
+    ]
+  );
+
+  if (rows.length === 0) {
+    throw new Error('failed to upsert module resource context');
+  }
+
+  return mapModuleResourceContextRow(rows[0]);
+}
+
+async function runDeleteWithClient(
+  client: PoolClient,
+  input: ModuleResourceContextDeleteInput
+): Promise<ModuleResourceContextRecord | null> {
+  const moduleId = normalizeIdentifier(input.moduleId, 'moduleId');
+  const resourceId = normalizeIdentifier(input.resourceId, 'resourceId');
+  const resourceType = normalizeResourceType(input.resourceType);
+  const { rows } = await client.query<ModuleResourceContextRow>(
+    `SELECT *
+       FROM module_resource_contexts
+      WHERE module_id = $1 AND resource_type = $2 AND resource_id = $3`,
+    [moduleId, resourceType, resourceId]
+  );
+  if (rows.length === 0) {
+    return null;
+  }
+  await client.query(
+    `DELETE FROM module_resource_contexts
+      WHERE module_id = $1 AND resource_type = $2 AND resource_id = $3`,
+    [moduleId, resourceType, resourceId]
+  );
+  return mapModuleResourceContextRow(rows[0]);
+}
+
+export async function upsertModuleResourceContext(
+  input: ModuleResourceContextUpsertInput,
+  options: { client?: PoolClient } = {}
+): Promise<ModuleResourceContextRecord> {
+  if (options.client) {
+    return runUpsertWithClient(options.client, input);
+  }
+  const record = await useConnection((client) => runUpsertWithClient(client, input));
+  await notifyModuleResourceContextChange(record, 'upsert');
+  return record;
+}
+
+export async function upsertModuleResourceContexts(
+  inputs: ModuleResourceContextUpsertInput[],
+  options: { client?: PoolClient } = {}
+): Promise<ModuleResourceContextRecord[]> {
+  if (inputs.length === 0) {
+    return [];
+  }
+  if (options.client) {
+    const results: ModuleResourceContextRecord[] = [];
+    for (const input of inputs) {
+      results.push(await runUpsertWithClient(options.client, input));
+    }
+    return results;
+  }
+  const results = await useConnection(async (client) => {
+    const produced: ModuleResourceContextRecord[] = [];
+    for (const input of inputs) {
+      produced.push(await runUpsertWithClient(client, input));
+    }
+    return produced;
+  });
+  await Promise.all(results.map((record) => notifyModuleResourceContextChange(record, 'upsert')));
+  return results;
+}
+
+export async function deleteModuleResourceContext(
+  input: ModuleResourceContextDeleteInput,
+  options: { client?: PoolClient } = {}
+): Promise<boolean> {
+  if (options.client) {
+    const removed = await runDeleteWithClient(options.client, input);
+    return removed !== null;
+  }
+  const removed = await useConnection((client) => runDeleteWithClient(client, input));
+  if (removed) {
+    await notifyModuleResourceContextChange(removed, 'delete');
+    return true;
+  }
+  return false;
+}
+
+export async function listModuleResourceContextsForModule(
+  moduleId: string,
+  options: { client?: PoolClient; resourceType?: ModuleResourceType }
+): Promise<ModuleResourceContextRecord[]> {
+  const normalizedModuleId = normalizeIdentifier(moduleId, 'moduleId');
+  const resourceType = options.resourceType ? normalizeResourceType(options.resourceType) : null;
+
+  const runner = async (client: PoolClient) => {
+    const params: unknown[] = [normalizedModuleId];
+    let query =
+      'SELECT * FROM module_resource_contexts WHERE module_id = $1 ORDER BY resource_type ASC, resource_id ASC';
+    if (resourceType) {
+      query =
+        'SELECT * FROM module_resource_contexts WHERE module_id = $1 AND resource_type = $2 ORDER BY resource_type ASC, resource_id ASC';
+      params.push(resourceType);
+    }
+    const { rows } = await client.query<ModuleResourceContextRow>(query, params);
+    return rows.map(mapModuleResourceContextRow);
+  };
+
+  if (options.client) {
+    return runner(options.client);
+  }
+  return useConnection(runner);
+}
+
+export async function listModuleAssignmentsForResource(
+  resourceType: ModuleResourceType,
+  resourceId: string,
+  options: { client?: PoolClient } = {}
+): Promise<ModuleResourceContextRecord[]> {
+  const normalizedResourceId = normalizeIdentifier(resourceId, 'resourceId');
+  const normalizedResourceType = normalizeResourceType(resourceType);
+
+  const runner = async (client: PoolClient) => {
+    const { rows } = await client.query<ModuleResourceContextRow>(
+      `SELECT *
+         FROM module_resource_contexts
+        WHERE resource_type = $1 AND resource_id = $2
+        ORDER BY module_id ASC`,
+      [normalizedResourceType, normalizedResourceId]
+    );
+    return rows.map(mapModuleResourceContextRow);
+  };
+
+  if (options.client) {
+    return runner(options.client);
+  }
+  return useConnection(runner);
+}
+
+export async function deleteModuleAssignmentsForResource(
+  resourceType: ModuleResourceType,
+  resourceId: string,
+  options: { client?: PoolClient } = {}
+): Promise<number> {
+  const normalizedResourceId = normalizeIdentifier(resourceId, 'resourceId');
+  const normalizedResourceType = normalizeResourceType(resourceType);
+
+  const runner = async (client: PoolClient) => {
+    const { rows } = await client.query<ModuleResourceContextRow>(
+      `SELECT *
+         FROM module_resource_contexts
+        WHERE resource_type = $1 AND resource_id = $2`,
+      [normalizedResourceType, normalizedResourceId]
+    );
+    if (rows.length === 0) {
+      return { count: 0, contexts: [] as ModuleResourceContextRecord[] };
+    }
+    await client.query(
+      `DELETE FROM module_resource_contexts
+        WHERE resource_type = $1 AND resource_id = $2`,
+      [normalizedResourceType, normalizedResourceId]
+    );
+    return {
+      count: rows.length,
+      contexts: rows.map(mapModuleResourceContextRow)
+    };
+  };
+
+  if (options.client) {
+    const { count } = await runner(options.client);
+    return count;
+  }
+  const { count, contexts } = await useConnection(runner);
+  if (contexts.length > 0) {
+    await Promise.all(contexts.map((record) => notifyModuleResourceContextChange(record, 'delete')));
+  }
+  return count;
+}

--- a/services/core/src/db/modules.ts
+++ b/services/core/src/db/modules.ts
@@ -642,6 +642,17 @@ export async function listModules(): Promise<ModuleRecord[]> {
   });
 }
 
+export async function getModuleById(moduleId: string): Promise<ModuleRecord | null> {
+  const normalized = normalizeModuleId(moduleId);
+  return useConnection(async (client) => {
+    const { rows } = await client.query<ModuleRow>('SELECT * FROM modules WHERE id = $1', [normalized]);
+    if (rows.length === 0) {
+      return null;
+    }
+    return mapModuleRow(rows[0]);
+  });
+}
+
 export async function setModuleEnablement(options: {
   moduleId: string;
   enabled: boolean;

--- a/services/core/src/db/rowMappers.ts
+++ b/services/core/src/db/rowMappers.ts
@@ -77,7 +77,9 @@ import {
   type ModuleArtifactRecord,
   type ModuleRecord,
   type ModuleTargetRecord,
-  type ModuleTargetRuntimeConfigRecord
+  type ModuleTargetRuntimeConfigRecord,
+  type ModuleResourceContextRecord,
+  type ModuleResourceType
 } from './types';
 import type {
   BuildRow,
@@ -118,7 +120,8 @@ import type {
   ModuleArtifactRow,
   ModuleRow,
   ModuleTargetRow,
-  ModuleTargetConfigRow
+  ModuleTargetConfigRow,
+  ModuleResourceContextRow
 } from './rowTypes';
 import type {
   ServiceRecord,
@@ -1679,6 +1682,22 @@ export function mapModuleTargetConfigRow(row: ModuleTargetConfigRow): ModuleTarg
     createdAt: row.created_at,
     updatedAt: row.updated_at
   } satisfies ModuleTargetRuntimeConfigRecord;
+}
+
+export function mapModuleResourceContextRow(row: ModuleResourceContextRow): ModuleResourceContextRecord {
+  return {
+    moduleId: row.module_id,
+    moduleVersion: row.module_version ?? null,
+    resourceType: row.resource_type as ModuleResourceType,
+    resourceId: row.resource_id,
+    resourceSlug: row.resource_slug ?? null,
+    resourceName: row.resource_name ?? null,
+    resourceVersion: row.resource_version ?? null,
+    isShared: Boolean(row.is_shared),
+    metadata: parseJsonColumn(row.metadata),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at
+  } satisfies ModuleResourceContextRecord;
 }
 
 function parseJsonColumn(value: unknown): JsonValue | null {

--- a/services/core/src/db/rowTypes.ts
+++ b/services/core/src/db/rowTypes.ts
@@ -733,3 +733,17 @@ export type ModuleTargetConfigRow = {
   created_at: string;
   updated_at: string;
 };
+
+export type ModuleResourceContextRow = {
+  module_id: string;
+  module_version: string | null;
+  resource_type: string;
+  resource_id: string;
+  resource_slug: string | null;
+  resource_name: string | null;
+  resource_version: string | null;
+  is_shared: boolean;
+  metadata: unknown;
+  created_at: string;
+  updated_at: string;
+};

--- a/services/core/src/db/types.ts
+++ b/services/core/src/db/types.ts
@@ -361,6 +361,7 @@ export type WorkflowEventQueryOptions = {
   jsonPath?: string | null;
   limit?: number;
   cursor?: WorkflowEventCursor | null;
+  eventIds?: string[] | null;
 };
 
 export type WorkflowEventQueryResult = {
@@ -884,6 +885,50 @@ export type ModuleRecord = {
   isEnabled: boolean;
   createdAt: string;
   updatedAt: string;
+};
+
+export type ModuleResourceType =
+  | 'service'
+  | 'service-network'
+  | 'workflow-definition'
+  | 'workflow-run'
+  | 'job-definition'
+  | 'job-run'
+  | 'asset'
+  | 'event'
+  | 'view'
+  | 'metric';
+
+export type ModuleResourceContextRecord = {
+  moduleId: string;
+  moduleVersion: string | null;
+  resourceType: ModuleResourceType;
+  resourceId: string;
+  resourceSlug: string | null;
+  resourceName: string | null;
+  resourceVersion: string | null;
+  isShared: boolean;
+  metadata: JsonValue | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type ModuleResourceContextUpsertInput = {
+  moduleId: string;
+  moduleVersion?: string | null;
+  resourceType: ModuleResourceType;
+  resourceId: string;
+  resourceSlug?: string | null;
+  resourceName?: string | null;
+  resourceVersion?: string | null;
+  isShared?: boolean;
+  metadata?: JsonValue | null;
+};
+
+export type ModuleResourceContextDeleteInput = {
+  moduleId: string;
+  resourceType: ModuleResourceType;
+  resourceId: string;
 };
 
 export type WorkflowTriggerScheduleDefinition = {

--- a/services/core/src/events.ts
+++ b/services/core/src/events.ts
@@ -13,7 +13,8 @@ import type {
   JobBundleVersionRecord,
   WorkflowDefinitionRecord,
   WorkflowRunRecord,
-  WorkflowEventRecord
+  WorkflowEventRecord,
+  ModuleResourceContextRecord
 } from './db/index';
 import type {
   AssetExpiredEventData,
@@ -80,6 +81,8 @@ export type ApphubEvent =
   | { type: 'workflow.run.succeeded'; data: { run: WorkflowRunRecord } }
   | { type: 'workflow.run.failed'; data: { run: WorkflowRunRecord } }
   | { type: 'workflow.run.canceled'; data: { run: WorkflowRunRecord } }
+  | { type: 'module.context.updated'; data: { context: ModuleResourceContextRecord } }
+  | { type: 'module.context.deleted'; data: { context: ModuleResourceContextRecord } }
   | { type: 'asset.produced'; data: AssetProducedEventData }
   | { type: 'asset.expired'; data: AssetExpiredEventData }
   | { type: 'metastore.record.created'; data: MetastoreRecordEventData }

--- a/services/core/src/jobs/service.ts
+++ b/services/core/src/jobs/service.ts
@@ -237,6 +237,7 @@ export type JobRunFilters = {
   jobSlugs?: string[];
   runtimes?: string[];
   search?: string;
+  moduleIds?: string[];
 };
 
 export type JobRunListResult = Awaited<ReturnType<typeof listJobRuns>>;
@@ -524,8 +525,8 @@ function toJobSummary(job: JobDefinitionRecord) {
 export class JobService {
   constructor(private readonly deps: JobServiceDependencies) {}
 
-  async listJobDefinitions(): Promise<JobDefinitionRecord[]> {
-    return this.deps.listJobDefinitions();
+  async listJobDefinitions(options: { moduleIds?: string[] } = {}): Promise<JobDefinitionRecord[]> {
+    return this.deps.listJobDefinitions(options);
   }
 
   async getRuntimeReadiness() {

--- a/services/core/src/routes/core.ts
+++ b/services/core/src/routes/core.ts
@@ -16,12 +16,14 @@ import {
   serializeService,
   serializeWorkflowDefinition,
   serializeWorkflowRun,
+  serializeModuleResourceContext,
   type SerializedBuild,
   type SerializedLaunch,
   type SerializedRepository,
   type SerializedService,
   type SerializedWorkflowDefinition,
-  type SerializedWorkflowRun
+  type SerializedWorkflowRun,
+  type SerializedModuleResourceContext
 } from './shared/serializers';
 import type { IngestionEvent } from '../db/index';
 import {
@@ -72,6 +74,8 @@ type OutboundEvent =
   | { type: 'service.updated'; data: { service: SerializedService } }
   | { type: 'workflow.definition.updated'; data: { workflow: SerializedWorkflowDefinition } }
   | { type: WorkflowRunEventType; data: { run: SerializedWorkflowRun } }
+  | { type: 'module.context.updated'; data: { context: SerializedModuleResourceContext } }
+  | { type: 'module.context.deleted'; data: { context: SerializedModuleResourceContext } }
   | { type: 'workflow.analytics.snapshot'; data: WorkflowAnalyticsSnapshotData }
   | { type: 'workflow.event.received'; data: { event: WorkflowEventRecordView } }
   | { type: 'asset.produced'; data: AssetProducedEventData }
@@ -145,6 +149,12 @@ function toOutboundEvent(event: ApphubEvent): OutboundEvent | null {
       return {
         type: 'workflow.definition.updated',
         data: { workflow: serializeWorkflowDefinition(event.data.workflow) }
+      };
+    case 'module.context.updated':
+    case 'module.context.deleted':
+      return {
+        type: event.type,
+        data: { context: serializeModuleResourceContext(event.data.context) }
       };
     case 'workflow.run.updated':
     case 'workflow.run.pending':

--- a/services/core/src/routes/jobs.ts
+++ b/services/core/src/routes/jobs.ts
@@ -26,6 +26,7 @@ import type { BundleEditorSnapshot } from '../jobs/bundleEditor';
 import type { JobDefinitionRecord, JsonValue } from '../db/types';
 import type { AiGeneratedBundleSuggestion } from '../ai/bundlePublisher';
 import { schemaRef } from '../openapi/definitions';
+import { handleModuleScopeError, resolveModuleScope } from './shared/moduleScope';
 
 const jobService = createJobService();
 
@@ -107,7 +108,8 @@ const jobRunListQuerySchema = z
         }
         return undefined;
       }, z.array(z.string()).optional()),
-    search: z.string().max(200).optional()
+    search: z.string().max(200).optional(),
+    moduleId: z.union([z.string(), z.array(z.string())]).optional()
   })
   .partial();
 
@@ -136,7 +138,11 @@ const jobRunListQueryOpenApiSchema = {
       type: 'string',
       description: 'Comma-separated list of runtimes to filter (node,python,docker,module).'
     },
-    search: { type: 'string', maxLength: 200 }
+    search: { type: 'string', maxLength: 200 },
+    moduleId: {
+      anyOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }],
+      description: 'Optional module identifier to scope job runs.'
+    }
   }
 } as const;
 
@@ -263,15 +269,37 @@ export async function registerJobRoutes(app: FastifyInstance): Promise<void> {
       schema: {
         tags: ['Jobs'],
         summary: 'List job definitions',
+        querystring: {
+          type: 'object',
+          additionalProperties: true,
+          properties: {
+            moduleId: {
+              anyOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }],
+              description: 'Optional module identifier to scope job definitions.'
+            }
+          }
+        },
         response: {
           200: jobDefinitionListResponse('Job definitions currently available to run.')
         }
       }
     },
-    async (_request, reply) => {
-      const jobs = await jobService.listJobDefinitions();
+    async (request, reply) => {
+      let moduleScope;
+      try {
+        const moduleIdValue = (request.query as { moduleId?: unknown } | undefined)?.moduleId;
+        moduleScope = await resolveModuleScope(request, moduleIdValue, ['job-definition']);
+      } catch (error) {
+        return handleModuleScopeError(reply, error);
+      }
+
+      const moduleIds = moduleScope?.hasFilters ? moduleScope.moduleIds : undefined;
+      const jobs = await jobService.listJobDefinitions({ moduleIds });
+      const filteredJobs = moduleScope?.hasFilters
+        ? moduleScope.filter(jobs, 'job-definition', (job) => ({ id: job.id, slug: job.slug }))
+        : jobs;
       reply.status(200);
-      return { data: jobs.map((job) => serializeJobDefinition(job)) };
+      return { data: filteredJobs.map((job) => serializeJobDefinition(job)) };
     }
   );
 
@@ -332,30 +360,54 @@ export async function registerJobRoutes(app: FastifyInstance): Promise<void> {
         return { error: parseQuery.error.flatten() };
       }
 
+      let moduleScope;
+      try {
+        moduleScope = await resolveModuleScope(request, parseQuery.data.moduleId, [
+          'job-definition',
+          'job-run'
+        ]);
+      } catch (error) {
+        return handleModuleScopeError(reply, error);
+      }
+
       const limit = Math.min(Math.max(parseQuery.data.limit ?? 25, 1), 50);
       const offset = Math.max(parseQuery.data.offset ?? 0, 0);
+      const slugSet = new Set<string>(parseQuery.data.job ?? []);
+      if (moduleScope?.hasFilters) {
+        for (const slug of moduleScope.getSlugs('job-definition')) {
+          slugSet.add(slug);
+        }
+      }
       const filters = {
         statuses: parseQuery.data.status,
-        jobSlugs: parseQuery.data.job,
+        jobSlugs: slugSet.size > 0 ? Array.from(slugSet) : undefined,
         runtimes: parseQuery.data.runtime,
-        search: parseQuery.data.search
+        search: parseQuery.data.search,
+        moduleIds: moduleScope?.hasFilters ? moduleScope.moduleIds : undefined
       };
       const { items, hasMore } = await jobService.listJobRuns({ limit, offset, filters });
+
+      const scopedItems = moduleScope?.hasFilters
+        ? items.filter((entry) =>
+            moduleScope.matches('job-run', { id: entry.run.id }) ||
+            moduleScope.matches('job-definition', { id: entry.job.id, slug: entry.job.slug })
+          )
+        : items;
 
       reply.status(200);
       await authResult.auth.log('succeeded', {
         action: 'job-runs.list',
-        count: items.length,
+        count: scopedItems.length,
         limit,
         offset,
-        hasMore
+        hasMore: hasMore && scopedItems.length > 0
       });
       return {
-        data: items.map((entry) => serializeJobRunWithDefinition(entry)),
+        data: scopedItems.map((entry) => serializeJobRunWithDefinition(entry)),
         meta: {
           limit,
           offset,
-          hasMore,
+          hasMore: hasMore && scopedItems.length > 0,
           nextOffset: hasMore ? offset + limit : null
         }
       };

--- a/services/core/src/routes/modules.ts
+++ b/services/core/src/routes/modules.ts
@@ -2,6 +2,9 @@ import { z } from 'zod';
 import type { FastifyInstance } from 'fastify';
 import type { ModuleCatalogData } from '@apphub/module-registry';
 import { getModuleCatalog } from '../modules/catalogService';
+import { listModuleResourceContextsForModule } from '../db/moduleResourceContexts';
+import { listModules } from '../db/modules';
+import type { ModuleResourceContextRecord, ModuleResourceType, ModuleRecord } from '../db/types';
 
 const catalogQuerySchema = z
   .object({
@@ -11,6 +14,30 @@ const catalogQuerySchema = z
       .toLowerCase()
       .transform((value) => value === 'true' || value === '1')
       .optional()
+  })
+  .strict()
+  .partial();
+
+const moduleResourceTypes = [
+  'service',
+  'service-network',
+  'workflow-definition',
+  'workflow-run',
+  'job-definition',
+  'job-run',
+  'asset',
+  'event',
+  'view',
+  'metric'
+] as const satisfies readonly ModuleResourceType[];
+
+const moduleResourceParamsSchema = z.object({
+  moduleId: z.string().trim().min(1)
+});
+
+const moduleResourceQuerySchema = z
+  .object({
+    resourceType: z.enum(moduleResourceTypes).optional()
   })
   .strict()
   .partial();
@@ -42,6 +69,53 @@ export async function registerModuleRoutes(app: FastifyInstance): Promise<void> 
       request.log.error({ err: error }, 'Failed to load module catalog');
       reply.status(500);
       return { error: 'Failed to load module catalog' };
+    }
+  });
+
+  app.get('/modules', async (request, reply) => {
+    try {
+      const modules: ModuleRecord[] = await listModules();
+      reply.status(200);
+      return { data: modules };
+    } catch (error) {
+      request.log.error({ err: error }, 'Failed to list modules');
+      reply.status(500);
+      return { error: 'Failed to list modules' };
+    }
+  });
+
+  app.get('/modules/:moduleId/resources', async (request, reply) => {
+    const parsedParams = moduleResourceParamsSchema.safeParse(request.params ?? {});
+    if (!parsedParams.success) {
+      reply.status(400);
+      return { error: parsedParams.error.flatten() };
+    }
+
+    const parsedQuery = moduleResourceQuerySchema.safeParse(request.query ?? {});
+    if (!parsedQuery.success) {
+      reply.status(400);
+      return { error: parsedQuery.error.flatten() };
+    }
+
+    const moduleId = parsedParams.data.moduleId;
+    const resourceType = parsedQuery.data.resourceType;
+
+    try {
+      const resources: ModuleResourceContextRecord[] = await listModuleResourceContextsForModule(moduleId, {
+        resourceType
+      });
+      reply.status(200);
+      return {
+        data: {
+          moduleId,
+          resourceType: resourceType ?? null,
+          resources
+        }
+      };
+    } catch (error) {
+      request.log.error({ err: error, moduleId }, 'Failed to load module resource contexts');
+      reply.status(500);
+      return { error: 'Failed to load module resource contexts' };
     }
   });
 }

--- a/services/core/src/routes/services.ts
+++ b/services/core/src/routes/services.ts
@@ -11,6 +11,7 @@ import {
   listServices,
   setServiceStatus,
   upsertService,
+  upsertModuleResourceContext,
   type JsonValue,
   type ServiceRecord,
   type ServiceStatusUpdate,
@@ -41,7 +42,12 @@ import {
 } from '../serviceManifestHelpers';
 import { getServiceHealthSnapshot, getServiceHealthSnapshots } from '../serviceRegistry';
 import { schemaRef } from '../openapi/definitions';
-import type { WorkflowStepDefinition, WorkflowTriggerDefinition } from '../db/types';
+import { handleModuleScopeError, resolveModuleScope } from './shared/moduleScope';
+import type {
+  WorkflowDefinitionRecord,
+  WorkflowStepDefinition,
+  WorkflowTriggerDefinition
+} from '../db/types';
 import type { ModuleManifest } from '@apphub/module-sdk';
 
 const SERVICE_REGISTRY_TOKEN = process.env.SERVICE_REGISTRY_TOKEN ?? '';
@@ -275,6 +281,78 @@ async function handleS3ModuleArtifact(params: {
   };
 }
 
+function buildWorkflowModuleContextMetadata(
+  workflow: LoadedWorkflowDefinition,
+  definition: WorkflowDefinitionRecord
+): JsonValue {
+  const metadata: Record<string, JsonValue> = {
+    sources: workflow.sources,
+    slug: definition.slug,
+    name: definition.name,
+    version: definition.version,
+    parametersSchema: definition.parametersSchema,
+    defaultParameters: definition.defaultParameters,
+    dag: JSON.parse(JSON.stringify(definition.dag)) as JsonValue
+  } satisfies Record<string, JsonValue>;
+
+  if (definition.metadata) {
+    metadata.metadata = definition.metadata;
+  }
+
+  if (workflow.definition.metadata !== undefined && workflow.definition.metadata !== null) {
+    metadata.manifest = workflow.definition.metadata as JsonValue;
+  }
+
+  return metadata;
+}
+
+async function applyModuleVersionToWorkflows(
+  moduleId: string,
+  moduleVersion: string,
+  workflows: LoadedWorkflowDefinition[],
+  logger: FastifyBaseLogger
+): Promise<void> {
+  const version = moduleVersion.trim();
+  if (!version) {
+    return;
+  }
+
+  const workflowBySlug = new Map<string, LoadedWorkflowDefinition>();
+  for (const workflow of workflows) {
+    const slug = workflow.definition.slug.trim().toLowerCase();
+    if (!slug) {
+      continue;
+    }
+    if (!workflowBySlug.has(slug)) {
+      workflowBySlug.set(slug, workflow);
+    }
+  }
+
+  for (const [slug, workflow] of workflowBySlug.entries()) {
+    try {
+      const definition = await getWorkflowDefinitionBySlug(slug);
+      if (!definition) {
+        continue;
+      }
+      await upsertModuleResourceContext({
+        moduleId,
+        moduleVersion: version,
+        resourceType: 'workflow-definition',
+        resourceId: definition.id,
+        resourceSlug: definition.slug,
+        resourceName: definition.name,
+        resourceVersion: String(definition.version),
+        metadata: buildWorkflowModuleContextMetadata(workflow, definition)
+      });
+    } catch (err) {
+      logger.warn(
+        { err, workflow: slug, moduleId, moduleVersion: version },
+        'Failed to update workflow module context version'
+      );
+    }
+  }
+}
+
 async function upsertModuleWorkflows(
   workflows: LoadedWorkflowDefinition[],
   options: { moduleId: string; logger: FastifyBaseLogger }
@@ -284,6 +362,28 @@ async function upsertModuleWorkflows(
   }
 
   const failures: Array<{ slug: string; error: Error }> = [];
+  const upsertContextForDefinition = async (
+    source: LoadedWorkflowDefinition,
+    definition: WorkflowDefinitionRecord
+  ) => {
+    try {
+      await upsertModuleResourceContext({
+        moduleId: options.moduleId,
+        moduleVersion: null,
+        resourceType: 'workflow-definition',
+        resourceId: definition.id,
+        resourceSlug: definition.slug,
+        resourceName: definition.name,
+        resourceVersion: String(definition.version),
+        metadata: buildWorkflowModuleContextMetadata(source, definition)
+      });
+    } catch (err) {
+      options.logger.warn(
+        { err, workflow: definition.slug, moduleId: options.moduleId },
+        'Failed to upsert workflow module context'
+      );
+    }
+  };
 
   for (const workflow of workflows) {
     try {
@@ -315,7 +415,7 @@ async function upsertModuleWorkflows(
 
       const existing = await getWorkflowDefinitionBySlug(slug);
       if (!existing) {
-        await createWorkflowDefinition({
+        const definitionRecord = await createWorkflowDefinition({
           slug,
           name,
           version,
@@ -332,8 +432,9 @@ async function upsertModuleWorkflows(
           { workflow: slug, moduleId: options.moduleId, sources: workflow.sources },
           'Imported workflow definition from module'
         );
+        await upsertContextForDefinition(workflow, definitionRecord);
       } else {
-        await updateWorkflowDefinition(slug, {
+        const updatedDefinition = await updateWorkflowDefinition(slug, {
           name,
           version,
           description,
@@ -345,6 +446,9 @@ async function upsertModuleWorkflows(
           metadata,
           dag: dagMetadata
         });
+        if (updatedDefinition) {
+          await upsertContextForDefinition(workflow, updatedDefinition);
+        }
         options.logger.info(
           { workflow: slug, moduleId: options.moduleId, sources: workflow.sources },
           'Updated workflow definition from module'
@@ -592,7 +696,7 @@ export type ServiceRoutesOptions = {
       moduleId: string;
       entries: LoadedManifestEntry[];
       networks: LoadedServiceNetwork[];
-    }) => Promise<{ servicesApplied: number; networksApplied: number }>;
+    }) => Promise<{ servicesApplied: number; networksApplied: number; moduleVersion: string }>;
   };
 };
 
@@ -756,8 +860,9 @@ export async function registerServiceRoutes(app: FastifyInstance, options: Servi
       return { error: 'failed to import workflows for module' };
     }
 
+    let manifestImportResult: { servicesApplied: number; networksApplied: number; moduleVersion: string };
     try {
-      await registry.importManifestModule({
+      manifestImportResult = await registry.importManifestModule({
         moduleId: preview.moduleId,
         entries: preview.entries,
         networks: preview.networks
@@ -771,10 +876,25 @@ export async function registerServiceRoutes(app: FastifyInstance, options: Servi
       return { error: 'failed to apply service manifest' };
     }
 
+    try {
+      await applyModuleVersionToWorkflows(
+        preview.moduleId,
+        manifestImportResult.moduleVersion,
+        preview.workflows,
+        request.log
+      );
+    } catch (err) {
+      request.log.warn(
+        { err, module: preview.moduleId },
+        'failed to update workflow module version context'
+      );
+    }
+
     reply.status(201);
     return {
       data: {
         module: preview.moduleId,
+        moduleVersion: manifestImportResult.moduleVersion,
         resolvedCommit: preview.resolvedCommit ?? commit ?? image ?? null,
         servicesDiscovered: preview.entries.length,
         networksDiscovered: preview.networks.length,
@@ -830,7 +950,11 @@ export async function registerServiceRoutes(app: FastifyInstance, options: Servi
           type: 'object',
           additionalProperties: true,
           properties: {
-            source: { type: 'string', enum: ['module', 'external'] }
+            source: { type: 'string', enum: ['module', 'external'] },
+            moduleId: {
+              anyOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }],
+              description: 'Optional module identifier to scope services.'
+            }
           }
         },
         response: {
@@ -841,7 +965,10 @@ export async function registerServiceRoutes(app: FastifyInstance, options: Servi
     },
     async (request, reply) => {
       const parseQuery = z
-        .object({ source: serviceSourceFilterSchema.optional() })
+        .object({
+          source: serviceSourceFilterSchema.optional(),
+          moduleId: z.union([z.string(), z.array(z.string())]).optional()
+        })
         .passthrough()
         .safeParse(request.query ?? {});
 
@@ -850,18 +977,33 @@ export async function registerServiceRoutes(app: FastifyInstance, options: Servi
         return { error: parseQuery.error.flatten() };
       }
 
-      const { source } = parseQuery.data;
+      const { source, moduleId } = parseQuery.data;
+
+      let moduleScope;
+      try {
+        moduleScope = await resolveModuleScope(request, moduleId, ['service']);
+      } catch (error) {
+        return handleModuleScopeError(reply, error);
+      }
+
       const services = await listServices();
-      const filteredServices = source
+      const sourceFiltered = source
         ? services.filter((service) => service.source === source)
         : services;
+
+      const filteredServices = moduleScope?.hasFilters
+        ? moduleScope.filter(sourceFiltered, 'service', (service) => ({
+            id: service.id,
+            slug: service.slug
+          }))
+        : sourceFiltered;
 
       const healthSnapshots = await getServiceHealthSnapshots(
         filteredServices.map((service) => service.slug)
       );
       const healthyCount = filteredServices.filter((service) => service.status === 'healthy').length;
       const unhealthyCount = filteredServices.length - healthyCount;
-      const sourceCounts = services.reduce(
+      const sourceCounts = filteredServices.reduce(
         (acc, service) => {
           acc[service.source] = (acc[service.source] ?? 0) + 1;
           return acc;
@@ -877,7 +1019,13 @@ export async function registerServiceRoutes(app: FastifyInstance, options: Servi
           total: filteredServices.length,
           healthyCount,
           unhealthyCount,
-          filters: source ? { source } : null,
+          filters:
+            source || (moduleScope?.hasFilters && moduleScope.moduleIds.length > 0)
+              ? {
+                  ...(source ? { source } : {}),
+                  ...(moduleScope?.hasFilters ? { moduleId: moduleScope.moduleIds } : {})
+                }
+              : null,
           sourceCounts
         }
       };

--- a/services/core/src/routes/shared/moduleScope.ts
+++ b/services/core/src/routes/shared/moduleScope.ts
@@ -1,0 +1,169 @@
+import { z } from 'zod';
+import type { FastifyReply, FastifyRequest } from 'fastify';
+import {
+  getModuleById,
+  listModuleResourceContextsForModule
+} from '../../db';
+import type { ModuleResourceType } from '../../db/types';
+
+const moduleIdSchema = z
+  .union([z.string(), z.array(z.string())])
+  .transform((value) => {
+    if (Array.isArray(value)) {
+      return value.flatMap((entry) => splitModuleIds(entry));
+    }
+    return splitModuleIds(value);
+  });
+
+function splitModuleIds(value: string): string[] {
+  return value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+export class ModuleScopeError extends Error {
+  statusCode: number;
+  constructor(statusCode: number, message: string) {
+    super(message);
+    this.statusCode = statusCode;
+  }
+}
+
+export type ModuleScope = {
+  moduleIds: string[];
+  hasFilters: boolean;
+  matches: (
+    resourceType: ModuleResourceType,
+    identifiers: { id?: string | null; slug?: string | null }
+  ) => boolean;
+  filter: <T>(
+    records: T[],
+    resourceType: ModuleResourceType,
+    getIdentifiers: (record: T) => { id?: string | null; slug?: string | null }
+  ) => T[];
+  getSlugs: (resourceType: ModuleResourceType) => string[];
+  getIds: (resourceType: ModuleResourceType) => string[];
+};
+
+export async function resolveModuleScope(
+  request: FastifyRequest,
+  moduleIdValue: unknown,
+  resourceTypes: readonly ModuleResourceType[]
+): Promise<ModuleScope | null> {
+  const rawModuleIds = parseModuleIds(moduleIdValue ?? request.headers['x-apphub-module-id']);
+  if (!rawModuleIds || rawModuleIds.length === 0) {
+    return {
+      moduleIds: [],
+      hasFilters: false,
+      matches: () => true,
+      filter: (records) => records,
+      getSlugs: () => [],
+      getIds: () => []
+    } satisfies ModuleScope;
+  }
+
+  const moduleIds = Array.from(new Set(rawModuleIds));
+  const resources = await loadModuleResources(moduleIds, resourceTypes);
+
+  return {
+    moduleIds,
+    hasFilters: true,
+    matches: (resourceType, identifiers) => matchesResource(resources, resourceType, identifiers),
+    filter: (records, resourceType, getIdentifiers) =>
+      records.filter((record) => matchesResource(resources, resourceType, getIdentifiers(record))),
+    getSlugs: (resourceType) => {
+      const entry = resources.get(resourceType);
+      return entry ? Array.from(entry.slugs.values()) : [];
+    },
+    getIds: (resourceType) => {
+      const entry = resources.get(resourceType);
+      return entry ? Array.from(entry.ids) : [];
+    }
+  } satisfies ModuleScope;
+}
+
+function parseModuleIds(input: unknown): string[] | null {
+  if (!input) {
+    return null;
+  }
+  const result = moduleIdSchema.safeParse(input);
+  if (!result.success) {
+    throw new ModuleScopeError(400, 'Invalid moduleId parameter');
+  }
+  return result.data;
+}
+
+type ResourceEntry = {
+  ids: Set<string>;
+  slugs: Set<string>;
+  slugLookup: Set<string>;
+};
+
+async function loadModuleResources(
+  moduleIds: string[],
+  resourceTypes: readonly ModuleResourceType[]
+): Promise<Map<ModuleResourceType, ResourceEntry>> {
+  const typeSet = new Set(resourceTypes);
+  const resources = new Map<ModuleResourceType, ResourceEntry>();
+
+  for (const moduleId of moduleIds) {
+    const record = await getModuleById(moduleId);
+    if (!record) {
+      throw new ModuleScopeError(404, `Module not found: ${moduleId}`);
+    }
+    const contexts = await listModuleResourceContextsForModule(moduleId, {});
+    for (const context of contexts) {
+      const resourceType = context.resourceType as ModuleResourceType;
+      if (!typeSet.has(resourceType)) {
+        continue;
+      }
+      let entry = resources.get(resourceType);
+      if (!entry) {
+        entry = { ids: new Set<string>(), slugs: new Set<string>(), slugLookup: new Set<string>() } satisfies ResourceEntry;
+        resources.set(resourceType, entry);
+      }
+      const normalizedId = context.resourceId.trim();
+      if (normalizedId) {
+        entry.ids.add(normalizedId);
+      }
+      if (context.resourceSlug) {
+        const slug = context.resourceSlug.trim();
+        if (slug) {
+          entry.slugs.add(slug);
+          entry.slugLookup.add(slug.toLowerCase());
+        }
+      }
+    }
+  }
+
+  return resources;
+}
+
+function matchesResource(
+  resources: Map<ModuleResourceType, ResourceEntry>,
+  resourceType: ModuleResourceType,
+  identifiers: { id?: string | null; slug?: string | null }
+): boolean {
+  const entry = resources.get(resourceType);
+  if (!entry) {
+    return false;
+  }
+  const identifierId = identifiers.id?.trim();
+  if (identifierId && entry.ids.has(identifierId)) {
+    return true;
+  }
+  const slug = identifiers.slug?.trim().toLowerCase();
+  if (slug && entry.slugLookup.has(slug)) {
+    return true;
+  }
+  return false;
+}
+
+export function handleModuleScopeError(reply: FastifyReply, error: unknown): { error: string } | never {
+  if (error instanceof ModuleScopeError) {
+    reply.status(error.statusCode);
+    return { error: error.message };
+  }
+  throw error;
+}

--- a/services/core/src/routes/shared/serializers.ts
+++ b/services/core/src/routes/shared/serializers.ts
@@ -22,7 +22,8 @@ import {
   type WorkflowEventRecord,
   type WorkflowActivityEntry,
   type WorkflowExecutionHistoryRecord,
-  type WorkflowRunStepAssetRecord
+  type WorkflowRunStepAssetRecord,
+  type ModuleResourceContextRecord
 } from '../../db/index';
 import type { BundleDownloadInfo } from '../../jobs/bundleStorage';
 import type { WorkflowJsonValue } from '../../workflows/zodSchemas';
@@ -648,6 +649,22 @@ export function serializeWorkflowEvent(event: WorkflowEventRecord) {
   };
 }
 
+export function serializeModuleResourceContext(context: ModuleResourceContextRecord) {
+  return {
+    moduleId: context.moduleId,
+    moduleVersion: context.moduleVersion,
+    resourceType: context.resourceType,
+    resourceId: context.resourceId,
+    resourceSlug: context.resourceSlug,
+    resourceName: context.resourceName,
+    resourceVersion: context.resourceVersion,
+    isShared: context.isShared,
+    metadata: context.metadata,
+    createdAt: context.createdAt,
+    updatedAt: context.updatedAt
+  };
+}
+
 export type SerializedRepository = ReturnType<typeof serializeRepository>;
 export type SerializedBuild = ReturnType<typeof serializeBuild>;
 export type SerializedLaunch = ReturnType<typeof serializeLaunch>;
@@ -663,3 +680,4 @@ export type SerializedWorkflowEventTrigger = ReturnType<typeof serializeWorkflow
 export type SerializedWorkflowTriggerDelivery = ReturnType<typeof serializeWorkflowTriggerDelivery>;
 export type SerializedWorkflowActivityEntry = ReturnType<typeof serializeWorkflowActivityEntry>;
 export type SerializedWorkflowEventRecord = ReturnType<typeof serializeWorkflowEvent>;
+export type SerializedModuleResourceContext = ReturnType<typeof serializeModuleResourceContext>;

--- a/services/core/src/routes/workflows.ts
+++ b/services/core/src/routes/workflows.ts
@@ -111,6 +111,7 @@ import { registerWorkflowTriggerRoutes } from './workflows/triggers';
 import { registerWorkflowGraphRoute } from './workflows/graph';
 import { getWorkflowDefaultParameters } from '../bootstrap';
 import { schemaRef } from '../openapi/definitions';
+import { handleModuleScopeError, resolveModuleScope } from './shared/moduleScope';
 import {
   diffJson,
   diffStatusTransitions,
@@ -301,7 +302,8 @@ const workflowRunListQuerySchema = z
     partition: z.string().max(200).optional(),
     search: z.string().max(200).optional(),
     from: z.string().datetime({ offset: true }).optional(),
-    to: z.string().datetime({ offset: true }).optional()
+    to: z.string().datetime({ offset: true }).optional(),
+    moduleId: z.union([z.string(), z.array(z.string())]).optional()
   })
   .partial();
 
@@ -326,7 +328,11 @@ const workflowRunListQueryOpenApiSchema = {
     partition: { type: 'string', maxLength: 200 },
     search: { type: 'string', maxLength: 200 },
     from: { type: 'string', format: 'date-time' },
-    to: { type: 'string', format: 'date-time' }
+    to: { type: 'string', format: 'date-time' },
+    moduleId: {
+      anyOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }],
+      description: 'Optional module identifier to scope workflow runs.'
+    }
   }
 } as const;
 
@@ -343,7 +349,8 @@ const workflowActivityListQuerySchema = z
     kind: stringArrayQuerySchema,
     search: z.string().max(200).optional(),
     from: z.string().datetime({ offset: true }).optional(),
-    to: z.string().datetime({ offset: true }).optional()
+    to: z.string().datetime({ offset: true }).optional(),
+    moduleId: z.union([z.string(), z.array(z.string())]).optional()
   })
   .partial();
 
@@ -363,7 +370,8 @@ const workflowTimelineQuerySchema = z
           return val.split(',');
         }
         return undefined;
-      }, z.array(z.string()).optional())
+      }, z.array(z.string()).optional()),
+    moduleId: z.union([z.string(), z.array(z.string())]).optional()
   })
   .partial();
 
@@ -405,14 +413,16 @@ const workflowAssetHistoryQuerySchema = z
   .object({
     limit: z
       .preprocess((val) => (val === undefined ? undefined : Number(val)), z.number().int().min(1).max(100).optional()),
-    partitionKey: z.string().min(1).max(200).optional()
+    partitionKey: z.string().min(1).max(200).optional(),
+    moduleId: z.union([z.string(), z.array(z.string())]).optional()
   })
   .partial();
 
 const workflowAssetPartitionsQuerySchema = z
   .object({
     lookback: z
-      .preprocess((val) => (val === undefined ? undefined : Number(val)), z.number().int().min(1).max(10_000).optional())
+      .preprocess((val) => (val === undefined ? undefined : Number(val)), z.number().int().min(1).max(10_000).optional()),
+    moduleId: z.union([z.string(), z.array(z.string())]).optional()
   })
   .partial();
 
@@ -437,7 +447,8 @@ const workflowAssetAutoMaterializeUpdateSchema = z
 
 const workflowAssetPartitionParamsQuerySchema = z
   .object({
-    partitionKey: z.string().min(1).max(200).optional()
+    partitionKey: z.string().min(1).max(200).optional(),
+    moduleId: z.union([z.string(), z.array(z.string())]).optional()
   })
   .partial();
 
@@ -457,17 +468,43 @@ export async function registerWorkflowRoutes(app: FastifyInstance): Promise<void
       schema: {
         tags: ['Workflows'],
         summary: 'List workflow definitions',
+        querystring: {
+          type: 'object',
+          additionalProperties: true,
+          properties: {
+            moduleId: {
+              anyOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }],
+              description: 'Optional module identifier to scope workflow definitions.'
+            }
+          }
+        },
         response: {
           200: workflowDefinitionListResponse('Workflow definitions currently available.'),
           500: errorResponse('The server failed to fetch workflow definitions.')
         }
       }
     },
-    async (_request, reply) => {
+    async (request, reply) => {
+      let moduleScope;
       try {
-        const workflows = await listWorkflowDefinitions();
+        moduleScope = await resolveModuleScope(request, (request.query as { moduleId?: unknown } | undefined)?.moduleId, [
+          'workflow-definition'
+        ]);
+      } catch (error) {
+        return handleModuleScopeError(reply, error);
+      }
+      try {
+        const workflows = await listWorkflowDefinitions({
+          moduleIds: moduleScope?.hasFilters ? moduleScope.moduleIds : undefined
+        });
+        const filtered = moduleScope?.hasFilters
+          ? moduleScope.filter(workflows, 'workflow-definition', (workflow) => ({
+              id: workflow.id,
+              slug: workflow.slug
+            }))
+          : workflows;
         reply.status(200);
-        return { data: workflows.map((workflow) => serializeWorkflowDefinition(workflow)) };
+        return { data: filtered.map((workflow) => serializeWorkflowDefinition(workflow)) };
       } catch (err) {
         reply.status(500);
         return { error: 'Failed to list workflows' };
@@ -476,11 +513,29 @@ export async function registerWorkflowRoutes(app: FastifyInstance): Promise<void
   );
 
   app.get('/workflow-schedules', async (request, reply) => {
+    let moduleScope;
     try {
-      const schedules = await listWorkflowSchedulesWithWorkflow();
+      moduleScope = await resolveModuleScope(request, (request.query as { moduleId?: unknown } | undefined)?.moduleId, [
+        'workflow-definition'
+      ]);
+    } catch (error) {
+      return handleModuleScopeError(reply, error);
+    }
+    try {
+      const schedules = await listWorkflowSchedulesWithWorkflow({
+        moduleIds: moduleScope?.hasFilters ? moduleScope.moduleIds : undefined
+      });
+      const filteredSchedules = moduleScope?.hasFilters
+        ? schedules.filter((entry) =>
+            moduleScope.matches('workflow-definition', {
+              id: entry.workflow.id,
+              slug: entry.workflow.slug
+            })
+          )
+        : schedules;
       reply.status(200);
       return {
-        data: schedules.map((entry) => ({
+        data: filteredSchedules.map((entry) => ({
           schedule: serializeWorkflowSchedule(entry.schedule),
           workflow: {
             id: entry.workflow.id,
@@ -517,33 +572,60 @@ export async function registerWorkflowRoutes(app: FastifyInstance): Promise<void
       return { error: parseQuery.error.flatten() };
     }
 
+    let moduleScope;
+    try {
+      moduleScope = await resolveModuleScope(request, parseQuery.data.moduleId, [
+        'workflow-definition',
+        'workflow-run'
+      ]);
+    } catch (error) {
+      return handleModuleScopeError(reply, error);
+    }
+
     const limit = Math.min(Math.max(parseQuery.data.limit ?? 20, 1), 50);
     const offset = Math.max(parseQuery.data.offset ?? 0, 0);
+    const slugSet = new Set<string>(parseQuery.data.workflow ?? []);
+    if (moduleScope?.hasFilters) {
+      for (const slug of moduleScope.getSlugs('workflow-definition')) {
+        slugSet.add(slug);
+      }
+    }
     const filters = {
       statuses: parseQuery.data.status,
-      workflowSlugs: parseQuery.data.workflow,
+      workflowSlugs: slugSet.size > 0 ? Array.from(slugSet) : undefined,
       triggerTypes: parseQuery.data.trigger,
       partition: parseQuery.data.partition,
       search: parseQuery.data.search,
       from: parseQuery.data.from,
-      to: parseQuery.data.to
-    };
+      to: parseQuery.data.to,
+      moduleIds: moduleScope?.hasFilters ? moduleScope.moduleIds : undefined
+    } satisfies NonNullable<Parameters<typeof listWorkflowRuns>[0]>['filters'];
+
     const { items, hasMore } = await listWorkflowRuns({ limit, offset, filters });
+    const scopedItems = moduleScope?.hasFilters
+      ? items.filter((entry) =>
+          moduleScope.matches('workflow-run', { id: entry.run.id }) ||
+          moduleScope.matches('workflow-definition', {
+            id: entry.workflow.id,
+            slug: entry.workflow.slug
+          })
+        )
+      : items;
 
     reply.status(200);
     await authResult.auth.log('succeeded', {
       action: 'workflow-runs.list',
-      count: items.length,
+      count: scopedItems.length,
       limit,
       offset,
-      hasMore
+      hasMore: hasMore && scopedItems.length > 0
     });
     return {
-      data: items.map((entry) => serializeWorkflowRunWithDefinition(entry)),
+      data: scopedItems.map((entry) => serializeWorkflowRunWithDefinition(entry)),
       meta: {
         limit,
         offset,
-        hasMore,
+        hasMore: hasMore && scopedItems.length > 0,
         nextOffset: hasMore ? offset + limit : null
       }
     };
@@ -570,6 +652,16 @@ export async function registerWorkflowRoutes(app: FastifyInstance): Promise<void
       return { error: parseQuery.error.flatten() };
     }
 
+    let moduleScope;
+    try {
+      moduleScope = await resolveModuleScope(request, parseQuery.data.moduleId, [
+        'workflow-definition',
+        'workflow-run'
+      ]);
+    } catch (error) {
+      return handleModuleScopeError(reply, error);
+    }
+
     const limit = Math.min(Math.max(parseQuery.data.limit ?? 20, 1), 100);
     const offset = Math.max(parseQuery.data.offset ?? 0, 0);
     const kinds = parseQuery.data.kind?.filter((value): value is 'run' | 'delivery' =>
@@ -584,7 +676,8 @@ export async function registerWorkflowRoutes(app: FastifyInstance): Promise<void
       kinds,
       search: parseQuery.data.search,
       from: parseQuery.data.from,
-      to: parseQuery.data.to
+      to: parseQuery.data.to,
+      moduleIds: moduleScope?.hasFilters ? moduleScope.moduleIds : undefined
     } satisfies NonNullable<Parameters<typeof listWorkflowActivity>[0]>['filters'];
 
     const { items, hasMore } = await listWorkflowActivity({ limit, offset, filters });
@@ -930,8 +1023,18 @@ export async function registerWorkflowRoutes(app: FastifyInstance): Promise<void
       return { error: parseQuery.error.flatten() };
     }
 
+    let moduleScope;
+    try {
+      moduleScope = await resolveModuleScope(request, parseQuery.data.moduleId, [
+        'workflow-definition',
+        'workflow-run'
+      ]);
+    } catch (error) {
+      return handleModuleScopeError(reply, error);
+    }
+
     const workflow = await getWorkflowDefinitionBySlug(parseParams.data.slug);
-    if (!workflow) {
+    if (!workflow || (moduleScope?.hasFilters && !moduleScope.matches('workflow-definition', { id: workflow.id, slug: workflow.slug }))) {
       reply.status(404);
       return { error: 'workflow not found' };
     }
@@ -966,8 +1069,18 @@ export async function registerWorkflowRoutes(app: FastifyInstance): Promise<void
       return { error: parseQuery.error.flatten() };
     }
 
+    let moduleScope;
+    try {
+      moduleScope = await resolveModuleScope(request, parseQuery.data.moduleId, [
+        'workflow-definition',
+        'workflow-run'
+      ]);
+    } catch (error) {
+      return handleModuleScopeError(reply, error);
+    }
+
     const workflow = await getWorkflowDefinitionBySlug(parseParams.data.slug);
-    if (!workflow) {
+    if (!workflow || (moduleScope?.hasFilters && !moduleScope.matches('workflow-definition', { id: workflow.id, slug: workflow.slug }))) {
       reply.status(404);
       return { error: 'workflow not found' };
     }
@@ -1006,6 +1119,16 @@ export async function registerWorkflowRoutes(app: FastifyInstance): Promise<void
       return { error: parseQuery.error.flatten() };
     }
 
+    let moduleScope;
+    try {
+      moduleScope = await resolveModuleScope(request, parseQuery.data.moduleId, [
+        'workflow-definition',
+        'workflow-run'
+      ]);
+    } catch (error) {
+      return handleModuleScopeError(reply, error);
+    }
+
     const now = new Date();
     const toDate = parseQuery.data.to ? new Date(parseQuery.data.to) : now;
     if (Number.isNaN(toDate.getTime())) {
@@ -1040,7 +1163,7 @@ export async function registerWorkflowRoutes(app: FastifyInstance): Promise<void
     const statusesFilter = statuses.length > 0 ? statuses : undefined;
 
     const workflow = await getWorkflowDefinitionBySlug(parseParams.data.slug);
-    if (!workflow) {
+    if (!workflow || (moduleScope?.hasFilters && !moduleScope.matches('workflow-definition', { id: workflow.id, slug: workflow.slug }))) {
       reply.status(404);
       return { error: 'workflow not found' };
     }
@@ -1240,7 +1363,19 @@ export async function registerWorkflowRoutes(app: FastifyInstance): Promise<void
         return { error: parseQuery.error.flatten() };
       }
 
-      const workflow = await getWorkflowDefinitionBySlug(parseParams.data.slug);
+      let moduleScope;
+      try {
+        moduleScope = await resolveModuleScope(request, parseQuery.data.moduleId, [
+          'workflow-definition',
+          'workflow-run'
+        ]);
+      } catch (error) {
+        return handleModuleScopeError(reply, error);
+      }
+
+      const moduleIds = moduleScope?.hasFilters ? moduleScope.moduleIds : undefined;
+
+      const workflow = await getWorkflowDefinitionBySlug(parseParams.data.slug, { moduleIds });
       if (!workflow) {
         reply.status(404);
         return { error: 'workflow not found' };
@@ -1250,9 +1385,9 @@ export async function registerWorkflowRoutes(app: FastifyInstance): Promise<void
       const offset = Math.max(0, parseQuery.data.offset ?? 0);
 
       const [runs, claim, failureState] = await Promise.all([
-        listWorkflowAutoRunsForDefinition(workflow.id, { limit, offset }),
-        getWorkflowAutoRunClaim(workflow.id),
-        getAutoMaterializeFailureState(workflow.id)
+        listWorkflowAutoRunsForDefinition(workflow.id, { limit, offset, moduleIds }),
+        getWorkflowAutoRunClaim(workflow.id, { moduleIds }),
+        getAutoMaterializeFailureState(workflow.id, { moduleIds })
       ]);
 
       reply.status(200);
@@ -1422,6 +1557,24 @@ export async function registerWorkflowRoutes(app: FastifyInstance): Promise<void
       return { error: parseQuery.error.flatten() };
     }
 
+    let moduleScope;
+    try {
+      moduleScope = await resolveModuleScope(request, parseQuery.data.moduleId, [
+        'workflow-definition',
+        'workflow-run'
+      ]);
+    } catch (error) {
+      return handleModuleScopeError(reply, error);
+    }
+
+    const moduleIds = moduleScope?.hasFilters ? moduleScope.moduleIds : undefined;
+
+    const workflow = await getWorkflowDefinitionBySlug(parseParams.data.slug, { moduleIds });
+    if (!workflow) {
+      reply.status(404);
+      return { error: 'workflow not found' };
+    }
+
     const normalized = normalizeAnalyticsQuery(parseQuery.data ?? {});
     if (!normalized.ok) {
       reply.status(400);
@@ -1429,10 +1582,10 @@ export async function registerWorkflowRoutes(app: FastifyInstance): Promise<void
     }
 
     try {
-      const stats = await getWorkflowRunStatsBySlug(
-        parseParams.data.slug,
-        normalized.value.options
-      );
+      const stats = await getWorkflowRunStatsBySlug(parseParams.data.slug, {
+        ...normalized.value.options,
+        moduleIds
+      });
       const serialized = serializeWorkflowRunStats(stats);
       reply.status(200);
       return {
@@ -1466,6 +1619,24 @@ export async function registerWorkflowRoutes(app: FastifyInstance): Promise<void
       return { error: parseQuery.error.flatten() };
     }
 
+    let moduleScope;
+    try {
+      moduleScope = await resolveModuleScope(request, parseQuery.data.moduleId, [
+        'workflow-definition',
+        'workflow-run'
+      ]);
+    } catch (error) {
+      return handleModuleScopeError(reply, error);
+    }
+
+    const moduleIds = moduleScope?.hasFilters ? moduleScope.moduleIds : undefined;
+
+    const workflow = await getWorkflowDefinitionBySlug(parseParams.data.slug, { moduleIds });
+    if (!workflow) {
+      reply.status(404);
+      return { error: 'workflow not found' };
+    }
+
     const normalized = normalizeAnalyticsQuery(parseQuery.data ?? {});
     if (!normalized.ok) {
       reply.status(400);
@@ -1473,10 +1644,10 @@ export async function registerWorkflowRoutes(app: FastifyInstance): Promise<void
     }
 
     try {
-      const metrics = await getWorkflowRunMetricsBySlug(
-        parseParams.data.slug,
-        normalized.value.options
-      );
+      const metrics = await getWorkflowRunMetricsBySlug(parseParams.data.slug, {
+        ...normalized.value.options,
+        moduleIds
+      });
       const serialized = serializeWorkflowRunMetrics(metrics);
       const bucketKey =
         normalized.value.bucketKey ?? mapIntervalToBucketKey(serialized.bucketInterval);
@@ -1514,14 +1685,27 @@ export async function registerWorkflowRoutes(app: FastifyInstance): Promise<void
       return { error: parseParams.error.flatten() };
     }
 
-    const workflow = await getWorkflowDefinitionBySlug(parseParams.data.slug);
+    let moduleScope;
+    try {
+      moduleScope = await resolveModuleScope(request, (request.query as { moduleId?: unknown } | undefined)?.moduleId, [
+        'workflow-definition',
+        'workflow-run',
+        'asset'
+      ]);
+    } catch (error) {
+      return handleModuleScopeError(reply, error);
+    }
+
+    const moduleIds = moduleScope?.hasFilters ? moduleScope.moduleIds : undefined;
+
+    const workflow = await getWorkflowDefinitionBySlug(parseParams.data.slug, { moduleIds });
     if (!workflow) {
       reply.status(404);
       return { error: 'workflow not found' };
     }
 
     const stepMetadata = buildWorkflowStepMetadata(workflow.steps);
-    const assetDeclarations = await listWorkflowAssetDeclarationsBySlug(workflow.slug);
+    const assetDeclarations = await listWorkflowAssetDeclarationsBySlug(workflow.slug, { moduleIds });
 
     type StepDescriptor = {
       stepId: string;
@@ -1589,7 +1773,7 @@ export async function registerWorkflowRoutes(app: FastifyInstance): Promise<void
       }
     }
 
-    const latestSnapshots = await listLatestWorkflowAssetSnapshots(workflow.id);
+    const latestSnapshots = await listLatestWorkflowAssetSnapshots(workflow.id, { moduleIds });
     const latestByAsset = new Map<string, WorkflowAssetSnapshotRecord>();
     for (const snapshot of latestSnapshots) {
       const assetId = snapshot.asset.assetId;
@@ -1696,7 +1880,20 @@ export async function registerWorkflowRoutes(app: FastifyInstance): Promise<void
       return { error: parseBody.error.flatten() };
     }
 
-    const workflow = await getWorkflowDefinitionBySlug(parseParams.data.slug);
+    let moduleScope;
+    try {
+      moduleScope = await resolveModuleScope(request, (request.query as { moduleId?: unknown } | undefined)?.moduleId, [
+        'workflow-definition',
+        'workflow-run',
+        'asset'
+      ]);
+    } catch (error) {
+      return handleModuleScopeError(reply, error);
+    }
+
+    const moduleIds = moduleScope?.hasFilters ? moduleScope.moduleIds : undefined;
+
+    const workflow = await getWorkflowDefinitionBySlug(parseParams.data.slug, { moduleIds });
     if (!workflow) {
       reply.status(404);
       await authResult.auth.log('failed', {
@@ -1771,13 +1968,26 @@ export async function registerWorkflowRoutes(app: FastifyInstance): Promise<void
       return { error: parseQuery.error.flatten() };
     }
 
-    const workflow = await getWorkflowDefinitionBySlug(parseParams.data.slug);
+    let moduleScope;
+    try {
+      moduleScope = await resolveModuleScope(request, (request.query as { moduleId?: unknown } | undefined)?.moduleId, [
+        'workflow-definition',
+        'workflow-run',
+        'asset'
+      ]);
+    } catch (error) {
+      return handleModuleScopeError(reply, error);
+    }
+
+    const moduleIds = moduleScope?.hasFilters ? moduleScope.moduleIds : undefined;
+
+    const workflow = await getWorkflowDefinitionBySlug(parseParams.data.slug, { moduleIds });
     if (!workflow) {
       reply.status(404);
       return { error: 'workflow not found' };
     }
 
-    const assetDeclarations = await listWorkflowAssetDeclarationsBySlug(workflow.slug);
+    const assetDeclarations = await listWorkflowAssetDeclarationsBySlug(workflow.slug, { moduleIds });
     const assetExists = assetDeclarations.some(
       (declaration) =>
         declaration.workflowDefinitionId === workflow.id &&
@@ -1811,7 +2021,8 @@ export async function registerWorkflowRoutes(app: FastifyInstance): Promise<void
 
     const history = await listWorkflowAssetHistory(workflow.id, parseParams.data.assetId, {
       limit,
-      partitionKey: partitionKeyFilter ?? null
+      partitionKey: partitionKeyFilter ?? null,
+      moduleIds
     });
     const stepMetadata = buildWorkflowStepMetadata(workflow.steps);
 
@@ -1884,13 +2095,26 @@ export async function registerWorkflowRoutes(app: FastifyInstance): Promise<void
       return { error: parseQuery.error.flatten() };
     }
 
-    const workflow = await getWorkflowDefinitionBySlug(parseParams.data.slug);
+    let moduleScope;
+    try {
+      moduleScope = await resolveModuleScope(request, (request.query as { moduleId?: unknown } | undefined)?.moduleId, [
+        'workflow-definition',
+        'workflow-run',
+        'asset'
+      ]);
+    } catch (error) {
+      return handleModuleScopeError(reply, error);
+    }
+
+    const moduleIds = moduleScope?.hasFilters ? moduleScope.moduleIds : undefined;
+
+    const workflow = await getWorkflowDefinitionBySlug(parseParams.data.slug, { moduleIds });
     if (!workflow) {
       reply.status(404);
       return { error: 'workflow not found' };
     }
 
-    const assetDeclarations = await listWorkflowAssetDeclarationsBySlug(workflow.slug);
+    const assetDeclarations = await listWorkflowAssetDeclarationsBySlug(workflow.slug, { moduleIds });
     const assetMatches = assetDeclarations.filter(
       (declaration) =>
         declaration.workflowDefinitionId === workflow.id &&
@@ -1903,7 +2127,7 @@ export async function registerWorkflowRoutes(app: FastifyInstance): Promise<void
     }
 
     const partitioningSpec = assetMatches.find((declaration) => declaration.partitioning)?.partitioning ?? null;
-    const partitions = await listWorkflowAssetPartitions(workflow.id, parseParams.data.assetId);
+    const partitions = await listWorkflowAssetPartitions(workflow.id, parseParams.data.assetId, { moduleIds });
     const partitionMap = new Map<string, typeof partitions[number]>();
 
     for (const entry of partitions) {
@@ -2041,7 +2265,20 @@ export async function registerWorkflowRoutes(app: FastifyInstance): Promise<void
       return { error: parseBody.error.flatten() };
     }
 
-    const workflow = await getWorkflowDefinitionBySlug(parseParams.data.slug);
+    let moduleScope;
+    try {
+      moduleScope = await resolveModuleScope(request, (request.query as { moduleId?: unknown } | undefined)?.moduleId, [
+        'workflow-definition',
+        'workflow-run',
+        'asset'
+      ]);
+    } catch (error) {
+      return handleModuleScopeError(reply, error);
+    }
+
+    const moduleIds = moduleScope?.hasFilters ? moduleScope.moduleIds : undefined;
+
+    const workflow = await getWorkflowDefinitionBySlug(parseParams.data.slug, { moduleIds });
     if (!workflow) {
       reply.status(404);
       await authResult.auth.log('failed', {
@@ -2051,7 +2288,7 @@ export async function registerWorkflowRoutes(app: FastifyInstance): Promise<void
       return { error: 'workflow not found' };
     }
 
-    const assetDeclarations = await listWorkflowAssetDeclarationsBySlug(workflow.slug);
+    const assetDeclarations = await listWorkflowAssetDeclarationsBySlug(workflow.slug, { moduleIds });
     const assetMatches = assetDeclarations.filter(
       (declaration) =>
         declaration.workflowDefinitionId === workflow.id &&
@@ -2156,7 +2393,20 @@ export async function registerWorkflowRoutes(app: FastifyInstance): Promise<void
       return { error: parseQuery.error.flatten() };
     }
 
-    const workflow = await getWorkflowDefinitionBySlug(parseParams.data.slug);
+    let moduleScope;
+    try {
+      moduleScope = await resolveModuleScope(request, (request.query as { moduleId?: unknown } | undefined)?.moduleId, [
+        'workflow-definition',
+        'workflow-run',
+        'asset'
+      ]);
+    } catch (error) {
+      return handleModuleScopeError(reply, error);
+    }
+
+    const moduleIds = moduleScope?.hasFilters ? moduleScope.moduleIds : undefined;
+
+    const workflow = await getWorkflowDefinitionBySlug(parseParams.data.slug, { moduleIds });
     if (!workflow) {
       reply.status(404);
       await authResult.auth.log('failed', {
@@ -2166,7 +2416,7 @@ export async function registerWorkflowRoutes(app: FastifyInstance): Promise<void
       return { error: 'workflow not found' };
     }
 
-    const assetDeclarations = await listWorkflowAssetDeclarationsBySlug(workflow.slug);
+    const assetDeclarations = await listWorkflowAssetDeclarationsBySlug(workflow.slug, { moduleIds });
     const assetMatches = assetDeclarations.filter(
       (declaration) =>
         declaration.workflowDefinitionId === workflow.id &&

--- a/services/core/src/serviceRegistry/invalidationBus.ts
+++ b/services/core/src/serviceRegistry/invalidationBus.ts
@@ -1,0 +1,168 @@
+import { EventEmitter } from 'node:events';
+import IORedis, { type Redis } from 'ioredis';
+import type { ModuleResourceType } from '../db/types';
+
+const INVALIDATION_CHANNEL = 'service-registry:invalidate';
+
+const emitter = new EventEmitter();
+
+type ServiceRegistryInvalidationSource = 'local' | 'remote';
+
+type ManifestInvalidationMessage = {
+  kind: 'manifest';
+  reason: string;
+  moduleId?: string | null;
+};
+
+type HealthInvalidationMessage = {
+  kind: 'health';
+  reason: string;
+  slug?: string | null;
+};
+
+type ModuleContextInvalidationMessage = {
+  kind: 'module-context';
+  moduleId: string;
+  moduleVersion?: string | null;
+  resourceType: ModuleResourceType;
+  resourceId: string;
+  resourceSlug?: string | null;
+  resourceName?: string | null;
+  action: 'upsert' | 'delete';
+};
+
+export type ServiceRegistryInvalidationMessage =
+  | ManifestInvalidationMessage
+  | HealthInvalidationMessage
+  | ModuleContextInvalidationMessage;
+
+type InternalInvalidationPayload = {
+  message: ServiceRegistryInvalidationMessage;
+  source: ServiceRegistryInvalidationSource;
+};
+
+let redisPublisher: Redis | null = null;
+let redisSubscriber: Redis | null = null;
+let redisSubscriptionActive = false;
+let redisConnectionPromise: Promise<void> | null = null;
+
+function normalize(value: string | undefined | null): string | undefined {
+  return value ? value.trim() : undefined;
+}
+
+function isInlineMode(): boolean {
+  const redisUrl = normalize(process.env.REDIS_URL);
+  if (redisUrl && redisUrl.toLowerCase() === 'inline') {
+    return true;
+  }
+  const eventsMode = normalize(process.env.APPHUB_EVENTS_MODE);
+  return Boolean(eventsMode && eventsMode.toLowerCase() === 'inline');
+}
+
+function resolveRedisUrl(): string {
+  const redisUrl = normalize(process.env.REDIS_URL);
+  if (!redisUrl || redisUrl.toLowerCase() === 'inline') {
+    return 'redis://127.0.0.1:6379';
+  }
+  return redisUrl;
+}
+
+function emitInvalidation(message: ServiceRegistryInvalidationMessage, source: ServiceRegistryInvalidationSource): void {
+  emitter.emit('invalidate', { message, source } satisfies InternalInvalidationPayload);
+}
+
+async function ensureRedisConnections(): Promise<void> {
+  if (isInlineMode()) {
+    redisPublisher = null;
+    if (redisSubscriber) {
+      redisSubscriber.disconnect();
+      redisSubscriber = null;
+    }
+    redisSubscriptionActive = false;
+    redisConnectionPromise = null;
+    return;
+  }
+
+  if (redisSubscriptionActive && redisPublisher && redisSubscriber) {
+    return;
+  }
+
+  if (redisConnectionPromise) {
+    await redisConnectionPromise;
+    return;
+  }
+
+  redisConnectionPromise = (async () => {
+    const url = resolveRedisUrl();
+
+    if (!redisPublisher) {
+      const publisher = new IORedis(url, { maxRetriesPerRequest: null });
+      publisher.on('error', (err) => {
+        console.error('[service-registry:invalidate] redis publish error', err);
+      });
+      redisPublisher = publisher;
+    }
+
+    if (!redisSubscriber) {
+      const subscriber = new IORedis(url, { maxRetriesPerRequest: null });
+      subscriber.on('message', (_channel, payload) => {
+        try {
+          const parsed = JSON.parse(payload) as ServiceRegistryInvalidationMessage;
+          emitInvalidation(parsed, 'remote');
+        } catch (err) {
+          console.error('[service-registry:invalidate] failed to parse invalidation payload', err);
+        }
+      });
+      subscriber.on('error', (err) => {
+        console.error('[service-registry:invalidate] redis subscribe error', err);
+      });
+      await subscriber.subscribe(INVALIDATION_CHANNEL);
+      redisSubscriber = subscriber;
+      redisSubscriptionActive = true;
+    }
+  })();
+
+  try {
+    await redisConnectionPromise;
+  } finally {
+    redisConnectionPromise = null;
+  }
+}
+
+export function subscribeToServiceRegistryInvalidations(
+  listener: (message: ServiceRegistryInvalidationMessage, source: ServiceRegistryInvalidationSource) => void
+): () => void {
+  const handler = (payload: InternalInvalidationPayload) => {
+    listener(payload.message, payload.source);
+  };
+
+  emitter.on('invalidate', handler);
+
+  void ensureRedisConnections();
+
+  return () => {
+    emitter.off('invalidate', handler);
+  };
+}
+
+export async function publishServiceRegistryInvalidation(
+  message: ServiceRegistryInvalidationMessage,
+  options: { skipLocal?: boolean } = {}
+): Promise<void> {
+  if (!options.skipLocal) {
+    emitInvalidation(message, 'local');
+  }
+
+  if (isInlineMode()) {
+    return;
+  }
+
+  try {
+    await ensureRedisConnections();
+    if (redisPublisher) {
+      await redisPublisher.publish(INVALIDATION_CHANNEL, JSON.stringify(message));
+    }
+  } catch (err) {
+    console.error('[service-registry:invalidate] failed to publish invalidation', err);
+  }
+}

--- a/services/core/src/serviceRegistryBackfill.ts
+++ b/services/core/src/serviceRegistryBackfill.ts
@@ -28,6 +28,7 @@ export type ServiceRegistryBackfillResult = {
   moduleId: string;
   servicesApplied: number;
   networksApplied: number;
+  moduleVersion: string;
 };
 
 function normalizePath(specifier: string | undefined): string | undefined {
@@ -111,7 +112,8 @@ export async function backfillServiceRegistry(
       results.push({
         moduleId: preview.moduleId,
         servicesApplied: importResult.servicesApplied,
-        networksApplied: importResult.networksApplied
+        networksApplied: importResult.networksApplied,
+        moduleVersion: importResult.moduleVersion
       });
     }
 
@@ -136,5 +138,5 @@ export async function backfillServiceRegistryFromPaths(
 }
 
 export function formatBackfillResult(result: ServiceRegistryBackfillResult): string {
-  return `Module ${result.moduleId}: ${result.servicesApplied} services, ${result.networksApplied} networks`;
+  return `Module ${result.moduleId}@${result.moduleVersion}: ${result.servicesApplied} services, ${result.networksApplied} networks`;
 }

--- a/services/core/src/workflows/http/analyticsQuery.ts
+++ b/services/core/src/workflows/http/analyticsQuery.ts
@@ -18,7 +18,8 @@ export const workflowAnalyticsQuerySchema = z
     from: z.string().optional(),
     to: z.string().optional(),
     range: z.enum(ANALYTICS_RANGE_OPTIONS).optional(),
-    bucket: z.enum(ANALYTICS_BUCKET_OPTIONS).optional()
+    bucket: z.enum(ANALYTICS_BUCKET_OPTIONS).optional(),
+    moduleId: z.union([z.string(), z.array(z.string())]).optional()
   })
   .partial()
   .strict();

--- a/services/core/src/workflows/repositories/definitionsRepository.ts
+++ b/services/core/src/workflows/repositories/definitionsRepository.ts
@@ -154,12 +154,29 @@ async function fetchWorkflowDefinitionById(
 
 async function fetchWorkflowDefinitionBySlug(
   client: PoolClient,
-  slug: string
+  slug: string,
+  options: { moduleIds?: string[] | null } = {}
 ): Promise<WorkflowDefinitionRecord | null> {
-  const { rows } = await client.query<WorkflowDefinitionRow>(
-    'SELECT * FROM workflow_definitions WHERE slug = $1',
-    [slug]
-  );
+  const moduleIds = Array.isArray(options.moduleIds)
+    ? Array.from(new Set(options.moduleIds.map((id) => id.trim()).filter((id) => id.length > 0)))
+    : null;
+
+  const params: unknown[] = [slug];
+  let query = 'SELECT * FROM workflow_definitions WHERE slug = $1';
+
+  if (moduleIds && moduleIds.length > 0) {
+    params.push(moduleIds);
+    query += `
+      AND EXISTS (
+        SELECT 1
+          FROM module_resource_contexts mrc
+         WHERE mrc.resource_type = 'workflow-definition'
+           AND mrc.resource_id = workflow_definitions.id
+           AND mrc.module_id = ANY($${params.length}::text[])
+      )`;
+  }
+
+  const { rows } = await client.query<WorkflowDefinitionRow>(query, params);
   if (rows.length === 0) {
     return null;
   }
@@ -260,17 +277,37 @@ async function attachEventTriggersToDefinitions(
 
 async function fetchWorkflowDefinitionsByIds(
   client: PoolClient,
-  ids: readonly string[]
+  ids: readonly string[],
+  options: { moduleIds?: string[] | null } = {}
 ): Promise<Map<string, WorkflowDefinitionRecord>> {
   if (ids.length === 0) {
     return new Map();
   }
 
+  const moduleIds = Array.isArray(options.moduleIds)
+    ? Array.from(new Set(options.moduleIds.map((id) => id.trim()).filter((id) => id.length > 0)))
+    : null;
+
+  const params: unknown[] = [ids];
+  let whereClause = 'WHERE id = ANY($1::text[])';
+
+  if (moduleIds && moduleIds.length > 0) {
+    params.push(moduleIds);
+    whereClause += `
+      AND EXISTS (
+        SELECT 1
+          FROM module_resource_contexts mrc
+         WHERE mrc.resource_type = 'workflow-definition'
+           AND mrc.resource_id = workflow_definitions.id
+           AND mrc.module_id = ANY($${params.length}::text[])
+      )`;
+  }
+
   const { rows } = await client.query<WorkflowDefinitionRow>(
     `SELECT *
        FROM workflow_definitions
-      WHERE id = ANY($1::text[])`,
-    [ids]
+      ${whereClause}`,
+    params
   );
 
   const definitions = rows.map(mapWorkflowDefinitionRow);
@@ -298,10 +335,31 @@ async function fetchWorkflowScheduleById(
   return mapWorkflowScheduleRow(rows[0]);
 }
 
-export async function listWorkflowDefinitions(): Promise<WorkflowDefinitionRecord[]> {
+export async function listWorkflowDefinitions(options: { moduleIds?: string[] | null } = {}): Promise<WorkflowDefinitionRecord[]> {
+  const moduleIds = Array.isArray(options.moduleIds)
+    ? Array.from(new Set(options.moduleIds.map((id) => id.trim()).filter((id) => id.length > 0)))
+    : null;
+
   return useConnection(async (client) => {
+    const params: Array<string[] | string> = [];
+    const conditions: string[] = [];
+
+    if (moduleIds && moduleIds.length > 0) {
+      const paramIndex = params.push(moduleIds);
+      conditions.push(`EXISTS (
+        SELECT 1
+          FROM module_resource_contexts mrc
+         WHERE mrc.resource_type = 'workflow-definition'
+           AND mrc.resource_id = workflow_definitions.id
+           AND mrc.module_id = ANY($${paramIndex}::text[])
+      )`);
+    }
+
+    const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
     const { rows } = await client.query<WorkflowDefinitionRow>(
-      'SELECT * FROM workflow_definitions ORDER BY slug ASC'
+      `SELECT * FROM workflow_definitions ${whereClause} ORDER BY slug ASC`,
+      params
     );
     const definitions = rows.map(mapWorkflowDefinitionRow);
     await attachSchedulesToDefinitions(client, definitions);
@@ -310,8 +368,11 @@ export async function listWorkflowDefinitions(): Promise<WorkflowDefinitionRecor
   });
 }
 
-export async function getWorkflowDefinitionBySlug(slug: string): Promise<WorkflowDefinitionRecord | null> {
-  return useConnection((client) => fetchWorkflowDefinitionBySlug(client, slug));
+export async function getWorkflowDefinitionBySlug(
+  slug: string,
+  options: { moduleIds?: string[] | null } = {}
+): Promise<WorkflowDefinitionRecord | null> {
+  return useConnection((client) => fetchWorkflowDefinitionBySlug(client, slug, options));
 }
 
 export async function getWorkflowDefinitionById(id: string): Promise<WorkflowDefinitionRecord | null> {
@@ -550,20 +611,40 @@ export async function listDueWorkflowSchedules({
   });
 }
 
-export async function listWorkflowSchedulesWithWorkflow(): Promise<WorkflowScheduleWithDefinition[]> {
+export async function listWorkflowSchedulesWithWorkflow(options: { moduleIds?: string[] | null } = {}): Promise<WorkflowScheduleWithDefinition[]> {
+  const moduleIds = Array.isArray(options.moduleIds)
+    ? Array.from(new Set(options.moduleIds.map((id) => id.trim()).filter((id) => id.length > 0)))
+    : null;
+
   return useConnection(async (client) => {
+    const params: unknown[] = [];
+    let whereClause = '';
+
+    if (moduleIds && moduleIds.length > 0) {
+      params.push(moduleIds);
+      whereClause = `WHERE EXISTS (
+        SELECT 1
+          FROM module_resource_contexts mrc
+         WHERE mrc.resource_type = 'workflow-definition'
+           AND mrc.resource_id = workflow_schedules.workflow_definition_id
+           AND mrc.module_id = ANY($${params.length}::text[])
+      )`;
+    }
+
     const { rows } = await client.query<WorkflowScheduleRow>(
       `SELECT *
          FROM workflow_schedules
+        ${whereClause}
         ORDER BY is_active DESC,
                  CASE WHEN next_run_at IS NULL THEN 1 ELSE 0 END,
                  next_run_at ASC NULLS LAST,
-                 created_at ASC`
+                 created_at ASC`,
+      params
     );
 
     const schedules = rows.map(mapWorkflowScheduleRow);
     const definitionIds = Array.from(new Set(schedules.map((schedule) => schedule.workflowDefinitionId)));
-    const definitions = await fetchWorkflowDefinitionsByIds(client, definitionIds);
+    const definitions = await fetchWorkflowDefinitionsByIds(client, definitionIds, { moduleIds });
 
     const results: WorkflowScheduleWithDefinition[] = [];
     for (const schedule of schedules) {
@@ -1767,8 +1848,12 @@ export async function updateWorkflowScheduleRuntimeMetadata(
   return schedule;
 }
 
-export async function fetchWorkflowDefinitionBySlugOrThrow(client: PoolClient, slug: string) {
-  const definition = await fetchWorkflowDefinitionBySlug(client, slug);
+export async function fetchWorkflowDefinitionBySlugOrThrow(
+  client: PoolClient,
+  slug: string,
+  options: { moduleIds?: string[] | null } = {}
+) {
+  const definition = await fetchWorkflowDefinitionBySlug(client, slug, options);
   if (!definition) {
     throw new Error(`Workflow with slug ${slug} not found`);
   }

--- a/services/core/tests/adminNuke.e2e.ts
+++ b/services/core/tests/adminNuke.e2e.ts
@@ -5,8 +5,8 @@ import net from 'node:net';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import EmbeddedPostgres from 'embedded-postgres';
-import { runE2E } from '@apphub/test-helpers';
+import { createEmbeddedPostgres, stopEmbeddedPostgres, runE2E } from '@apphub/test-helpers';
+import type EmbeddedPostgres from 'embedded-postgres';
 let embeddedPostgres: EmbeddedPostgres | null = null;
 let embeddedPostgresCleanup: (() => Promise<void>) | null = null;
 
@@ -38,7 +38,7 @@ async function ensureEmbeddedPostgres(): Promise<void> {
   const dataRoot = await mkdtemp(path.join(tmpdir(), 'apphub-admin-nuke-pg-'));
   const port = await findAvailablePort();
 
-  const postgres = new EmbeddedPostgres({
+  const postgres: EmbeddedPostgres = createEmbeddedPostgres({
     databaseDir: dataRoot,
     port,
     user: 'postgres',
@@ -55,7 +55,7 @@ async function ensureEmbeddedPostgres(): Promise<void> {
 
   embeddedPostgresCleanup = async () => {
     try {
-      await postgres.stop();
+      await stopEmbeddedPostgres(postgres);
     } finally {
       await rm(dataRoot, { recursive: true, force: true });
     }

--- a/services/core/tests/eventSamplingReplay.test.ts
+++ b/services/core/tests/eventSamplingReplay.test.ts
@@ -5,7 +5,8 @@ import { randomUUID } from 'node:crypto';
 import { mkdtemp, rm } from 'node:fs/promises';
 import path from 'node:path';
 import { tmpdir } from 'node:os';
-import EmbeddedPostgres from 'embedded-postgres';
+import { createEmbeddedPostgres, stopEmbeddedPostgres } from '@apphub/test-helpers';
+import type EmbeddedPostgres from 'embedded-postgres';
 
 async function allocatePort(): Promise<number> {
   return new Promise((resolve, reject) => {
@@ -27,7 +28,7 @@ async function allocatePort(): Promise<number> {
 async function startDatabase(): Promise<() => Promise<void>> {
   const dataDir = await mkdtemp(path.join(tmpdir(), 'apphub-event-sampling-replay-db-'));
   const port = await allocatePort();
-  const postgres = new EmbeddedPostgres({
+  const postgres: EmbeddedPostgres = createEmbeddedPostgres({
     databaseDir: dataDir,
     port,
     user: 'postgres',
@@ -44,7 +45,7 @@ async function startDatabase(): Promise<() => Promise<void>> {
 
   return async () => {
     try {
-      await postgres.stop();
+    await stopEmbeddedPostgres(postgres);
     } finally {
       await rm(dataDir, { recursive: true, force: true });
     }

--- a/services/core/tests/eventSamplingStore.test.ts
+++ b/services/core/tests/eventSamplingStore.test.ts
@@ -5,7 +5,8 @@ import { randomUUID } from 'node:crypto';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import EmbeddedPostgres from 'embedded-postgres';
+import { createEmbeddedPostgres, stopEmbeddedPostgres } from '@apphub/test-helpers';
+import type EmbeddedPostgres from 'embedded-postgres';
 import type { EventEnvelope, JsonValue } from '@apphub/event-bus';
 
 async function allocatePort(): Promise<number> {
@@ -28,7 +29,7 @@ async function allocatePort(): Promise<number> {
 async function startDatabase(): Promise<() => Promise<void>> {
   const dataDir = await mkdtemp(path.join(tmpdir(), 'apphub-event-sampling-db-'));
   const port = await allocatePort();
-  const postgres = new EmbeddedPostgres({
+  const postgres: EmbeddedPostgres = createEmbeddedPostgres({
     databaseDir: dataDir,
     port,
     user: 'postgres',
@@ -45,7 +46,7 @@ async function startDatabase(): Promise<() => Promise<void>> {
 
   return async () => {
     try {
-      await postgres.stop();
+    await stopEmbeddedPostgres(postgres);
     } finally {
       await rm(dataDir, { recursive: true, force: true });
     }

--- a/services/core/tests/ingestion.e2e.ts
+++ b/services/core/tests/ingestion.e2e.ts
@@ -17,8 +17,8 @@ import { exec as execCallback } from 'node:child_process';
 import { promisify } from 'node:util';
 import net from 'node:net';
 import WebSocket from 'ws';
-import EmbeddedPostgres from 'embedded-postgres';
-import { runE2E } from '@apphub/test-helpers';
+import { createEmbeddedPostgres, stopEmbeddedPostgres, runE2E } from '@apphub/test-helpers';
+import type EmbeddedPostgres from 'embedded-postgres';
 
 const exec = promisify(execCallback);
 
@@ -59,7 +59,7 @@ async function ensureEmbeddedPostgres(): Promise<void> {
 
   const dataRoot = await mkdtemp(path.join(tmpdir(), 'apphub-pg-'));
   const port = await findAvailablePort();
-  const postgres = new EmbeddedPostgres({
+  const postgres: EmbeddedPostgres = createEmbeddedPostgres({
     databaseDir: dataRoot,
     port,
     user: 'postgres',
@@ -84,7 +84,7 @@ async function ensureEmbeddedPostgres(): Promise<void> {
 
   embeddedPostgresCleanup = async () => {
     try {
-      await postgres.stop();
+      await stopEmbeddedPostgres(postgres);
     } finally {
       await rm(dataRoot, { recursive: true, force: true });
     }

--- a/services/core/tests/ingestionLaunchEnvTemplates.e2e.ts
+++ b/services/core/tests/ingestionLaunchEnvTemplates.e2e.ts
@@ -4,8 +4,8 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import net from 'node:net';
 import path from 'node:path';
-import EmbeddedPostgres from 'embedded-postgres';
-import { runE2E } from '@apphub/test-helpers';
+import { createEmbeddedPostgres, stopEmbeddedPostgres, runE2E } from '@apphub/test-helpers';
+import type EmbeddedPostgres from 'embedded-postgres';
 
 async function findAvailablePort(): Promise<number> {
   return new Promise((resolve, reject) => {
@@ -33,7 +33,7 @@ runE2E(async ({ registerCleanup }) => {
   registerCleanup(() => rm(dataRoot, { recursive: true, force: true }));
 
   const port = await findAvailablePort();
-  const postgres = new EmbeddedPostgres({
+  const postgres: EmbeddedPostgres = createEmbeddedPostgres({
     databaseDir: dataRoot,
     port,
     user: 'postgres',
@@ -46,7 +46,7 @@ runE2E(async ({ registerCleanup }) => {
   await postgres.createDatabase('apphub');
 
   registerCleanup(async () => {
-    await postgres.stop();
+    await stopEmbeddedPostgres(postgres);
   });
 
   process.env.DATABASE_URL = `postgres://postgres:postgres@127.0.0.1:${port}/apphub`;

--- a/services/core/tests/jobRegistry.e2e.ts
+++ b/services/core/tests/jobRegistry.e2e.ts
@@ -5,9 +5,9 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { createHash } from 'node:crypto';
-import EmbeddedPostgres from 'embedded-postgres';
+import { createEmbeddedPostgres, stopEmbeddedPostgres, runE2E } from '@apphub/test-helpers';
+import type EmbeddedPostgres from 'embedded-postgres';
 import type { FastifyInstance } from 'fastify';
-import { runE2E } from '@apphub/test-helpers';
 
 let embeddedPostgres: EmbeddedPostgres | null = null;
 let embeddedPostgresCleanup: (() => Promise<void>) | null = null;
@@ -48,7 +48,7 @@ async function ensureEmbeddedPostgres(): Promise<void> {
   const dataRoot = await mkdtemp(path.join(tmpdir(), 'apphub-job-registry-pg-'));
   const port = await findAvailablePort();
 
-  const postgres = new EmbeddedPostgres({
+  const postgres: EmbeddedPostgres = createEmbeddedPostgres({
     databaseDir: dataRoot,
     port,
     user: 'postgres',
@@ -65,7 +65,7 @@ async function ensureEmbeddedPostgres(): Promise<void> {
 
   embeddedPostgresCleanup = async () => {
     try {
-      await postgres.stop();
+      await stopEmbeddedPostgres(postgres);
     } finally {
       await rm(dataRoot, { recursive: true, force: true });
     }

--- a/services/core/tests/jobSandbox.e2e.ts
+++ b/services/core/tests/jobSandbox.e2e.ts
@@ -6,8 +6,8 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import * as tar from 'tar';
 import { createHash } from 'node:crypto';
-import EmbeddedPostgres from 'embedded-postgres';
-import { runE2E } from '@apphub/test-helpers';
+import { createEmbeddedPostgres, stopEmbeddedPostgres, runE2E } from '@apphub/test-helpers';
+import type EmbeddedPostgres from 'embedded-postgres';
 
 let embeddedPostgres: EmbeddedPostgres | null = null;
 let embeddedPostgresCleanup: (() => Promise<void>) | null = null;
@@ -44,7 +44,7 @@ async function ensureEmbeddedPostgres(): Promise<void> {
   const dataRoot = await mkdtemp(path.join(tmpdir(), 'apphub-sandbox-pg-'));
   const port = await findAvailablePort();
 
-  const postgres = new EmbeddedPostgres({
+  const postgres: EmbeddedPostgres = createEmbeddedPostgres({
     databaseDir: dataRoot,
     port,
     user: 'postgres',
@@ -61,7 +61,7 @@ async function ensureEmbeddedPostgres(): Promise<void> {
 
   embeddedPostgresCleanup = async () => {
     try {
-      await postgres.stop();
+      await stopEmbeddedPostgres(postgres);
     } finally {
       await rm(dataRoot, { recursive: true, force: true });
     }

--- a/services/core/tests/jobs.e2e.ts
+++ b/services/core/tests/jobs.e2e.ts
@@ -4,8 +4,8 @@ import net from 'node:net';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import EmbeddedPostgres from 'embedded-postgres';
-import { runE2E } from '@apphub/test-helpers';
+import { createEmbeddedPostgres, stopEmbeddedPostgres, runE2E } from '@apphub/test-helpers';
+import type EmbeddedPostgres from 'embedded-postgres';
 import type { FastifyInstance } from 'fastify';
 
 let embeddedPostgres: EmbeddedPostgres | null = null;
@@ -46,7 +46,7 @@ async function ensureEmbeddedPostgres(): Promise<void> {
   const dataRoot = await mkdtemp(path.join(tmpdir(), 'apphub-jobs-pg-'));
   const port = await findAvailablePort();
 
-  const postgres = new EmbeddedPostgres({
+  const postgres: EmbeddedPostgres = createEmbeddedPostgres({
     databaseDir: dataRoot,
     port,
     user: 'postgres',
@@ -63,7 +63,7 @@ async function ensureEmbeddedPostgres(): Promise<void> {
 
   embeddedPostgresCleanup = async () => {
     try {
-      await postgres.stop();
+      await stopEmbeddedPostgres(postgres);
     } finally {
       await rm(dataRoot, { recursive: true, force: true });
     }

--- a/services/core/tests/launchManifestCommand.e2e.ts
+++ b/services/core/tests/launchManifestCommand.e2e.ts
@@ -4,8 +4,8 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import net from 'node:net';
 import path from 'node:path';
-import EmbeddedPostgres from 'embedded-postgres';
-import { runE2E } from '@apphub/test-helpers';
+import { createEmbeddedPostgres, stopEmbeddedPostgres, runE2E } from '@apphub/test-helpers';
+import type EmbeddedPostgres from 'embedded-postgres';
 import { KubectlMock } from '@apphub/kubectl-mock';
 import type { FastifyInstance } from 'fastify';
 
@@ -45,7 +45,7 @@ async function ensureEmbeddedPostgres(): Promise<void> {
   const dataRoot = await mkdtemp(path.join(tmpdir(), 'launch-manifest-command-pg-'));
   const port = await findAvailablePort();
 
-  const postgres = new EmbeddedPostgres({
+  const postgres: EmbeddedPostgres = createEmbeddedPostgres({
     databaseDir: dataRoot,
     port,
     user: 'postgres',
@@ -62,7 +62,7 @@ async function ensureEmbeddedPostgres(): Promise<void> {
 
   embeddedPostgresCleanup = async () => {
     try {
-      await postgres.stop();
+      await stopEmbeddedPostgres(postgres);
     } finally {
       await rm(dataRoot, { recursive: true, force: true });
     }

--- a/services/core/tests/launchManifestEnv.e2e.ts
+++ b/services/core/tests/launchManifestEnv.e2e.ts
@@ -4,8 +4,8 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import net from 'node:net';
 import path from 'node:path';
-import EmbeddedPostgres from 'embedded-postgres';
-import { runE2E } from '@apphub/test-helpers';
+import { createEmbeddedPostgres, stopEmbeddedPostgres, runE2E } from '@apphub/test-helpers';
+import type EmbeddedPostgres from 'embedded-postgres';
 import { KubectlMock } from '@apphub/kubectl-mock';
 import type { FastifyInstance } from 'fastify';
 
@@ -45,7 +45,7 @@ async function ensureEmbeddedPostgres(): Promise<void> {
   const dataRoot = await mkdtemp(path.join(tmpdir(), 'launch-manifest-env-pg-'));
   const port = await findAvailablePort();
 
-  const postgres = new EmbeddedPostgres({
+  const postgres: EmbeddedPostgres = createEmbeddedPostgres({
     databaseDir: dataRoot,
     port,
     user: 'postgres',
@@ -62,7 +62,7 @@ async function ensureEmbeddedPostgres(): Promise<void> {
 
   embeddedPostgresCleanup = async () => {
     try {
-      await postgres.stop();
+      await stopEmbeddedPostgres(postgres);
     } finally {
       await rm(dataRoot, { recursive: true, force: true });
     }

--- a/services/core/tests/manifestEnvMetadata.test.ts
+++ b/services/core/tests/manifestEnvMetadata.test.ts
@@ -71,7 +71,11 @@ async function run() {
 
   const app = Fastify();
   const stubRegistry = {
-    importManifestModule: async () => ({ servicesApplied: 2, networksApplied: 1 })
+    importManifestModule: async () => ({
+      servicesApplied: 2,
+      networksApplied: 1,
+      moduleVersion: '1'
+    })
   } as const;
   await registerServiceRoutes(app, { registry: stubRegistry });
   try {

--- a/services/core/tests/moduleScopeWorkflows.e2e.ts
+++ b/services/core/tests/moduleScopeWorkflows.e2e.ts
@@ -1,0 +1,252 @@
+import './setupTestEnv';
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import { mkdtemp, rm } from 'node:fs/promises';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import net from 'node:net';
+import { createEmbeddedPostgres, stopEmbeddedPostgres, runE2E } from '@apphub/test-helpers';
+import type EmbeddedPostgres from 'embedded-postgres';
+import type { FastifyInstance } from 'fastify';
+import type * as CoreDbModule from '../src/db';
+import { useConnection } from '../src/db/utils';
+
+const OPERATOR_TOKEN = 'module-scope-operator-token';
+
+process.env.APPHUB_OPERATOR_TOKENS = JSON.stringify([
+  {
+    subject: 'module-scope-e2e',
+    token: OPERATOR_TOKEN,
+    scopes: ['workflows:read']
+  }
+]);
+process.env.SERVICE_REGISTRY_TOKEN = 'module-scope-service-token';
+
+let embeddedPostgres: EmbeddedPostgres | null = null;
+let embeddedCleanup: (() => Promise<void>) | null = null;
+
+async function findAvailablePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (typeof address === 'object' && address) {
+        const { port } = address;
+        server.close(() => resolve(port));
+      } else {
+        server.close(() => reject(new Error('Failed to determine available port')));
+      }
+    });
+  });
+}
+
+async function ensureEmbeddedPostgres(): Promise<void> {
+  if (embeddedPostgres) {
+    return;
+  }
+
+  const dataRoot = await mkdtemp(path.join(tmpdir(), 'apphub-module-scope-pg-'));
+  const port = await findAvailablePort();
+
+  const postgres: EmbeddedPostgres = createEmbeddedPostgres({
+    databaseDir: dataRoot,
+    port,
+    user: 'postgres',
+    password: 'postgres',
+    persistent: false
+  });
+
+  await postgres.initialise();
+  await postgres.start();
+  await postgres.createDatabase('apphub');
+
+  process.env.DATABASE_URL = `postgres://postgres:postgres@127.0.0.1:${port}/apphub`;
+  process.env.PGPOOL_MAX = '6';
+
+  embeddedCleanup = async () => {
+    try {
+      await stopEmbeddedPostgres(postgres);
+    } finally {
+      await rm(dataRoot, { recursive: true, force: true });
+    }
+  };
+
+  embeddedPostgres = postgres;
+}
+
+async function shutdownEmbeddedPostgres(): Promise<void> {
+  const cleanup = embeddedCleanup;
+  embeddedCleanup = null;
+  embeddedPostgres = null;
+  if (cleanup) {
+    await cleanup();
+  }
+}
+
+async function withCoreServer(handler: (app: FastifyInstance, db: CoreDbModule) => Promise<void>): Promise<void> {
+  await ensureEmbeddedPostgres();
+  process.env.APPHUB_EVENTS_MODE = 'inline';
+  process.env.REDIS_URL = 'inline';
+  process.env.APPHUB_ALLOW_INLINE_MODE = 'true';
+
+  const db = await import('../src/db');
+  await db.ensureDatabase();
+
+  const { buildServer } = await import('../src/server');
+  const app = await buildServer();
+  await app.ready();
+
+  try {
+    await handler(app, db);
+  } finally {
+    await app.close();
+    await db.closePool();
+  }
+}
+
+runE2E(async ({ registerCleanup }) => {
+  registerCleanup(async () => shutdownEmbeddedPostgres());
+
+  await withCoreServer(async (app, db) => {
+    const moduleId = 'module-scope-fixture';
+    const moduleVersion = '1.0.0';
+    const moduleDisplayName = 'Module Scope Fixture';
+
+    await useConnection(async (client) => {
+      await client.query(
+        `INSERT INTO modules (id, display_name, description, latest_version)
+         VALUES ($1, $2, $3, $4)
+         ON CONFLICT (id)
+         DO UPDATE SET
+           display_name = EXCLUDED.display_name,
+           description = EXCLUDED.description,
+           latest_version = EXCLUDED.latest_version,
+           updated_at = NOW()`,
+        [moduleId, moduleDisplayName, 'Fixture module for scope tests', moduleVersion]
+      );
+    });
+
+    const workflowSlugBase = randomUUID().replace(/-/g, '').slice(0, 8);
+    const moduleWorkflowSlug = `module-wf-${workflowSlugBase}`;
+    const otherWorkflowSlug = `other-wf-${workflowSlugBase}`;
+
+    const moduleWorkflow = await db.createWorkflowDefinition({
+      slug: moduleWorkflowSlug,
+      name: 'Module scoped workflow',
+      steps: []
+    });
+    const otherWorkflow = await db.createWorkflowDefinition({
+      slug: otherWorkflowSlug,
+      name: 'Unscoped workflow',
+      steps: []
+    });
+
+    await db.upsertModuleResourceContext({
+      moduleId,
+      moduleVersion,
+      resourceType: 'workflow-definition',
+      resourceId: moduleWorkflow.id,
+      resourceSlug: moduleWorkflow.slug,
+      resourceName: moduleWorkflow.name,
+      resourceVersion: String(moduleWorkflow.version),
+      metadata: { slug: moduleWorkflow.slug, name: moduleWorkflow.name }
+    });
+
+    const moduleRun = await db.createWorkflowRun(moduleWorkflow.id, {
+      status: 'pending',
+      runKey: 'module-run'
+    });
+    const otherRun = await db.createWorkflowRun(otherWorkflow.id, {
+      status: 'pending',
+      runKey: 'other-run'
+    });
+
+    const moduleRunContexts = await db.listModuleAssignmentsForResource('workflow-run', moduleRun.id);
+    assert.equal(moduleRunContexts.length, 1, 'module workflow run should be assigned to module');
+    assert.equal(moduleRunContexts[0]?.moduleId, moduleId);
+
+    const unscopedRunContexts = await db.listModuleAssignmentsForResource('workflow-run', otherRun.id);
+    assert.equal(unscopedRunContexts.length, 0, 'unscoped workflow run should not have module assignments');
+
+    const allRunsResponse = await app.inject({
+      method: 'GET',
+      url: '/workflow-runs',
+      headers: {
+        Authorization: `Bearer ${OPERATOR_TOKEN}`
+      }
+    });
+    assert.equal(allRunsResponse.statusCode, 200, 'unscoped request should succeed');
+    const allRunsBody = allRunsResponse.json() as {
+      data: Array<{ run: { id: string }; workflow: { slug: string } }>;
+    };
+    const allRunSlugs = new Set(allRunsBody.data.map((entry) => entry.workflow.slug));
+    assert.ok(allRunSlugs.has(moduleWorkflow.slug), 'unscoped response should include module workflow');
+    assert.ok(allRunSlugs.has(otherWorkflow.slug), 'unscoped response should include other workflow');
+
+    const scopedRunsResponse = await app.inject({
+      method: 'GET',
+      url: '/workflow-runs',
+      headers: {
+        Authorization: `Bearer ${OPERATOR_TOKEN}`,
+        'X-AppHub-Module-Id': moduleId
+      }
+    });
+    assert.equal(scopedRunsResponse.statusCode, 200, 'module-scoped request should succeed');
+    const scopedRunsBody = scopedRunsResponse.json() as {
+      data: Array<{ run: { id: string }; workflow: { slug: string } }>;
+    };
+    assert.equal(scopedRunsBody.data.length, 1, 'module-scoped runs should only include module workflow');
+    assert.equal(scopedRunsBody.data[0]?.workflow.slug, moduleWorkflow.slug);
+
+    const queryScopedRunsResponse = await app.inject({
+      method: 'GET',
+      url: `/workflow-runs?moduleId=${encodeURIComponent(moduleId)}`,
+      headers: {
+        Authorization: `Bearer ${OPERATOR_TOKEN}`
+      }
+    });
+    assert.equal(queryScopedRunsResponse.statusCode, 200);
+    const queryScopedRunsBody = queryScopedRunsResponse.json() as {
+      data: Array<{ run: { id: string }; workflow: { slug: string } }>;
+    };
+    assert.equal(queryScopedRunsBody.data.length, 1);
+    assert.equal(queryScopedRunsBody.data[0]?.workflow.slug, moduleWorkflow.slug);
+
+    const missingModuleResponse = await app.inject({
+      method: 'GET',
+      url: '/workflow-runs',
+      headers: {
+        Authorization: `Bearer ${OPERATOR_TOKEN}`,
+        'X-AppHub-Module-Id': 'missing-module'
+      }
+    });
+    assert.equal(missingModuleResponse.statusCode, 404, 'unknown module should yield 404');
+
+    const workflowsResponse = await app.inject({
+      method: 'GET',
+      url: '/workflows',
+      headers: {
+        Authorization: `Bearer ${OPERATOR_TOKEN}`
+      }
+    });
+    assert.equal(workflowsResponse.statusCode, 200);
+    const workflowsBody = workflowsResponse.json() as { data: Array<{ slug: string }> };
+    const workflowSlugs = workflowsBody.data.map((entry) => entry.slug);
+    assert.ok(workflowSlugs.includes(moduleWorkflow.slug));
+    assert.ok(workflowSlugs.includes(otherWorkflow.slug));
+
+    const scopedWorkflowsResponse = await app.inject({
+      method: 'GET',
+      url: `/workflows?moduleId=${encodeURIComponent(moduleId)}`,
+      headers: {
+        Authorization: `Bearer ${OPERATOR_TOKEN}`
+      }
+    });
+    assert.equal(scopedWorkflowsResponse.statusCode, 200);
+    const scopedWorkflowsBody = scopedWorkflowsResponse.json() as { data: Array<{ slug: string }> };
+    assert.equal(scopedWorkflowsBody.data.length, 1);
+    assert.equal(scopedWorkflowsBody.data[0]?.slug, moduleWorkflow.slug);
+  });
+});

--- a/services/core/tests/retryAdmin.e2e.ts
+++ b/services/core/tests/retryAdmin.e2e.ts
@@ -1,10 +1,10 @@
 import './setupTestEnv';
 import assert from 'node:assert/strict';
 import { randomUUID } from 'node:crypto';
-import EmbeddedPostgres from 'embedded-postgres';
+import { createEmbeddedPostgres, stopEmbeddedPostgres, runE2E } from '@apphub/test-helpers';
+import type EmbeddedPostgres from 'embedded-postgres';
 import Fastify from 'fastify';
 import cookie from '@fastify/cookie';
-import { runE2E } from '@apphub/test-helpers';
 
 let embeddedPostgres: EmbeddedPostgres | null = null;
 let postgresDataDir: string | null = null;
@@ -20,7 +20,7 @@ async function ensureEmbeddedPostgres(): Promise<void> {
   postgresDataDir = dataRoot;
 
   const port = 14_000 + Math.floor(Math.random() * 1_000);
-  const postgres = new EmbeddedPostgres({
+  const postgres: EmbeddedPostgres = createEmbeddedPostgres({
     port,
     databaseDir: dataRoot,
     persistent: false,
@@ -43,7 +43,7 @@ async function shutdownEmbeddedPostgres(): Promise<void> {
     return;
   }
   try {
-    await embeddedPostgres.stop();
+    await stopEmbeddedPostgres(embeddedPostgres);
   } finally {
     embeddedPostgres = null;
     if (postgresDataDir) {

--- a/services/core/tests/serviceRegistryBackfill.test.ts
+++ b/services/core/tests/serviceRegistryBackfill.test.ts
@@ -3,7 +3,8 @@ import assert from 'node:assert/strict';
 import { mkdtemp, rm } from 'node:fs/promises';
 import path from 'node:path';
 import { tmpdir } from 'node:os';
-import EmbeddedPostgres from 'embedded-postgres';
+import { createEmbeddedPostgres, stopEmbeddedPostgres } from '@apphub/test-helpers';
+import type EmbeddedPostgres from 'embedded-postgres';
 import { backfillServiceRegistry } from '../src/serviceRegistryBackfill';
 import {
   getServiceBySlug,
@@ -34,7 +35,7 @@ async function ensureEmbeddedPostgres(): Promise<void> {
   }
   cleanupDir = await mkdtemp(path.join(tmpdir(), 'service-registry-backfill-'));
   const port = 49_000 + Math.floor(Math.random() * 1000);
-  const instance = new EmbeddedPostgres({
+  const instance: EmbeddedPostgres = createEmbeddedPostgres({
     databaseDir: cleanupDir,
     port,
     user: 'postgres',
@@ -55,7 +56,7 @@ async function shutdownEmbeddedPostgres(): Promise<void> {
   const dir = cleanupDir;
   cleanupDir = null;
   if (instance) {
-    await instance.stop();
+    await stopEmbeddedPostgres(instance);
   }
   if (dir) {
     await rm(dir, { recursive: true, force: true });

--- a/services/core/tests/setupTestEnv.ts
+++ b/services/core/tests/setupTestEnv.ts
@@ -6,7 +6,8 @@ import fs from 'node:fs';
 import { tmpdir } from 'node:os';
 import { after } from 'node:test';
 import { mkdtemp, rm } from 'node:fs/promises';
-import EmbeddedPostgres from 'embedded-postgres';
+import { createEmbeddedPostgres, stopEmbeddedPostgres } from '@apphub/test-helpers';
+import type EmbeddedPostgres from 'embedded-postgres';
 
 const ipcDir = path.join(tmpdir(), 'apphub-tsx-ipc');
 try {
@@ -61,7 +62,7 @@ async function startEmbeddedPostgres(): Promise<void> {
   const dataRoot = await mkdtemp(path.join(tmpdir(), 'apphub-core-pg-'));
   const port = await findAvailablePort();
 
-  const postgres = new EmbeddedPostgres({
+  const postgres: EmbeddedPostgres = createEmbeddedPostgres({
     databaseDir: dataRoot,
     port,
     user: 'postgres',
@@ -78,7 +79,7 @@ async function startEmbeddedPostgres(): Promise<void> {
 
   embeddedCleanup = async () => {
     try {
-      await postgres.stop();
+      await stopEmbeddedPostgres(postgres);
     } finally {
       await rm(dataRoot, { recursive: true, force: true });
     }

--- a/services/core/tests/workflowEventsQuery.test.ts
+++ b/services/core/tests/workflowEventsQuery.test.ts
@@ -4,7 +4,8 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import path from 'node:path';
 import { tmpdir } from 'node:os';
 import net from 'node:net';
-import EmbeddedPostgres from 'embedded-postgres';
+import { createEmbeddedPostgres, stopEmbeddedPostgres } from '@apphub/test-helpers';
+import type EmbeddedPostgres from 'embedded-postgres';
 import { randomUUID } from 'node:crypto';
 import type { WorkflowEventCursor, WorkflowEventInsert } from '../src/db/types';
 
@@ -28,7 +29,7 @@ async function allocatePort(): Promise<number> {
 async function startDatabase(): Promise<() => Promise<void>> {
   const dataDir = await mkdtemp(path.join(tmpdir(), 'apphub-workflow-events-db-'));
   const port = await allocatePort();
-  const postgres = new EmbeddedPostgres({
+  const postgres: EmbeddedPostgres = createEmbeddedPostgres({
     databaseDir: dataDir,
     port,
     user: 'postgres',
@@ -45,7 +46,7 @@ async function startDatabase(): Promise<() => Promise<void>> {
 
   return async () => {
     try {
-      await postgres.stop();
+    await stopEmbeddedPostgres(postgres);
     } finally {
       await rm(dataDir, { recursive: true, force: true });
     }

--- a/services/core/tests/workflowGraphRoute.e2e.ts
+++ b/services/core/tests/workflowGraphRoute.e2e.ts
@@ -5,9 +5,9 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import path from 'node:path';
 import { tmpdir } from 'node:os';
 import net from 'node:net';
-import EmbeddedPostgres from 'embedded-postgres';
+import { createEmbeddedPostgres, stopEmbeddedPostgres, runE2E } from '@apphub/test-helpers';
+import type EmbeddedPostgres from 'embedded-postgres';
 import type { FastifyInstance } from 'fastify';
-import { runE2E } from '@apphub/test-helpers';
 
 type CoreDbModule = typeof import('../src/db');
 
@@ -56,7 +56,7 @@ async function ensureEmbeddedPostgres(): Promise<void> {
   const dataRoot = await mkdtemp(path.join(tmpdir(), 'apphub-workflow-graph-pg-'));
   const port = await findAvailablePort();
 
-  const postgres = new EmbeddedPostgres({
+  const postgres: EmbeddedPostgres = createEmbeddedPostgres({
     databaseDir: dataRoot,
     port,
     user: 'postgres',
@@ -73,7 +73,7 @@ async function ensureEmbeddedPostgres(): Promise<void> {
 
   embeddedCleanup = async () => {
     try {
-      await postgres.stop();
+    await stopEmbeddedPostgres(postgres);
     } finally {
       await rm(dataRoot, { recursive: true, force: true });
     }

--- a/services/core/tests/workflowRetries.test.ts
+++ b/services/core/tests/workflowRetries.test.ts
@@ -1,7 +1,8 @@
 import './setupTestEnv';
 import assert from 'node:assert/strict';
 import { randomUUID } from 'node:crypto';
-import EmbeddedPostgres from 'embedded-postgres';
+import { createEmbeddedPostgres, stopEmbeddedPostgres } from '@apphub/test-helpers';
+import type EmbeddedPostgres from 'embedded-postgres';
 import net from 'node:net';
 import { mkdtemp, rm } from 'node:fs/promises';
 import path from 'node:path';
@@ -51,7 +52,7 @@ async function ensureEmbeddedPostgres(): Promise<void> {
   const dataRoot = await mkdtemp(path.join(tmpdir(), 'apphub-workflow-retry-pg-'));
   const port = await findAvailablePort();
 
-  const postgres = new EmbeddedPostgres({
+  const postgres: EmbeddedPostgres = createEmbeddedPostgres({
     databaseDir: dataRoot,
     persistent: false,
     port,
@@ -71,7 +72,7 @@ async function ensureEmbeddedPostgres(): Promise<void> {
   embeddedPostgres = postgres;
   embeddedCleanup = async () => {
     try {
-      await postgres.stop();
+      await stopEmbeddedPostgres(postgres);
     } finally {
       await rm(dataRoot, { recursive: true, force: true });
     }

--- a/services/core/tests/workflows.e2e.ts
+++ b/services/core/tests/workflows.e2e.ts
@@ -6,12 +6,12 @@ import net from 'node:net';
 import { mkdtemp, rm, writeFile, readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import EmbeddedPostgres from 'embedded-postgres';
+import { createEmbeddedPostgres, stopEmbeddedPostgres, runE2E } from '@apphub/test-helpers';
+import type EmbeddedPostgres from 'embedded-postgres';
 import type { FastifyInstance } from 'fastify';
 import type { JobRunContext, JobResult } from '../src/jobs/runtime';
 import { refreshSecretStore } from '../src/secretStore';
 import { emitApphubEvent } from '../src/events';
-import { runE2E } from '@apphub/test-helpers';
 let embeddedPostgres: EmbeddedPostgres | null = null;
 let embeddedPostgresCleanup: (() => Promise<void>) | null = null;
 
@@ -59,7 +59,7 @@ async function ensureEmbeddedPostgres(): Promise<void> {
   const dataRoot = await mkdtemp(path.join(tmpdir(), 'apphub-workflows-pg-'));
   const port = await findAvailablePort();
 
-  const postgres = new EmbeddedPostgres({
+  const postgres: EmbeddedPostgres = createEmbeddedPostgres({
     databaseDir: dataRoot,
     port,
     user: 'postgres',
@@ -76,7 +76,7 @@ async function ensureEmbeddedPostgres(): Promise<void> {
 
   embeddedPostgresCleanup = async () => {
     try {
-      await postgres.stop();
+      await stopEmbeddedPostgres(postgres);
     } finally {
       await rm(dataRoot, { recursive: true, force: true });
     }

--- a/services/filestore/tests/autoProvision.test.ts
+++ b/services/filestore/tests/autoProvision.test.ts
@@ -5,7 +5,7 @@ import { randomUUID } from 'node:crypto';
 import { mkdtemp, rm } from 'node:fs/promises';
 import path from 'node:path';
 import { tmpdir } from 'node:os';
-import EmbeddedPostgres from 'embedded-postgres';
+import { createEmbeddedPostgres, stopEmbeddedPostgres } from '../../../tests/helpers';
 import type { FastifyBaseLogger } from 'fastify';
 import { runE2E } from '../../../tests/helpers';
 
@@ -16,7 +16,7 @@ runE2E(async ({ registerCleanup }) => {
   });
 
   const port = 59000 + Math.floor(Math.random() * 1000);
-  const postgres = new EmbeddedPostgres({
+  const postgres = createEmbeddedPostgres({
     databaseDir: dataDir,
     port,
     user: 'postgres',
@@ -28,7 +28,7 @@ runE2E(async ({ registerCleanup }) => {
   await postgres.start();
   await postgres.createDatabase('apphub');
   registerCleanup(async () => {
-    await postgres.stop();
+    await stopEmbeddedPostgres(postgres);
   });
 
   const schemaSuffix = randomUUID().slice(0, 8);

--- a/services/filestore/tests/migrations.test.ts
+++ b/services/filestore/tests/migrations.test.ts
@@ -6,7 +6,8 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import path from 'node:path';
 import { tmpdir } from 'node:os';
 import { after, before, test } from 'node:test';
-import EmbeddedPostgres from 'embedded-postgres';
+import { createEmbeddedPostgres, stopEmbeddedPostgres } from '../../../tests/helpers';
+import type EmbeddedPostgres from 'embedded-postgres';
 
 let postgres: EmbeddedPostgres | null = null;
 let dataDirectory: string | null = null;
@@ -19,7 +20,7 @@ before(async () => {
   const dataRoot = await mkdtemp(path.join(tmpdir(), 'filestore-pg-'));
   dataDirectory = dataRoot;
   const port = 55000 + Math.floor(Math.random() * 1000);
-  const embedded = new EmbeddedPostgres({
+  const embedded: EmbeddedPostgres = createEmbeddedPostgres({
     databaseDir: dataRoot,
     port,
     user: 'postgres',
@@ -59,9 +60,7 @@ after(async () => {
   if (clientModule) {
     await clientModule.closePool();
   }
-  if (postgres) {
-    await postgres.stop();
-  }
+  await stopEmbeddedPostgres(postgres);
   if (dataDirectory) {
     await rm(dataDirectory, { recursive: true, force: true });
   }

--- a/services/filestore/tests/orchestrator.test.ts
+++ b/services/filestore/tests/orchestrator.test.ts
@@ -6,7 +6,8 @@ import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { tmpdir } from 'node:os';
 import { after, afterEach, before, test } from 'node:test';
-import EmbeddedPostgres from 'embedded-postgres';
+import { createEmbeddedPostgres, stopEmbeddedPostgres } from '../../../tests/helpers';
+import type EmbeddedPostgres from 'embedded-postgres';
 
 import type { CommandExecutor } from '../src/executors/types';
 import { createLocalExecutor } from '../src/executors/localExecutor';
@@ -33,7 +34,7 @@ before(async () => {
   const dataRoot = await mkdtemp(path.join(tmpdir(), 'filestore-orchestrator-pg-'));
   dataDirectory = dataRoot;
   const port = 56000 + Math.floor(Math.random() * 1000);
-  const embedded = new EmbeddedPostgres({
+  const embedded: EmbeddedPostgres = createEmbeddedPostgres({
     databaseDir: dataRoot,
     port,
     user: 'postgres',
@@ -114,9 +115,7 @@ after(async () => {
   if (clientModule) {
     await clientModule.closePool();
   }
-  if (postgres) {
-    await postgres.stop();
-  }
+  await stopEmbeddedPostgres(postgres);
   if (dataDirectory) {
     await rm(dataDirectory, { recursive: true, force: true });
   }

--- a/services/filestore/tests/routes.test.ts
+++ b/services/filestore/tests/routes.test.ts
@@ -6,7 +6,7 @@ import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import path from 'node:path';
 import { tmpdir } from 'node:os';
 import http from 'node:http';
-import EmbeddedPostgres from 'embedded-postgres';
+import { createEmbeddedPostgres, stopEmbeddedPostgres } from '../../../tests/helpers';
 import { encodeFilestoreNodeFiltersParam } from '@apphub/shared/filestoreFilters';
 import { runE2E } from '../../../tests/helpers';
 
@@ -69,7 +69,7 @@ runE2E(async ({ registerCleanup }) => {
   });
 
   const port = 57000 + Math.floor(Math.random() * 1000);
-  const postgres = new EmbeddedPostgres({
+  const postgres = createEmbeddedPostgres({
     databaseDir: dataDir,
     port,
     user: 'postgres',
@@ -81,7 +81,7 @@ runE2E(async ({ registerCleanup }) => {
   await postgres.start();
   await postgres.createDatabase('apphub');
   registerCleanup(async () => {
-    await postgres.stop();
+    await stopEmbeddedPostgres(postgres);
   });
 
   process.env.FILESTORE_DATABASE_URL = `postgres://postgres:postgres@127.0.0.1:${port}/apphub`;

--- a/services/filestore/tests/s3Executor.test.ts
+++ b/services/filestore/tests/s3Executor.test.ts
@@ -6,7 +6,8 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import path from 'node:path';
 import { tmpdir } from 'node:os';
 import { after, afterEach, before, test } from 'node:test';
-import EmbeddedPostgres from 'embedded-postgres';
+import { createEmbeddedPostgres, stopEmbeddedPostgres } from '../../../tests/helpers';
+import type EmbeddedPostgres from 'embedded-postgres';
 import {
   DeleteObjectCommand,
   DeleteObjectsCommand,
@@ -89,7 +90,7 @@ before(async () => {
   const dataRoot = await mkdtemp(path.join(tmpdir(), 'filestore-s3-pg-'));
   dataDirectory = dataRoot;
   const port = 56500 + Math.floor(Math.random() * 1000);
-  const embedded = new EmbeddedPostgres({
+  const embedded: EmbeddedPostgres = createEmbeddedPostgres({
     databaseDir: dataRoot,
     port,
     user: 'postgres',
@@ -166,9 +167,7 @@ after(async () => {
   if (clientModule) {
     await clientModule.closePool();
   }
-  if (postgres) {
-    await postgres.stop();
-  }
+  await stopEmbeddedPostgres(postgres);
   if (dataDirectory) {
     await rm(dataDirectory, { recursive: true, force: true });
   }

--- a/services/metastore/tests/integration/autoMigrations.test.ts
+++ b/services/metastore/tests/integration/autoMigrations.test.ts
@@ -5,7 +5,8 @@ import net from 'node:net';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import EmbeddedPostgres from 'embedded-postgres';
+import { createEmbeddedPostgres, stopEmbeddedPostgres } from '@apphub/test-helpers';
+import type EmbeddedPostgres from 'embedded-postgres';
 import { runE2E } from '@apphub/test-helpers';
 
 async function findAvailablePort(): Promise<number> {
@@ -54,7 +55,7 @@ runE2E(async ({ registerCleanup }) => {
   const dataDir = await mkdtemp(path.join(tmpdir(), 'metastore-migrate-pg-'));
   const port = await findAvailablePort();
 
-  const postgres = new EmbeddedPostgres({
+  const postgres: EmbeddedPostgres = createEmbeddedPostgres({
     databaseDir: dataDir,
     port,
     user: 'postgres',
@@ -71,7 +72,7 @@ runE2E(async ({ registerCleanup }) => {
   });
 
   registerCleanup(async () => {
-    await postgres.stop();
+    await stopEmbeddedPostgres(postgres);
   });
 
   process.env.DATABASE_URL = `postgres://postgres:postgres@127.0.0.1:${port}/apphub`;

--- a/services/metastore/tests/integration/filestoreHealthEndpoint.test.ts
+++ b/services/metastore/tests/integration/filestoreHealthEndpoint.test.ts
@@ -5,7 +5,8 @@ import net from 'node:net';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import EmbeddedPostgres from 'embedded-postgres';
+import { createEmbeddedPostgres, stopEmbeddedPostgres } from '@apphub/test-helpers';
+import type EmbeddedPostgres from 'embedded-postgres';
 import type { FastifyInstance } from 'fastify';
 import type { FilestoreNodeEventPayload } from '@apphub/shared/filestoreEvents';
 import { runE2E } from '@apphub/test-helpers';
@@ -58,7 +59,7 @@ async function setupMetastore(): Promise<TestContext> {
   const dataDir = await mkdtemp(path.join(tmpdir(), 'metastore-health-'));
   const port = await findAvailablePort();
 
-  const postgres = new EmbeddedPostgres({
+  const postgres: EmbeddedPostgres = createEmbeddedPostgres({
     databaseDir: dataDir,
     port,
     user: 'postgres',
@@ -112,7 +113,7 @@ runE2E(async ({ registerCleanup }) => {
   });
 
   registerCleanup(async () => {
-    await postgres.stop();
+    await stopEmbeddedPostgres(postgres);
   });
 
   registerCleanup(async () => {

--- a/services/metastore/tests/integration/namespaces.test.ts
+++ b/services/metastore/tests/integration/namespaces.test.ts
@@ -5,7 +5,8 @@ import net from 'node:net';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import EmbeddedPostgres from 'embedded-postgres';
+import { createEmbeddedPostgres, stopEmbeddedPostgres } from '@apphub/test-helpers';
+import type EmbeddedPostgres from 'embedded-postgres';
 import type { FastifyInstance } from 'fastify';
 import { runE2E } from '@apphub/test-helpers';
 
@@ -60,7 +61,7 @@ async function setupMetastore(): Promise<MetastoreContext> {
   const dataDir = await mkdtemp(path.join(tmpdir(), 'metastore-pg-'));
   const port = await findAvailablePort();
 
-  const postgres = new EmbeddedPostgres({
+  const postgres: EmbeddedPostgres = createEmbeddedPostgres({
     databaseDir: dataDir,
     port,
     user: 'postgres',
@@ -136,7 +137,7 @@ runE2E(async ({ registerCleanup }) => {
   });
 
   registerCleanup(async () => {
-    await postgres.stop();
+    await stopEmbeddedPostgres(postgres);
   });
 
   registerCleanup(async () => {

--- a/services/metastore/tests/integration/records.test.js
+++ b/services/metastore/tests/integration/records.test.js
@@ -9,7 +9,7 @@ const node_net_1 = __importDefault(require("node:net"));
 const promises_1 = require("node:fs/promises");
 const node_os_1 = require("node:os");
 const node_path_1 = __importDefault(require("node:path"));
-const embedded_postgres_1 = __importDefault(require("embedded-postgres"));
+const test_helpers_1 = require("@apphub/test-helpers");
 const app_1 = require("../../src/app");
 const client_1 = require("../../src/db/client");
 async function findAvailablePort() {
@@ -34,7 +34,7 @@ async function findAvailablePort() {
     process.env.NODE_ENV = 'test';
     const dataRoot = await (0, promises_1.mkdtemp)(node_path_1.default.join((0, node_os_1.tmpdir)(), 'metastore-pg-'));
     const port = await findAvailablePort();
-    const postgres = new embedded_postgres_1.default({
+    const postgres = (0, test_helpers_1.createEmbeddedPostgres)({
         databaseDir: dataRoot,
         port,
         user: 'postgres',
@@ -54,7 +54,7 @@ async function findAvailablePort() {
             await app.close();
         }
         await (0, client_1.closePool)();
-        await postgres.stop();
+        await (0, test_helpers_1.stopEmbeddedPostgres)(postgres);
         await (0, promises_1.rm)(dataRoot, { recursive: true, force: true });
     });
     const build = await (0, app_1.buildApp)();

--- a/services/metastore/tests/integration/records.test.ts
+++ b/services/metastore/tests/integration/records.test.ts
@@ -6,7 +6,8 @@ import net from 'node:net';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import EmbeddedPostgres from 'embedded-postgres';
+import { createEmbeddedPostgres, stopEmbeddedPostgres } from '@apphub/test-helpers';
+import type EmbeddedPostgres from 'embedded-postgres';
 import type { FastifyInstance } from 'fastify';
 import { runE2E } from '@apphub/test-helpers';
 
@@ -57,7 +58,7 @@ async function setupMetastore(): Promise<TestContext> {
   const dataDir = await mkdtemp(path.join(tmpdir(), 'metastore-pg-'));
   const port = await findAvailablePort();
 
-  const postgres = new EmbeddedPostgres({
+  const postgres: EmbeddedPostgres = createEmbeddedPostgres({
     databaseDir: dataDir,
     port,
     user: 'postgres',
@@ -122,7 +123,7 @@ runE2E(async ({ registerCleanup }) => {
   });
 
   registerCleanup(async () => {
-    await postgres.stop();
+    await stopEmbeddedPostgres(postgres);
   });
 
   registerCleanup(async () => {

--- a/services/metastore/tests/integration/schemaRegistry.test.ts
+++ b/services/metastore/tests/integration/schemaRegistry.test.ts
@@ -5,7 +5,8 @@ import net from 'node:net';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import EmbeddedPostgres from 'embedded-postgres';
+import { createEmbeddedPostgres, stopEmbeddedPostgres } from '@apphub/test-helpers';
+import type EmbeddedPostgres from 'embedded-postgres';
 import type { FastifyInstance } from 'fastify';
 import { runE2E } from '@apphub/test-helpers';
 
@@ -60,7 +61,7 @@ async function setupMetastore(): Promise<MetastoreContext> {
   const dataDir = await mkdtemp(path.join(tmpdir(), 'metastore-schema-pg-'));
   const port = await findAvailablePort();
 
-  const postgres = new EmbeddedPostgres({
+  const postgres: EmbeddedPostgres = createEmbeddedPostgres({
     databaseDir: dataDir,
     port,
     user: 'postgres',
@@ -144,7 +145,7 @@ runE2E(async ({ registerCleanup }) => {
   });
 
   registerCleanup(async () => {
-    await postgres.stop();
+    await stopEmbeddedPostgres(postgres);
   });
 
   registerCleanup(async () => {

--- a/services/metastore/tests/integration/streamAuth.test.ts
+++ b/services/metastore/tests/integration/streamAuth.test.ts
@@ -5,7 +5,8 @@ import net from 'node:net';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import EmbeddedPostgres from 'embedded-postgres';
+import { createEmbeddedPostgres, stopEmbeddedPostgres } from '@apphub/test-helpers';
+import type EmbeddedPostgres from 'embedded-postgres';
 import type { FastifyInstance } from 'fastify';
 import { runE2E } from '@apphub/test-helpers';
 
@@ -56,7 +57,7 @@ async function setupMetastore(): Promise<TestContext> {
   const dataDir = await mkdtemp(path.join(tmpdir(), 'metastore-auth-'));
   const port = await findAvailablePort();
 
-  const postgres = new EmbeddedPostgres({
+  const postgres: EmbeddedPostgres = createEmbeddedPostgres({
     databaseDir: dataDir,
     port,
     user: 'postgres',
@@ -125,7 +126,7 @@ runE2E(async ({ registerCleanup }) => {
   });
 
   registerCleanup(async () => {
-    await postgres.stop();
+    await stopEmbeddedPostgres(postgres);
   });
 
   registerCleanup(async () => {

--- a/services/timestore/tests/utils/embeddedPostgres.ts
+++ b/services/timestore/tests/utils/embeddedPostgres.ts
@@ -1,53 +1,5 @@
-import EmbeddedPostgres from 'embedded-postgres';
-
-const activeInstances = new Set<EmbeddedPostgres>();
-
-type EmbeddedPostgresOptions = ConstructorParameters<typeof EmbeddedPostgres>[0];
-
-function ensureSharedMemoryFlag(flags: string[] | undefined): string[] {
-  const normalized = Array.isArray(flags) ? [...flags] : [];
-  const hasSharedMemorySetting = normalized.some((flag) =>
-    typeof flag === 'string' && flag.includes('shared_memory_type=')
-  );
-  if (!hasSharedMemorySetting) {
-    normalized.push('-c', 'shared_memory_type=mmap');
-  }
-  return normalized;
-}
-
-export function createEmbeddedPostgres(options?: EmbeddedPostgresOptions): EmbeddedPostgres {
-  const normalizedOptions = {
-    ...(options ?? {}),
-    postgresFlags: ensureSharedMemoryFlag((options as { postgresFlags?: string[] } | undefined)?.postgresFlags)
-  } as EmbeddedPostgresOptions;
-
-  const info = {
-    databaseDir: (normalizedOptions as { databaseDir?: string }).databaseDir,
-    port: (normalizedOptions as { port?: number }).port
-  };
-  console.info('[timestore:test] starting embedded Postgres', info);
-
-  const instance = new EmbeddedPostgres(normalizedOptions);
-  activeInstances.add(instance);
-  return instance;
-}
-
-export async function stopEmbeddedPostgres(instance: EmbeddedPostgres | null | undefined): Promise<void> {
-  if (!instance) {
-    return;
-  }
-  try {
-    await instance.stop();
-  } catch (error) {
-    console.warn('[timestore:test] failed to stop embedded Postgres', error);
-  } finally {
-    activeInstances.delete(instance);
-  }
-}
-
-export async function stopAllEmbeddedPostgres(): Promise<void> {
-  const instances = Array.from(activeInstances);
-  for (const instance of instances) {
-    await stopEmbeddedPostgres(instance);
-  }
-}
+export {
+  createEmbeddedPostgres,
+  stopEmbeddedPostgres,
+  stopAllEmbeddedPostgres
+} from '@apphub/test-helpers';

--- a/tests/helpers/embeddedPostgres.ts
+++ b/tests/helpers/embeddedPostgres.ts
@@ -1,0 +1,173 @@
+import { rmSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+
+import EmbeddedPostgres from 'embedded-postgres';
+
+type EmbeddedPostgresOptions = ConstructorParameters<typeof EmbeddedPostgres>[0];
+
+type InstanceMetadata = {
+  dataDir: string | null;
+  persistent: boolean;
+};
+
+const activeInstances = new Set<EmbeddedPostgres>();
+const instanceMetadata = new WeakMap<EmbeddedPostgres, InstanceMetadata>();
+
+function upsertPostgresFlag(flags: string[], key: string, value: string): void {
+  const pattern = `${key}=`;
+  if (flags.some((flag) => typeof flag === 'string' && flag.includes(pattern))) {
+    return;
+  }
+  flags.push('-c', `${key}=${value}`);
+}
+
+function ensurePostgresFlags(input: string[] | undefined): string[] {
+  const flags = Array.isArray(input) ? [...input] : [];
+  upsertPostgresFlag(flags, 'shared_memory_type', 'mmap');
+  upsertPostgresFlag(flags, 'dynamic_shared_memory_type', 'posix');
+  return flags;
+}
+
+function clearSharedMemorySegmentsSync(): void {
+  if (process.platform !== 'darwin' && process.platform !== 'linux') {
+    return;
+  }
+  if (typeof process.getuid !== 'function') {
+    return;
+  }
+
+  const uid = process.getuid();
+  const ipcs = spawnSync('ipcs', ['-m'], { encoding: 'utf8' });
+  if (ipcs.status !== 0 || !ipcs.stdout) {
+    return;
+  }
+
+  const segmentIds: string[] = [];
+  const userName = process.env.USER ?? null;
+  for (const line of ipcs.stdout.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('------') || trimmed.startsWith('T ')) {
+      continue;
+    }
+
+    const parts = trimmed.split(/\s+/);
+    if (parts.length < 4) {
+      continue;
+    }
+
+    let idToken: string | null = null;
+    let ownerToken: string | null = null;
+
+    if (parts[0] === 'm' || parts[0] === 'q' || parts[0] === 's') {
+      idToken = parts[1] ?? null;
+      ownerToken = parts[4] ?? null;
+    } else {
+      idToken = parts[0] ?? null;
+      ownerToken = parts[2] ?? null;
+    }
+
+    if (!idToken) {
+      continue;
+    }
+
+    if (ownerToken) {
+      const ownerUid = Number.parseInt(ownerToken, 10);
+      if (Number.isNaN(ownerUid)) {
+        if (userName && ownerToken !== userName) {
+          continue;
+        }
+      } else if (ownerUid !== uid) {
+        continue;
+      }
+    } else if (userName) {
+      // without owner information we skip removal
+      continue;
+    }
+
+    segmentIds.push(idToken);
+  }
+
+  if (segmentIds.length === 0) {
+    return;
+  }
+
+  for (const segmentId of segmentIds) {
+    const result = spawnSync('ipcrm', ['-m', segmentId]);
+    if (result.status !== 0 && result.stderr) {
+      console.warn('[embedded-postgres] failed to clear shared memory segment', {
+        segmentId,
+        error: result.stderr.toString()
+      });
+    }
+  }
+}
+
+function removeDataDirectorySync(directory: string | null): void {
+  if (!directory) {
+    return;
+  }
+  try {
+    rmSync(directory, { recursive: true, force: true });
+  } catch (error) {
+    console.warn('[embedded-postgres] failed to remove existing data directory', { directory, error });
+  }
+}
+
+export function createEmbeddedPostgres(options?: EmbeddedPostgresOptions): EmbeddedPostgres {
+  clearSharedMemorySegmentsSync();
+
+  const normalizedOptions = {
+    ...(options ?? {}),
+    postgresFlags: ensurePostgresFlags(
+      (options as EmbeddedPostgresOptions | undefined)?.postgresFlags as string[] | undefined
+    )
+  } as EmbeddedPostgresOptions;
+
+  const dataDir =
+    typeof (normalizedOptions as { databaseDir?: unknown }).databaseDir === 'string'
+      ? ((normalizedOptions as { databaseDir?: string }).databaseDir ?? null)
+      : null;
+
+  if (dataDir) {
+    removeDataDirectorySync(dataDir);
+  }
+
+  const instance = new EmbeddedPostgres(normalizedOptions);
+  activeInstances.add(instance);
+  instanceMetadata.set(instance, {
+    dataDir,
+    persistent: Boolean((normalizedOptions as { persistent?: boolean }).persistent)
+  });
+  return instance;
+}
+
+export async function stopEmbeddedPostgres(instance: EmbeddedPostgres | null | undefined): Promise<void> {
+  if (!instance) {
+    return;
+  }
+  const metadata = instanceMetadata.get(instance);
+
+  try {
+    await instance.stop();
+  } catch (error) {
+    console.warn('[embedded-postgres] failed to stop instance', error);
+  } finally {
+    activeInstances.delete(instance);
+    if (metadata && metadata.dataDir && !metadata.persistent) {
+      try {
+        await rm(metadata.dataDir, { recursive: true, force: true });
+      } catch (error) {
+        console.warn('[embedded-postgres] failed to remove data directory', { directory: metadata.dataDir, error });
+      }
+    }
+    clearSharedMemorySegmentsSync();
+  }
+}
+
+export async function stopAllEmbeddedPostgres(): Promise<void> {
+  const instances = Array.from(activeInstances);
+  for (const instance of instances) {
+    await stopEmbeddedPostgres(instance);
+  }
+}

--- a/tests/helpers/index.ts
+++ b/tests/helpers/index.ts
@@ -1,3 +1,8 @@
 export { runE2E } from './runE2E';
 export type { RunE2EOptions } from './runE2E';
 export { scheduleForcedExit, logActiveHandles } from './forceExit';
+export {
+  createEmbeddedPostgres,
+  stopEmbeddedPostgres,
+  stopAllEmbeddedPostgres
+} from './embeddedPostgres';

--- a/tests/helpers/runE2E.ts
+++ b/tests/helpers/runE2E.ts
@@ -1,6 +1,7 @@
 import process from 'node:process';
 
 import { scheduleForcedExit, logActiveHandles } from './forceExit';
+import { stopAllEmbeddedPostgres } from './embeddedPostgres';
 
 const DEFAULT_CLEANUP_TIMEOUT_MS = 60_000;
 
@@ -38,7 +39,11 @@ export async function runE2E(
   } else {
     console.info('[runE2E] Starting scenario');
   }
-  const cleanupHandlers: CleanupHandler[] = [];
+  const cleanupHandlers: CleanupHandler[] = [
+    async () => {
+      await stopAllEmbeddedPostgres();
+    }
+  ];
   let exitCode = 0;
   let shutdownPromise: Promise<void> | null = null;
   let receivedSignal = false;


### PR DESCRIPTION
## Summary
- add module resource context utilities and module scope resolver in core
- scope workflow auto-materialize and asset read APIs by module context
- propagate moduleId from frontend module scope into workflow asset and graph clients

## Testing
- npm run lint --workspace @apphub/frontend -- --cache
- npm run lint --workspace @apphub/core

## Follow-up
- Scope mark/clear stale endpoints and partition parameter mutations via module-aware lookups in services/core/src/routes/assets.ts (currently resolveWorkflowAsset ignores module scope)
- Backfill module_resource_contexts for existing resources and add integrity checks/migrations for production datasets
- Add integration coverage for module-filtered asset endpoints and frontend tests for module switching
- Ensure websocket/event consumers filter module-specific payloads and document new header/query requirements