### PR TITLE
feat: refresh marketing copy and diagrams

### DIFF
--- a/apps/website/src/components/diagrams.tsx
+++ b/apps/website/src/components/diagrams.tsx
@@ -31,11 +31,11 @@ type DiagramSpec = {
 
 const frameWidth = 360
 const frameHeight = 220
-const nodeDefaultWidth = 104
-const nodeDefaultHeight = 52
-const connectionPadding = 12
-const connectionStartInset = 5
-const connectionArrowInset = 12
+const nodeDefaultWidth = 92
+const nodeDefaultHeight = 44
+const connectionPadding = 8
+const connectionStartInset = 4
+const connectionArrowInset = 10
 
 type NodeRect = {
   x: number
@@ -248,25 +248,37 @@ const createDiagram = (spec: DiagramSpec): FC => {
 export const DataPlaneDiagram = createDiagram({
   title: 'Data plane flow',
   nodes: [
-    { id: 'ingest', label: 'Ingestion\nWorkers', x: 18, y: 32, width: 108, height: 56 },
-    { id: 'events', label: 'Event Bus', x: 236, y: 24, width: 100, height: 50 },
-    { id: 'core', label: 'Core\nOrchestrator', x: 128, y: 92, width: 132, height: 72 },
-    { id: 'timestore', label: 'Timestore', x: 18, y: 178 },
-    { id: 'filestore', label: 'Filestore', x: 132, y: 178 },
-    { id: 'metastore', label: 'Metastore', x: 246, y: 178 }
+    { id: 'ingest', label: 'Ingestion\nWorkers', x: 20, y: 30 },
+    { id: 'stream', label: 'Streaming\nFeeds', x: 136, y: 24 },
+    { id: 'bus', label: 'Event\nBus', x: 252, y: 30 },
+    { id: 'core', label: 'Workflows /\nJobs / Assets', x: 118, y: 90, width: 140, height: 68 },
+    {
+      id: 'timestore',
+      label: 'Timestore\nStaging -> Parquet',
+      x: 16,
+      y: 164,
+      width: 148,
+      height: 52
+    },
+    {
+      id: 'stores',
+      label: 'Filestore +\nMetastore Events',
+      x: 212,
+      y: 164,
+      width: 140,
+      height: 52
+    }
   ],
   connections: [
     { from: 'ingest', to: 'core' },
-    { from: 'events', to: 'core' },
-    { from: 'core', to: 'events' },
+    { from: 'stream', to: 'core' },
+    { from: 'core', to: 'bus' },
+    { from: 'bus', to: 'core' },
     { from: 'core', to: 'timestore' },
-    { from: 'core', to: 'filestore' },
-    { from: 'core', to: 'metastore' }
-  ],
-  annotations: [
-    { x: 68, y: 26, text: 'Telemetry in' },
-    { x: 292, y: 20, text: 'Queues & triggers', align: 'end' },
-    { x: 180, y: 166, text: 'Persisted state', align: 'middle' }
+    { from: 'core', to: 'stores' },
+    { from: 'timestore', to: 'core', dashed: true },
+    { from: 'stores', to: 'core', dashed: true },
+    { from: 'bus', to: 'stores', dashed: true }
   ]
 })
 
@@ -274,7 +286,7 @@ export const DeploymentOptionsDiagram = createDiagram({
   title: 'Deployment options',
   nodes: [
     { id: 'control', label: 'Control Plane', x: 130, y: 26, width: 120, height: 60 },
-    { id: 'servers', label: 'Dedicated\nServers', x: 24, y: 134 },
+    { id: 'servers', label: 'Single\nMachine', x: 24, y: 134 },
     { id: 'cloud', label: 'Cloud\nKubernetes', x: 132, y: 148 },
     { id: 'hybrid', label: 'Hybrid\nEdge Sites', x: 240, y: 134 }
   ],
@@ -282,118 +294,106 @@ export const DeploymentOptionsDiagram = createDiagram({
     { from: 'control', to: 'servers' },
     { from: 'control', to: 'cloud' },
     { from: 'control', to: 'hybrid' }
-  ],
-  annotations: [
-    { x: 190, y: 104, text: 'Same module tooling across environments', align: 'middle' }
   ]
 })
 
 export const EventBusDiagram = createDiagram({
   title: 'Event bus coordination',
   nodes: [
-    { id: 'producers', label: 'Module Jobs', x: 26, y: 34 },
-    { id: 'bus', label: 'Redis / BullMQ\nEvent Bus', x: 198, y: 60, width: 140, height: 64 },
-    { id: 'workflows', label: 'Workflows', x: 26, y: 160 },
-    { id: 'external', label: 'External\nSystems', x: 238, y: 162 }
+    { id: 'producers', label: 'Module Jobs\n& Assets', x: 24, y: 40 },
+    { id: 'bus', label: 'Event\nBus', x: 204, y: 36, width: 120, height: 52 },
+    { id: 'workflows', label: 'Workflows', x: 24, y: 148 },
+    { id: 'triggers', label: 'Triggers /\nSchedules', x: 204, y: 144, width: 120, height: 52 },
+    { id: 'external', label: 'External\nSystems', x: 312, y: 92 }
   ],
   connections: [
     { from: 'producers', to: 'bus' },
     { from: 'bus', to: 'workflows' },
+    { from: 'bus', to: 'triggers' },
     { from: 'bus', to: 'external' },
+    { from: 'triggers', to: 'bus', dashed: true },
     { from: 'external', to: 'bus', dashed: true }
-  ],
-  annotations: [
-    { x: 200, y: 40, text: 'Domain events, retries, scheduling' }
   ]
 })
 
 export const ModuleLifecycleDiagram = createDiagram({
   title: 'Module lifecycle',
   nodes: [
-    { id: 'design', label: 'Design\nBlueprint', x: 32, y: 44 },
-    { id: 'develop', label: 'Develop\nModule', x: 228, y: 44 },
-    { id: 'deploy', label: 'Deploy &\nOperate', x: 228, y: 156 },
-    { id: 'evolve', label: 'Evolve\nVersion', x: 32, y: 156 }
+    { id: 'design', label: 'Scope\nWorkflows & Assets', x: 24, y: 44, width: 140, height: 68 },
+    { id: 'develop', label: 'Build\nModule Bundle', x: 224, y: 44, width: 136, height: 68 },
+    { id: 'deploy', label: 'Operate &\nObserve', x: 224, y: 156, width: 136, height: 68 },
+    { id: 'evolve', label: 'Evolve\nVersion', x: 24, y: 156, width: 140, height: 68 }
   ],
   connections: [
     { from: 'design', to: 'develop' },
     { from: 'develop', to: 'deploy' },
     { from: 'deploy', to: 'evolve' },
     { from: 'evolve', to: 'design', dashed: true }
-  ],
-  annotations: [
-    { x: 180, y: 26, text: 'Tests, docs & observability baked in', align: 'middle' }
   ]
 })
 
 export const ObservatoryFlowDiagram = createDiagram({
   title: 'Observatory data flow',
   nodes: [
-    { id: 'sensors', label: 'Field\nSensors', x: 18, y: 108 },
-    { id: 'gateway', label: 'Observatory\nGateway', x: 112, y: 48 },
-    { id: 'core', label: 'Core\nJobs', x: 210, y: 108 },
-    { id: 'storage', label: 'Timestore', x: 112, y: 174 },
-    { id: 'dashboards', label: 'Dashboards\n& Alerts', x: 292, y: 86, width: 112, height: 68 }
+    { id: 'sensors', label: 'Field\nSensors', x: 20, y: 112, width: 88, height: 48 },
+    { id: 'gateway', label: 'Gateway /\nEvent Bus', x: 128, y: 24, width: 112, height: 52 },
+    { id: 'jobs', label: 'Module Jobs\n& Workflows', x: 118, y: 96, width: 140, height: 64 },
+    { id: 'filestore', label: 'Filestore\nInventory', x: 16, y: 164, width: 104, height: 48 },
+    { id: 'metastore', label: 'Metastore\nDocuments', x: 132, y: 164, width: 112, height: 48 },
+    { id: 'timestore', label: 'Timestore\nParquet', x: 248, y: 164, width: 104, height: 48 },
+    { id: 'ui', label: 'UI Graph\nDashboards', x: 252, y: 32, width: 96, height: 56 }
   ],
   connections: [
     { from: 'sensors', to: 'gateway' },
-    { from: 'gateway', to: 'core' },
-    { from: 'core', to: 'storage' },
-    { from: 'storage', to: 'dashboards' },
-    { from: 'core', to: 'dashboards' }
-  ],
-  annotations: [
-    { x: 112, y: 32, text: 'Validated telemetry' },
-    { x: 270, y: 172, text: 'Fresh partitions & metrics', align: 'end' }
+    { from: 'gateway', to: 'jobs' },
+    { from: 'jobs', to: 'filestore' },
+    { from: 'jobs', to: 'metastore' },
+    { from: 'jobs', to: 'timestore' },
+    { from: 'gateway', to: 'ui' },
+    { from: 'timestore', to: 'ui', dashed: true },
+    { from: 'filestore', to: 'jobs', dashed: true },
+    { from: 'metastore', to: 'jobs', dashed: true }
   ]
 })
 
 export const SystemArchitectureDiagram = createDiagram({
   title: 'System architecture overview',
   nodes: [
-    { id: 'ui', label: 'Unified\nUI', x: 30, y: 36, width: 96, height: 52 },
-    { id: 'api', label: 'API\nGateway', x: 132, y: 36, width: 96, height: 52 },
-    { id: 'workers', label: 'Workers', x: 234, y: 36, width: 96, height: 52 },
-    { id: 'db', label: 'DB', x: 30, y: 156, width: 96, height: 52 },
-    { id: 'eventBus', label: 'Event\nBus', x: 132, y: 150, width: 96, height: 64 },
-    { id: 'storage', label: 'Object\nStorage', x: 234, y: 156, width: 96, height: 52 }
+    { id: 'ui', label: 'Unified\nUI', x: 24, y: 24, width: 96, height: 56 },
+    { id: 'gateway', label: 'API\nGateway', x: 132, y: 24, width: 96, height: 56 },
+    { id: 'workflows', label: 'Workflows\n& Jobs', x: 240, y: 24, width: 108, height: 60 },
+    { id: 'bus', label: 'Event\nBus', x: 134, y: 96, width: 112, height: 64 },
+    { id: 'filestore', label: 'Filestore', x: 24, y: 168, width: 96, height: 56 },
+    { id: 'timestore', label: 'Timestore', x: 134, y: 168, width: 96, height: 56 },
+    { id: 'metastore', label: 'Metastore', x: 244, y: 168, width: 96, height: 56 }
   ],
   connections: [
-    { from: 'ui', to: 'api' },
-    { from: 'api', to: 'workers' },
-    { from: 'api', to: 'eventBus' },
-    { from: 'workers', to: 'eventBus' },
-    { from: 'api', to: 'db' },
-    { from: 'workers', to: 'storage' },
-    { from: 'eventBus', to: 'workers', dashed: true },
-    { from: 'db', to: 'api', dashed: true }
-  ],
-  annotations: [
-    {
-      x: 180,
-      y: 222,
-      text: 'Event bus centered keeps services decoupled without bespoke glue',
-      align: 'middle'
-    }
+    { from: 'ui', to: 'gateway' },
+    { from: 'gateway', to: 'workflows' },
+    { from: 'gateway', to: 'bus' },
+    { from: 'workflows', to: 'bus' },
+    { from: 'bus', to: 'filestore' },
+    { from: 'bus', to: 'timestore' },
+    { from: 'bus', to: 'metastore' },
+    { from: 'filestore', to: 'bus', dashed: true },
+    { from: 'timestore', to: 'bus', dashed: true },
+    { from: 'metastore', to: 'bus', dashed: true }
   ]
 })
 
 export const UiGraphDiagram = createDiagram({
   title: 'UI graph highlights',
   nodes: [
-    { id: 'workflows', label: 'Workflows\nGraph', x: 24, y: 108 },
-    { id: 'assets', label: 'Assets\nLineage', x: 132, y: 38 },
-    { id: 'sql', label: 'SQL Lab', x: 240, y: 108 },
-    { id: 'alerts', label: 'Health &\nAlerts', x: 132, y: 178 }
+    { id: 'workflows', label: 'Graph View\nWorkflows', x: 24, y: 108 },
+    { id: 'assets', label: 'Assets &\nLineage', x: 132, y: 36 },
+    { id: 'sql', label: 'SQL +\nAnalytics', x: 240, y: 108 },
+    { id: 'status', label: 'Streaming\nStatus', x: 132, y: 178 }
   ],
   connections: [
     { from: 'assets', to: 'workflows' },
     { from: 'assets', to: 'sql' },
-    { from: 'workflows', to: 'alerts' },
-    { from: 'sql', to: 'alerts', dashed: true }
-  ],
-  annotations: [
-    { x: 180, y: 24, text: 'Cross-linked experiences', align: 'middle' }
+    { from: 'workflows', to: 'status' },
+    { from: 'sql', to: 'status', dashed: true }
   ]
 })
 
@@ -411,9 +411,6 @@ export const BusinessConstellationDiagram = createDiagram({
     { from: 'platform', to: 'engineering' },
     { from: 'leadership', to: 'operations', dashed: true },
     { from: 'operations', to: 'engineering', dashed: true }
-  ],
-  annotations: [
-    { x: 180, y: 118, text: 'Shared metrics & playbooks', align: 'middle' }
   ]
 })
 
@@ -430,9 +427,6 @@ export const BusinessObservatoryDiagram = createDiagram({
     { from: 'module', to: 'governance' },
     { from: 'module', to: 'dashboards' },
     { from: 'governance', to: 'dashboards' }
-  ],
-  annotations: [
-    { x: 182, y: 36, text: 'Co-owned by leadership + engineering', align: 'middle' }
   ]
 })
 
@@ -449,9 +443,6 @@ export const AdoptionJourneyDiagram = createDiagram({
     { from: 'lab', to: 'launch' },
     { from: 'launch', to: 'expand' },
     { from: 'expand', to: 'frame', dashed: true }
-  ],
-  annotations: [
-    { x: 180, y: 30, text: 'Guided enablement loops', align: 'middle' }
   ]
 })
 export const EventFlowDiagram = createDiagram({
@@ -459,7 +450,7 @@ export const EventFlowDiagram = createDiagram({
   nodes: [
     { id: 'sources', label: 'Module\nJobs', x: 20, y: 92 },
     { id: 'router', label: 'Event\nRouter', x: 128, y: 52 },
-    { id: 'bus', label: 'Queues /\nTopics', x: 236, y: 92 },
+    { id: 'bus', label: 'Redis +\nBullMQ Bus', x: 236, y: 92, width: 120, height: 52 },
     { id: 'workflows', label: 'Workflows', x: 128, y: 164 },
     { id: 'metrics', label: 'Metrics &\nAlerts', x: 236, y: 164 }
   ],
@@ -469,9 +460,6 @@ export const EventFlowDiagram = createDiagram({
     { from: 'bus', to: 'workflows' },
     { from: 'workflows', to: 'metrics' },
     { from: 'metrics', to: 'router', dashed: true }
-  ],
-  annotations: [
-    { x: 182, y: 36, text: 'Typed payloads + replay support', align: 'middle' }
   ]
 })
 
@@ -480,7 +468,7 @@ export const FilestoreStackDiagram = createDiagram({
   nodes: [
     { id: 'clients', label: 'Workers &\nModules', x: 24, y: 132 },
     { id: 'api', label: 'Filestore\nAPI', x: 132, y: 52 },
-    { id: 'ledger', label: 'Metadata\nLedger', x: 240, y: 132 },
+    { id: 'ledger', label: 'Metadata\nLedger & Events', x: 240, y: 132, width: 120, height: 60 },
     { id: 'storage', label: 'Object\nStorage', x: 132, y: 196 }
   ],
   connections: [
@@ -489,9 +477,6 @@ export const FilestoreStackDiagram = createDiagram({
     { from: 'api', to: 'storage' },
     { from: 'ledger', to: 'clients', dashed: true },
     { from: 'ledger', to: 'storage', dashed: true }
-  ],
-  annotations: [
-    { x: 182, y: 36, text: 'Deterministic reconciliation', align: 'middle' }
   ]
 })
 
@@ -513,9 +498,6 @@ export const ObservabilityDiagram = createDiagram({
     { from: 'logs', to: 'dash' },
     { from: 'metrics', to: 'alerts' },
     { from: 'traces', to: 'alerts', dashed: true }
-  ],
-  annotations: [
-    { x: 184, y: 206, text: 'Unified telemetry pipeline', align: 'middle' }
   ]
 })
 
@@ -536,9 +518,6 @@ export const TechnicalArchitectureDiagram = createDiagram({
     { from: 'worker', to: 'observability' },
     { from: 'storage', to: 'catalog' },
     { from: 'catalog', to: 'gateway' }
-  ],
-  annotations: [
-    { x: 190, y: 16, text: 'Types + contracts propagate across layers', align: 'middle' }
   ]
 })
 
@@ -547,7 +526,7 @@ export const TimestoreStackDiagram = createDiagram({
   nodes: [
     { id: 'ingest', label: 'Ingest\nJobs', x: 24, y: 124 },
     { id: 'duckdb', label: 'DuckDB\nPlanner', x: 132, y: 44 },
-    { id: 'parquet', label: 'Parquet\nShards', x: 240, y: 124 },
+    { id: 'parquet', label: 'Parquet\nPartitions', x: 240, y: 124 },
     { id: 'sql', label: 'ANSI SQL\nAPI', x: 132, y: 196 }
   ],
   connections: [
@@ -555,8 +534,5 @@ export const TimestoreStackDiagram = createDiagram({
     { from: 'duckdb', to: 'parquet' },
     { from: 'duckdb', to: 'sql' },
     { from: 'sql', to: 'parquet', dashed: true }
-  ],
-  annotations: [
-    { x: 188, y: 32, text: 'Pushdown + partition pruning', align: 'middle' }
   ]
 })

--- a/apps/website/src/pages/business/index.astro
+++ b/apps/website/src/pages/business/index.astro
@@ -10,17 +10,17 @@ const reasons = [
   {
     heading: 'Everything becomes a module',
     detail:
-      'Use cases live as versioned modules with jobs, assets, UI surfaces, and runbooks. Governance, rollout, and measurement stay consistent across teams.'
+      'Use cases live as versioned modules with workflows, jobs, events, triggers, schedules, assets, UI surfaces, and runbooks. Governance, rollout, and measurement stay consistent across teams.'
   },
   {
     heading: 'Shared operations platform',
     detail:
-      'Executives, engineers, and operators work from the same data and workflow fabric—no fragmented stacks or duplicate tooling.'
+      'Executives, engineers, and operators work from the same event bus, stores, and UI. No fragmented stacks or duplicate tooling.'
   },
   {
     heading: 'Weeks, not quarters',
     detail:
-      'We model the first module alongside you and hand over a repeatable blueprint so every follow-on use case arrives faster.'
+      'We model the first module alongside you, wire it into the orchestrator, and hand over a repeatable blueprint so every follow-on use case arrives faster.'
   }
 ];
 
@@ -55,10 +55,10 @@ const modulePatterns = [
 ];
 
 const valueSignals = [
-  'Shared source of truth for telemetry, workflows, and reports.',
-  'Faster time-to-market because modules reuse the same infrastructure footprint.',
-  'Lower integration risk: Redis queues, timestore partitions, and module governance are already battle tested in the platform.',
-  'Operators stay in the loop through the AppHub UI—no context lost in spreadsheets or slide decks.'
+  'Shared source of truth for telemetry, workflows, schedules, and reports over the same event bus.',
+  'Faster time-to-market because modules reuse Filestore, Metastore, and Timestore instead of stitching point solutions.',
+  'Lower integration risk: Redis plus BullMQ, Parquet partitions, and document events are already built into the platform.',
+  'Operators stay in the loop through the AppHub UI—live graphs and analytics remove the need for spreadsheet syncs.'
 ];
 
 const engagementTimeline = [
@@ -79,15 +79,15 @@ const engagementTimeline = [
 const observatoryHighlights = [
   {
     title: 'Telemetry to action',
-    detail: 'Instrument data arrives via the observatory gateway, lands in Filestore with rich metadata, and kicks off workflow runs when assets refresh.'
+    detail: 'Instrument data arrives via the observatory gateway, lands in Filestore with rich metadata, updates Timestore, and kicks off workflows or schedules when assets refresh.'
   },
   {
     title: 'Audience-aligned visuals',
-    detail: 'Module services render dashboards directly inside the AppHub UI, so site leads and executives read the same view.'
+    detail: 'Module services render dashboards and the live graph directly inside the AppHub UI, so site leads and executives read the same view with real-time status.'
   },
   {
     title: 'Auditable outcomes',
-    detail: 'Every workflow run, file change, and timestore partition is logged. Leadership reviews readiness in minutes, not days.'
+    detail: 'Every workflow run, document change, file event, and timestore partition is logged. Leadership reviews readiness in minutes, not days.'
   }
 ];
 ---
@@ -98,7 +98,7 @@ const observatoryHighlights = [
         <p class="page-hero__eyebrow">For leadership teams</p>
         <h1>Model any operations programme as an AppHub module.</h1>
         <p class="page-hero__intro">
-          AppHub is open source and currently an early prototype. We are outlining how we will partner with business leaders once the platform is production ready.
+          AppHub is open source and still an early prototype. I am outlining how I plan to partner with business leaders once the platform proves itself in the field.
         </p>
         <div class="page-hero__actions">
           <a class="button button--primary" href="mailto:osirisapphub@gmail.com">Schedule a strategy workshop</a>
@@ -108,7 +108,7 @@ const observatoryHighlights = [
         <div class="page-hero__notice">
           <strong>Planning in progress:</strong>
           <span>
-            Adoption services are not yet available. We are looking for contributors across the platform, operations playbooks, and this website to help shape the launch—email
+            Adoption services are not yet available. I am looking for contributors across the platform, operations playbooks, and this website to help shape the launch—email
             <a href="mailto:osirisapphub@gmail.com">osirisapphub@gmail.com</a> if you would like to help.
           </span>
         </div>
@@ -190,7 +190,7 @@ const observatoryHighlights = [
         ))}
       </ol>
       <p class="timeline__note">
-        Combine internal teams with our strategists, solution engineers, and operator coaches once the programme launches—this draft timeline captures how we aim to support open-source adopters.
+        Combine internal teams with collaborators from the community once the programme launches—this draft timeline captures how I expect to support open-source adopters.
       </p>
     </div>
   </section>

--- a/apps/website/src/pages/index.astro
+++ b/apps/website/src/pages/index.astro
@@ -12,153 +12,152 @@ import {
 
 const title = 'Osiris AppHub | Unified modular operations platform';
 const description =
-  'AppHub pairs an event-driven core, timestore, filestore, metastore, and unified UI so teams can ship modules that orchestrate data and automation in weeks.';
+  'AppHub is the orchestration engine I always wanted: workflows, jobs, assets, and data services sharing a Redis + BullMQ bus with a live UI on top.';
 
 const heroStats = [
-  { label: 'Platform status', value: 'Open-source operations platform' },
-  { label: 'Module rollout time', value: 'Weeks from sketch to live operations' },
-  { label: 'Engagement focus', value: 'Teaching + turnkey module creation' }
+  { label: 'Platform compass', value: 'Performance, scalability, flexibility - no trade-offs' },
+  { label: 'Core loop', value: 'Workflows / jobs / events / triggers / schedules / assets' },
+  { label: 'Data fabric', value: 'Filestore, Metastore, and Timestore stay in lockstep via the bus' }
 ];
 
 const components = [
   {
-    name: 'Core orchestrator',
+    name: 'Orchestration engine',
     copy:
-      'Fastify API and Redis-backed BullMQ workers coordinate jobs, assets, and events. Asset auto-materialisation keeps modules fresh without manual triggers.'
+      'Temporal and Dagster showed the way, but I trimmed the fat. Modules wire workflows, jobs, events, triggers, schedules, and assets together while BullMQ keeps latency in the single-digit milliseconds.'
   },
   {
     name: 'Timestore',
     copy:
-      'DuckDB-powered SQL API backed by partitioned Parquet in object storage. Predicate pushdown and distributed execution keep costs low and queries fast.'
+      'DuckDB plans buffer on a staging disk, flush into Parquet partitions, and scale out on object storage. ANSI SQL stays front and center whether you are querying minutes of telemetry or months of history.'
   },
   {
     name: 'Filestore',
     copy:
-      'Deterministic storage manager that tracks directory sizes, hashes, and change events across S3, MinIO, and local mounts.'
+      'Every read or write goes through the service so we always know sizes, checksums, provenance, and which module touched a payload across S3, GCS, Azure, MinIO, or local disks.'
   },
   {
     name: 'Metastore',
     copy:
-      'Namespace-scoped document store with optimistic concurrency and rich querying for module settings, topology, and governance metadata.'
+      'Postgres-backed document store that emits events whenever a document changes. Perfect for configuration, topology, and everything human-sized that still needs orchestration hooks.'
   },
   {
     name: 'Unified UI',
     copy:
-      'React console renders live workflow graphs, asset lineage, service health, and SQL workspaces without leaving the browser.'
+      'React console streaming straight from the event bus. Graphs, SQL workspaces, asset inventories, and analytics land in one place, with Prometheus-ready metrics still exposed if you want Grafana.'
   }
 ];
 
 const modulePrinciples = [
   {
-    title: 'Modules everywhere',
+    title: 'Wire the system you need',
     detail:
-      'Every use case becomes a module bundle built with the TypeScript SDK. Jobs, workflows, services, and UI surfaces ship together, versioned, and ready to import.'
+      'Workflow runs, cron schedules, event triggers, and asset auto-materialisation live side by side. Mix them per module and change course without asking platform teams for permission.'
   },
   {
-    title: 'First-class ergonomics',
+    title: 'Modules stay flexible',
     detail:
-      'Capability shims for filestore, metastore, timestore, and the event bus mean module authors write clear domain logic instead of plumbing.'
+      'Jobs, services, assets, events, and UI surfaces live in one bundle. Version it, promote it, or tear it apart when requirements shift.'
   },
   {
-    title: 'Real-time evolution',
+    title: 'Fast ergonomics',
     detail:
-      'Publish new module versions with compatibility checks, migrations, and promotion pipelines so operations stay ahead of changing requirements.'
+      'The TypeScript SDK exposes filestore, metastore, timestore, and event bus capabilities so authors write domain logic instead of plumbing.'
   }
 ];
 
 const useCases = [
   {
-    name: 'Environmental observatory',
+    name: 'Observatory operations',
     summary:
-      'Ingest instrument telemetry every minute, reconcile files with Filestore, materialise partitions in Timestore, and publish dashboards automatically.'
+      'Stream sensor events into Timestore, reconcile files through Filestore, and light up workflows the instant an asset refreshes.'
   },
   {
-    name: 'Industrial asset uptime',
+    name: 'Industrial runtime',
     summary:
-      'Fuse PLC readings, operator inspections, and maintenance orders into a module that predicts equipment drift and schedules remediation flows.'
+      'Blend PLC telemetry, maintenance records, and operator feedback. Schedules cover steady-state tasks while events and asset freshness handle surprises.'
   },
   {
-    name: 'Field logistics co-ordination',
+    name: 'Data product platform',
     summary:
-      'Blend inventory snapshots, routing constraints, and crew updates with custom events so dispatchers and sites stay in lockstep.'
+      'Publish data assets backed by Timestore partitions, broadcast change notices with Metastore events, and let the UI visualise lineage automatically.'
   }
 ];
 
 const dataHighlights = [
-  'SQL you already know. Timestore accepts ANSI SQL while translating queries into DuckDB plans executed over Parquet shards in object storage.',
-  'Partitioned manifests. Manifest sharding keeps ingestion fast even as datasets span months of history.',
-  'Hybrid storage. Pair cloud buckets with MinIO or on-prem disks; Filestore keeps metadata consistent and reconciles drift automatically.'
+  'Staging first. Ingest lands on a fast disk, then flushes into Parquet partitions once thresholds hit so the hot path stays predictable while object storage scales.',
+  'DuckDB everywhere. Queries hit ANSI SQL endpoints, lean on predicate pushdown, and can fan out horizontally thanks to partition-aware planning.',
+  'Streaming ready. Kafka or any streaming pipe can drop records right into the flow while Filestore keeps file-like assets aligned with the same dataset.'
 ];
 
 const orchestrationPoints = [
-  'Redis-backed event bus. BullMQ queues move events, workflow runs, and triggers with millisecond latency.',
-  'Asset-based automation and event triggers. Choose freshness-based runs or explicit domain events to launch workflows instantly.',
-  'Observable workers. Queue metrics, Prometheus exports, and OpenTelemetry traces come baked in for every background role.'
+  'Redis plus BullMQ at the core. Events, triggers, workflows, and schedules ride the same low-latency bus.',
+  'Asset auto-materialisation keeps modules fresh. Assets declare freshness rules, and the orchestrator reacts the moment data moves.',
+  'Event hooks everywhere. Filestore and Metastore emit change events so modules react instantly without brittle polling.'
 ];
 
 const uiHighlights = [
-  'Live workflow topology. Graphs show each run, dependency, and asset freshness in real time—no separate tracing tool needed.',
-  'Faster than stand-alone orchestrators. AppHub skips heavyweight RPC layers so modules move quicker than Temporal while inheriting Dagster-style assets.',
-  'In-app SQL lab. Query timestores, preview files, and link every result back to the producing module without leaving the console.'
+  'Live graph view. Every workflow, job, and asset overlays its status as the bus emits updates.',
+  'Analytics built in. Inspect timestore partitions, file inventories, and metastore documents without leaving the console.',
+  'Still pluggable. Prometheus metrics, structured logs, and traces escape so you keep external dashboards if you want them.'
 ];
 
 const deploymentOptions = [
   {
-    heading: 'Dedicated servers',
-    detail: 'Bring your own hardware with Docker Compose or Minikube. MinIO supplies object storage when S3 is not available.'
+    heading: 'Single machine',
+    detail: 'Docker Compose or Minikube plus a small staging disk gives you the full stack and flushes to object storage as partitions mature.'
   },
   {
-    heading: 'Cloud-native',
-    detail: 'Deploy on Kubernetes with autoscaling workers, or run the stack on a VM plus managed S3/GCS buckets for effortless durability.'
+    heading: 'Cloud native',
+    detail: 'Run services on Kubernetes with autoscaling workers. Object storage can be S3, GCS, or Azure while Redis and DuckDB scale independently.'
   },
   {
-    heading: 'Hybrid topologies',
-    detail: 'Mix local ingestion workers with cloud AppHub services. Redis queues and service discovery keep modules coordinated across sites.'
+    heading: 'Hybrid topology',
+    detail: 'Place ingestion next to data sources and keep the core in the cloud. The event bus and shared stores keep every module in sync.'
   }
 ];
 
 const services = [
   {
-    title: 'Immersive teaching sessions',
+    title: 'Deep-dive architecture sessions',
     detail:
-      'Hands-on workshops cover AppHub architecture, the module SDK, and how to wire timestore/filestore integrations. Teams leave ready to build.'
+      'Walk through orchestrator patterns, event trigger design, and how to map modules onto the stores without guesswork.'
   },
   {
-    title: 'Module modelling sprints',
+    title: 'Module design sprints',
     detail:
-      'We translate your use case into a module blueprint—jobs, assets, services, and governance artifacts included.'
+      'Codify workflows, schedules, assets, and UI surfaces together so your first module launches with confidence.'
   },
   {
-    title: 'Turnkey module builds',
+    title: 'Benchmark and scale reviews',
     detail:
-      'Partner with our engineers to deliver a production-ready module, complete with observability dashboards and runbooks.'
+      'Stress Timestore, measure Redis and BullMQ throughput, and tune the staging to Parquet pipeline before you bet your operations on it.'
   }
 ];
 
 const observatoryTakeaways = [
-  'Gateway normalises sensor events and pushes them through the Redis event bus into the Core.',
-  'Filestore journals every instrument upload, tracking directory sizes and hashing payloads for provenance.',
-  'Timestore compacts minute partitions into Parquet shards while exposing a SQL API for analysts and dashboards.',
-  'Event triggers fire downstream workflows the moment new telemetry arrives, complementing asset auto-materialisation.',
-  'Module services render the Observatory graph and status boards inside the unified UI using the module SDK capabilities.'
+  'Sensors post events onto the bus so workflows, schedules, and assets stay in sync.',
+  'Filestore captures every file with metadata, checksums, and emits change events for downstream jobs.',
+  'Metastore documents track sites and equipment; updates fire events so the right workflows adjust immediately.',
+  'Timestore stages minute data on disk, flushes to Parquet, and responds to SQL in milliseconds thanks to DuckDB.',
+  'The UI graph streams live status so operators drill into runs without refreshing dashboards.'
 ];
 ---
 <BaseLayout title={title} description={description}>
   <section class="hero" aria-labelledby="hero-heading">
     <div class="container hero__inner">
       <div class="hero__content">
-        <p class="hero__eyebrow">Built for evolving operations</p>
-        <h1 id="hero-heading">Launch a modular operations platform that keeps pace with change.</h1>
+        <p class="hero__eyebrow">For operators who want it all</p>
+        <h1 id="hero-heading">Build the operations platform I kept wishing existed.</h1>
         <p class="hero__summary">
-          Osiris AppHub unifies the orchestrator, timestore, filestore, metastore, and UI into one event-driven platform. It is fully open
-          source—self-host it, fork it, or collaborate with our team to build modules faster.
+          Osiris AppHub is a fast orchestration engine inspired by Temporal and Dagster but trimmed for real-world performance. Workflows, jobs, events, triggers, schedules, and assets live inside one module, all speaking over a low-latency Redis plus BullMQ bus while Filestore, Metastore, and Timestore listen in.
         </p>
         <div class="hero__status">
           <p>
-            <strong>Heads-up:</strong> the unified UI is mid-polish and will keep changing rapidly—expect frequent visual and UX updates as we harden the experience.
+            <strong>Heads-up:</strong> the unified UI is still rough around the edges. Please give the demo a spin anyway—the live graph view streams straight off the event bus.
           </p>
           <p>
-            <strong>Early prototype:</strong> AppHub is pre-production and evolving in the open. We will announce production readiness once the community validates the full workflow.
+            <strong>Early prototype:</strong> AppHub is pre-production and evolving in the open while I prove out performance, scalability, and flexibility. Production guidance will land once the community helps hammer on the entire loop.
           </p>
         </div>
         <div class="hero__actions">
@@ -171,9 +170,9 @@ const observatoryTakeaways = [
         <div class="hero__contributor">
           <strong>Join the crew:</strong>
           <span>
-            We are actively looking for contributors across the stack—core services, SDKs, and this website. If you want to shape onboarding playbooks, strengthen the platform, or ship UI polish, email
+            I am actively looking for collaborators across the stack—core services, SDKs, modules, and this site. If you want to load test Timestore, tune the orchestrator, or help polish the UI, email
             <a href="mailto:osirisapphub@gmail.com">osirisapphub@gmail.com</a>
-            or hop into our
+            or hop into the
             <a href="https://discord.gg/STJGs5zHCN" target="_blank" rel="noreferrer">Discord server</a>.
           </span>
         </div>
@@ -190,7 +189,7 @@ const observatoryTakeaways = [
         <div class="diagram">
           <SystemArchitectureDiagram />
         </div>
-        <figcaption>Event bus at the centre: modules speak through shared services instead of bespoke glue code.</figcaption>
+        <figcaption>Redis and BullMQ sit at the centre so workflows, stores, and the UI stay in sync without bespoke glue.</figcaption>
       </figure>
     </div>
   </section>
@@ -198,10 +197,9 @@ const observatoryTakeaways = [
   <section class="components" aria-labelledby="components-heading">
     <div class="container components__inner">
       <div class="section-header">
-        <h2 id="components-heading" class="section-heading">Five services, one platform</h2>
+        <h2 id="components-heading" class="section-heading">Five services, one purpose-built platform</h2>
         <p>
-          Each AppHub workspace ships the same building blocks, so modules rely on proven infrastructure instead of reinventing data pipes
-          and orchestration.
+          Every workspace ships the orchestrator plus Filestore, Metastore, Timestore, and the UI. They all speak over the same event bus so modules stay fast, observable, and ready to evolve.
         </p>
       </div>
       <div class="components__grid">
@@ -223,7 +221,7 @@ const observatoryTakeaways = [
         </div>
       </figure>
       <div>
-        <h2 id="modules-heading" class="section-heading">Modules are how you ship use cases</h2>
+        <h2 id="modules-heading" class="section-heading">Modules bundle workflows, jobs, events, and assets</h2>
         <div class="modules__grid">
           {modulePrinciples.map((item) => (
             <article>
@@ -233,8 +231,7 @@ const observatoryTakeaways = [
           ))}
         </div>
         <p class="modules__footnote">
-          The module SDK lives in <code>packages/module-sdk</code> and gives authors typed access to filestore, metastore, timestore, and the event bus in just a
-          few lines.
+          The module SDK lives in <code>packages/module-sdk</code> and gives authors typed access to filestore, metastore, timestore, the event bus, and UI surfaces from a few lines of TypeScript.
         </p>
       </div>
     </div>
@@ -242,7 +239,7 @@ const observatoryTakeaways = [
 
   <section class="use-cases" aria-labelledby="use-cases-heading">
     <div class="container use-cases__inner">
-      <h2 id="use-cases-heading" class="section-heading">Example modules we are delivering</h2>
+      <h2 id="use-cases-heading" class="section-heading">Example modules we are proving out right now</h2>
       <div class="use-cases__grid">
         {useCases.map((item) => (
           <article>
@@ -257,7 +254,10 @@ const observatoryTakeaways = [
   <section class="data-plane" aria-labelledby="data-plane-heading">
     <div class="container data-plane__inner">
       <div>
-        <h2 id="data-plane-heading" class="section-heading">Data plane built on object storage</h2>
+        <h2 id="data-plane-heading" class="section-heading">Timestore data plane built on object storage</h2>
+        <p>
+          Timestore is tuned for high-volume timeseries. It stages writes on disk, flushes to Parquet, and answers ANSI SQL through DuckDB without forcing a separate warehouse.
+        </p>
         <ul>
           {dataHighlights.map((point) => (
             <li>{point}</li>
@@ -280,7 +280,10 @@ const observatoryTakeaways = [
         </div>
       </figure>
       <div>
-        <h2 id="orchestration-heading" class="section-heading">Event-driven orchestration without the overhead</h2>
+        <h2 id="orchestration-heading" class="section-heading">Event-driven orchestration tuned for latency</h2>
+        <p>
+          The Redis plus BullMQ bus moves events, triggers, schedules, and asset materialisations with minimal overhead so modules react in real time.
+        </p>
         <ul>
           {orchestrationPoints.map((point) => (
             <li>{point}</li>
@@ -293,7 +296,10 @@ const observatoryTakeaways = [
   <section class="ui" aria-labelledby="ui-heading">
     <div class="container ui__inner">
       <div>
-        <h2 id="ui-heading" class="section-heading">A unified UI operators actually enjoy using</h2>
+        <h2 id="ui-heading" class="section-heading">Unified UI with live graphs and analytics built in</h2>
+        <p>
+          The console blends real-time updates from the bus with polling where it still makes sense, so operators see fresh status without juggling dashboards.
+        </p>
         <ul>
           {uiHighlights.map((point) => (
             <li>{point}</li>
@@ -323,16 +329,16 @@ const observatoryTakeaways = [
         ))}
       </div>
       <p class="deploy__note">
-        Redis queues, Postgres, and object storage scale independently, so hybrid footprints—edge ingestion, cloud analytics, dedicated failover—stay in sync.
+        Redis, Postgres, staging disks, and object storage scale on their own timelines, so hybrid footprints—edge ingest, cloud analytics, active failover—stay in sync.
       </p>
     </div>
   </section>
 
   <section class="services" aria-labelledby="services-heading">
     <div class="container services__inner">
-      <h2 id="services-heading" class="section-heading">Adoption services in the works</h2>
+      <h2 id="services-heading" class="section-heading">Adoption services we are sketching</h2>
       <p class="services__intro">
-        We are drafting these co-building tracks right now—adoption services are not yet available. Help us design and deliver them by contributing to the platform and playbooks.
+        These tracks are still drafts while I harden the platform. Help shape them by contributing to the services, modules, and playbooks that will power launch day.
       </p>
       <div class="services__grid">
         {services.map((item) => (
@@ -348,9 +354,9 @@ const observatoryTakeaways = [
   <section class="observatory" aria-labelledby="observatory-heading">
     <div class="container observatory__inner">
       <div>
-        <h2 id="observatory-heading" class="section-heading">Case study · Observatory module</h2>
+        <h2 id="observatory-heading" class="section-heading">Case study · Observatory module tying it all together</h2>
         <p class="observatory__intro">
-          The environmental observatory module is built entirely with the module SDK. It ingests instrument data, reconciles files, materialises parquet, and renders dashboards without leaving AppHub.
+          The environmental observatory module is built with the SDK end to end. It ingests telemetry, reconciles files, flushes timestore partitions, reacts to metastore updates, and renders live dashboards inside AppHub.
         </p>
         <ul>
           {observatoryTakeaways.map((item) => (
@@ -369,9 +375,9 @@ const observatoryTakeaways = [
   <section class="cta" aria-labelledby="cta-heading">
     <div class="container cta__inner">
       <div>
-        <h2 id="cta-heading" class="section-heading">Start building with the community</h2>
+        <h2 id="cta-heading" class="section-heading">Help stress test the platform with the community</h2>
         <p>
-          Clone the repo, explore existing modules, and ship your own workflows. We collaborate in the open—file issues, open pull requests, or team up with us for turnkey delivery.
+          Clone the repo, explore existing modules, and see how the orchestrator behaves under real workloads. File issues, open pull requests, or partner with me if you want a turnkey build.
         </p>
       </div>
       <div class="cta__actions">

--- a/apps/website/src/pages/technical/index.astro
+++ b/apps/website/src/pages/technical/index.astro
@@ -10,57 +10,58 @@ import {
 } from '@components/diagrams';
 
 const title = 'Technical overview | Osiris AppHub';
-const description = 'Dive into the architecture of the AppHub operations platform: orchestrator, data plane, event bus, and module ergonomics.';
+const description =
+  'Dive into the architecture I am building for AppHub: the orchestrator, event bus, timestore, filestore, metastore, and UI working as one system.';
 
 const coreStack = [
   {
     heading: 'Core orchestrator',
     detail:
-      'Fastify gateway with typed OpenAPI surface. Redis + BullMQ drive ingest, workflow, build, and materializer queues. Asset materialisation keeps data fresh automatically.'
+      'Fastify gateway with typed OpenAPI surface. Redis plus BullMQ drive ingest, workflow, build, trigger, and schedule queues. Asset auto-materialisation keeps modules fresh without manual babysitting.'
   },
   {
     heading: 'Timestore',
     detail:
-      'DuckDB runtime generates Parquet partitions in object storage, exposes ANSI SQL, and uses predicate pushdown to keep IO costs low.'
+      'DuckDB runtime buffers writes on a staging disk, flushes Parquet partitions, and serves ANSI SQL. Predicate pushdown and partition pruning keep scans fast while scaling on object storage.'
   },
   {
     heading: 'Filestore',
     detail:
-      'Transactional filesystem API that journals mutations, tracks hashes, and reconciles drift across MinIO, S3, GCS, or local disks.'
+      'Transactional storage API that journals mutations, tracks sizes and hashes, maintains the inventory, and emits change events across MinIO, S3, GCS, Azure, or local disks.'
   },
   {
     heading: 'Metastore',
-    detail: 'PostgreSQL-backed document store with optimistic concurrency and JSON-path querying for module settings and topology.'
+    detail: 'PostgreSQL-backed document store with optimistic concurrency that emits events whenever a document changes, making configuration and topology reactive by default.'
   },
   {
     heading: 'Unified UI',
-    detail: 'Vite + React console streaming WebSocket events, rendering workflow graphs, SQL editor, and service health from the core.'
+    detail: 'Vite plus React console that streams from the event bus, rendering workflow graphs, SQL workspaces, asset inventories, and health panels in one place.'
   }
 ];
 
 const eventHighlights = [
-  'BullMQ queues with Redis deliver sub-50ms event fan-out for workflow runs, asset updates, and service health frames.',
-  'Inline mode keeps local development simple, while HTTP proxies let sandboxed jobs publish events without bundling BullMQ.',
-  'Asset materialisation and explicit event triggers both kick off workflows—choose freshness-based or domain-driven execution patterns.'
+  'BullMQ queues with Redis deliver low latency fan-out for workflow runs, asset updates, triggers, and schedule heartbeats.',
+  'Inline mode keeps local development simple, while HTTP proxies let sandboxed jobs publish events without embedding BullMQ clients.',
+  'Asset auto-materialisation, explicit event triggers, and cron schedules coexist—mix freshness based or domain driven execution whenever you need.'
 ];
 
 const timestoreDetails = [
-  'Partitioned Parquet manifests sharded by day keep ingestion free of row-level contention.',
-  'DuckDB query plans exploit predicate pushdown and column pruning, so scanning months of data remains affordable.',
-  'Lifecycle workers manage compaction, retention, and exports. Metrics such as `timestore_ingest_job_duration_seconds` ship out of the box.',
-  'SQL editor in the UI reuses the same API surface exposed to modules; no parallel warehouse required.'
+  'Partitioned Parquet manifests sharded by time keep ingestion free of row-level contention and ready for horizontal planning.',
+  'DuckDB query plans exploit predicate pushdown, column pruning, and parallel execution so scanning months of history stays affordable.',
+  'Lifecycle workers manage compaction, retention, exports, and streaming merges. Metrics such as `timestore_ingest_job_duration_seconds` ship out of the box.',
+  'Streaming inputs slot straight into the same datasets while the SQL editor in the UI reuses the exact API modules call.'
 ];
 
 const filestoreDetails = [
-  'Journaled mutations guarantee metadata accuracy—size, checksums, lifecycles—across every node.',
+  'Journaled mutations guarantee inventory accuracy—sizes, checksums, metadata, lineage—across every node.',
   'Watchers and reconciliation workers detect drift introduced outside the API and self-heal using BullMQ jobs.',
-  'Backends span local volumes, MinIO, S3, or GCS. Metadata stays central in Postgres while payloads live in object storage.',
-  'Event feeds push change notifications into modules and timestore so downstream consumers react instantly.'
+  'Backends span local volumes, MinIO, S3, Azure, or GCS. Metadata stays central in Postgres while payloads live in object storage.',
+  'Event feeds push change notifications into modules, timestore, and metastore so downstream consumers react instantly.'
 ];
 
 const moduleErgonomics = [
-  'TypeScript SDK supplies capability shims for filestore, metastore, timestore, and the event bus. Authors focus on domain logic.',
-  'Targets (jobs, workflows, services) declare semantic versions and assets, enabling precise rollouts and auto-materialisation.',
+  'TypeScript SDK supplies capability shims for filestore, metastore, timestore, the event bus, and UI surfaces. Authors stay focused on domain logic.',
+  'Targets (jobs, workflows, schedules, triggers, services) declare semantic versions and assets, enabling precise rollouts and asset auto-materialisation.',
   'Services ship with registrations so module-defined UIs appear automatically in the AppHub console.'
 ];
 
@@ -91,21 +92,21 @@ export default defineModule({
 const deployment = [
   {
     title: 'Single-node prototyping',
-    copy: 'Docker Compose or Minikube packages Redis, Postgres, object storage (MinIO), and the AppHub services for quick demos.'
+    copy: 'Docker Compose or Minikube packages Redis, Postgres, MinIO, and the AppHub services. A small staging disk buffers timestore writes before they flush to Parquet.'
   },
   {
     title: 'Kubernetes-first',
-    copy: 'Helm manifests and workers scale horizontally. Object storage can be S3, GCS, or in-cluster MinIO; Redis and Postgres scale independently.'
+    copy: 'Helm manifests and workers scale horizontally. Object storage can be S3, GCS, Azure, or in-cluster MinIO; Redis, DuckDB, and Postgres scale independently.'
   },
   {
     title: 'Hybrid footprints',
-    copy: 'Run ingestion workers next to data sources while keeping AppHub services in the cloud. Event bus routing and service registry keep everything in sync.'
+    copy: 'Run ingestion workers next to data sources while keeping AppHub services in the cloud. The event bus and shared stores keep everything in sync across sites.'
   }
 ];
 
 const observability = [
   'Prometheus metrics across services (queue depth, ingest latency, reconciliation backlog) with configurable scopes.',
-  'OpenTelemetry spans for timestore queries, ingestion, and workflow execution.',
+  'OpenTelemetry spans for timestore queries, ingestion, and workflow execution, plus structured logs for every job.',
   'Admin APIs expose queue health, event explorers, dataset audit trails, and asset histories.'
 ];
 ---
@@ -113,10 +114,10 @@ const observability = [
   <section class="page-hero">
     <div class="container page-hero__inner">
       <div>
-        <p class="page-hero__eyebrow">For engineering and platform teams</p>
-        <h1>The event-driven operations platform behind AppHub modules.</h1>
+        <p class="page-hero__eyebrow">Under the hood of AppHub</p>
+        <h1>The orchestration engine I am building for real operations.</h1>
         <p class="page-hero__intro">
-          AppHub is open source. It pairs an opinionated orchestrator with a scalable data plane so modules can blend automation, telemetry, and operator experiences without reinventing the stack.
+          AppHub is open source. I am welding the orchestrator, Redis plus BullMQ bus, timestore, filestore, metastore, and UI together so modules blend automation, telemetry, and operator experiences without reinventing plumbing.
         </p>
         <div class="page-hero__actions">
           <a class="button button--primary" href="mailto:osirisapphub@gmail.com">Book an architecture review</a>
@@ -126,7 +127,7 @@ const observability = [
         <div class="page-hero__notice">
           <strong>Current status:</strong>
           <span>
-            UI polish is ongoing and the platform is still an early prototype. We will publish production guidance once the modules and services are battle-tested—contributors are welcome to help us get there.
+            UI polish is ongoing and the platform is still an early prototype. I will publish production guidance once workflows, stores, and the UI prove themselves under load—help me get there by contributing.
           </span>
         </div>
       </div>
@@ -134,7 +135,7 @@ const observability = [
         <div class="diagram">
           <TechnicalArchitectureDiagram />
         </div>
-        <figcaption>Core workers, data services, and UI share the same event bus and object storage fabric.</figcaption>
+        <figcaption>Core workers, data services, and the UI share the Redis plus BullMQ event bus and the same storage fabric.</figcaption>
       </figure>
     </div>
   </section>
@@ -161,7 +162,10 @@ const observability = [
         </div>
       </figure>
       <div>
-        <h2 id="events-heading" class="section-heading">Event bus & asset materialisation</h2>
+        <h2 id="events-heading" class="section-heading">Event bus, triggers, and schedules</h2>
+        <p>
+          Everything in AppHub talks over the same Redis plus BullMQ bus: workflows, jobs, triggers, schedules, and asset refreshes. Low latency is the baseline, not an afterthought.
+        </p>
         <ul>
           {eventHighlights.map((item) => (
             <li>{item}</li>
@@ -175,6 +179,9 @@ const observability = [
     <div class="container timestore__inner">
       <div>
         <h2 id="timestore-heading" class="section-heading">Timestore at scale</h2>
+        <p>
+          Designed for high volume timeseries. Writes hit a staging disk, flush to Parquet partitions, and DuckDB handles SQL with partition-aware planning.
+        </p>
         <ul>
           {timestoreDetails.map((item) => (
             <li>{item}</li>
@@ -197,7 +204,10 @@ const observability = [
         </div>
       </figure>
       <div>
-        <h2 id="filestore-heading" class="section-heading">Filestore metadata engine</h2>
+        <h2 id="filestore-heading" class="section-heading">Filestore inventory and event engine</h2>
+        <p>
+          Files never bypass the service. That is how we keep the inventory accurate, emit change events, and reconcile drift across every storage backend.
+        </p>
         <ul>
           {filestoreDetails.map((item) => (
             <li>{item}</li>


### PR DESCRIPTION
## Summary
- adopt new hero slogan and tighten homepage copy around the event bus
- keep business and technical briefs aligned with the orchestration + stores narrative
- redraw marketing diagrams with smaller nodes, cleaner spacing, and consistent event bus labeling

## Testing
- npm run lint --workspace @apphub/website