### PR TITLE
feat: add manual deployment scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,9 @@
     "minikube:verify": "node scripts/minikube-verify.mjs",
     "e2e": "tsx tests/e2e/observatory.e2e.ts",
     "e2e:timestore": "tsx tests/e2e/timestore.e2e.ts",
-    "module:admin": "npm run module:admin --workspace @apphub/core --"
+    "module:admin": "npm run module:admin --workspace @apphub/core --",
+    "deploy:website": "node scripts/deploy-website.mjs",
+    "deploy:demo": "node scripts/deploy-demo-stack.mjs"
   },
   "devDependencies": {
     "@rolldown/pluginutils": "^1.0.0-beta.35",

--- a/scripts/deploy-demo-stack.mjs
+++ b/scripts/deploy-demo-stack.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process'
+import { join } from 'node:path'
+
+const args = parseArgs(process.argv.slice(2))
+const branch = validateRef(args.branch ?? args.ref ?? 'main')
+const repoRoot = runCapture('git', ['rev-parse', '--show-toplevel']).trim()
+const terraformDir = join(repoRoot, 'infra/aws-demo')
+
+ensureCommand('terraform')
+ensureCommand('ssh')
+ensureCommand('git')
+
+console.log(`▶ Deploying demo stack from branch "${branch}"`)
+
+const outputs = JSON.parse(
+  runCapture('terraform', ['-chdir', terraformDir, 'output', '-json'])
+)
+const endpoint = outputs.demo_endpoint?.value ?? null
+const publicIp = outputs.ec2_public_ip?.value ?? null
+const host = args.host ?? endpoint ?? publicIp
+
+if (!host) {
+  throw new Error(
+    'Unable to resolve target host. Provide --host or ensure terraform outputs are up to date.'
+  )
+}
+
+const script = `
+set -euo pipefail
+BRANCH="${branch}"
+cd /opt/apphub/source
+git fetch origin "$BRANCH"
+git checkout -B "$BRANCH" "origin/$BRANCH"
+git reset --hard "origin/$BRANCH"
+git clean -xdf
+git pull --ff-only origin "$BRANCH"
+COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker compose \\
+  --file docker/demo-stack.compose.yml \\
+  --file /opt/apphub/docker-compose.override.yml \\
+  --env-file /opt/apphub/.env \\
+  up -d --remove-orphans --build
+docker compose \\
+  --file docker/demo-stack.compose.yml \\
+  --file /opt/apphub/docker-compose.override.yml \\
+  --env-file /opt/apphub/.env \\
+  ps
+`
+
+const sshResult = spawnSync(
+  'ssh',
+  [`ec2-user@${host}`, 'bash', '-s'],
+  {
+    input: script,
+    stdio: ['pipe', 'inherit', 'inherit']
+  }
+)
+
+if (sshResult.status !== 0) {
+  throw new Error(`Remote deployment failed with status ${sshResult.status ?? 'unknown'}`)
+}
+
+console.log('✅ Demo stack deployment complete')
+
+function parseArgs(input) {
+  const result = {}
+  const queue = [...input]
+  while (queue.length) {
+    const arg = queue.shift()
+    switch (arg) {
+      case '--branch':
+      case '--ref': {
+        const value = queue.shift()
+        if (!value) throw new Error(`${arg} requires a value`)
+        result.branch = value
+        break
+      }
+      case '--host': {
+        const value = queue.shift()
+        if (!value) throw new Error('--host requires a value')
+        result.host = value
+        break
+      }
+      default:
+        throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+  return result
+}
+
+function validateRef(value) {
+  if (!/^[A-Za-z0-9._/-]+$/.test(value)) {
+    throw new Error(`Invalid git ref: ${value}`)
+  }
+  return value
+}
+
+function runCapture(cmd, args, options = {}) {
+  const result = spawnSync(cmd, args, {
+    stdio: ['inherit', 'pipe', 'inherit'],
+    encoding: 'utf8',
+    ...options
+  })
+  if (result.status !== 0) {
+    throw new Error(`[${cmd}] exited with status ${result.status ?? 'unknown'}`)
+  }
+  return result.stdout.trim()
+}
+
+function ensureCommand(binary) {
+  const result = spawnSync(binary, ['--version'], { stdio: 'ignore' })
+  if (result.status !== 0) {
+    throw new Error(`Required command "${binary}" not found in PATH`)
+  }
+}

--- a/scripts/deploy-website.mjs
+++ b/scripts/deploy-website.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+import { mkdtempSync, rmSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { spawnSync } from 'node:child_process'
+
+const args = parseArgs(process.argv.slice(2))
+const ref = args.branch ?? args.ref ?? 'main'
+const invalidate = args.invalidate ?? true
+const repoRoot = runCapture('git', ['rev-parse', '--show-toplevel']).trim()
+const terraformDir = join(repoRoot, 'infra/aws-demo')
+
+ensureCommand('terraform')
+ensureCommand('aws')
+ensureCommand('git')
+ensureCommand('npm')
+
+console.log(`▶ Deploying website from ref "${ref}"`)
+
+run('git', ['fetch', 'origin', ref], { cwd: repoRoot })
+
+const targetRef = resolveRef(ref)
+const worktreeDir = mkdtempSync(join(tmpdir(), 'apphub-website-'))
+let worktreeAttached = false
+
+try {
+  run('git', ['worktree', 'add', '--force', '--detach', worktreeDir, targetRef], {
+    cwd: repoRoot
+  })
+  worktreeAttached = true
+
+  console.log('▶ Installing dependencies (npm ci)')
+  run('npm', ['ci'], { cwd: worktreeDir })
+
+  console.log('▶ Building website')
+  run('npm', ['run', 'build', '--workspace', '@apphub/website'], { cwd: worktreeDir })
+
+  const distDir = join(worktreeDir, 'apps/website/dist')
+  if (!existsSync(distDir)) {
+    throw new Error(`Build output not found at ${distDir}`)
+  }
+
+  const outputs = JSON.parse(
+    runCapture('terraform', ['-chdir', terraformDir, 'output', '-json'])
+  )
+  const bucket = outputs.website_bucket?.value ?? null
+  const distribution = outputs.website_distribution_id?.value ?? null
+  const endpoint = outputs.demo_endpoint?.value ?? null
+  const publicIp = outputs.ec2_public_ip?.value ?? null
+  const host = args.host ?? endpoint ?? publicIp
+
+  if (!bucket && !host) {
+    throw new Error(
+      'Unable to determine deployment target. Ensure terraform outputs include website_bucket or ec2_public_ip.'
+    )
+  }
+
+  if (bucket) {
+    console.log(`▶ Syncing dist/ to s3://${bucket}`)
+    run('aws', ['s3', 'sync', distDir, `s3://${bucket}`, '--delete'], { cwd: repoRoot })
+  } else {
+    console.log('ℹ website_bucket output not found, skipping S3 sync')
+  }
+
+  if (distribution && invalidate) {
+    console.log(`▶ Creating CloudFront invalidation for distribution ${distribution}`)
+    run('aws', [
+      'cloudfront',
+      'create-invalidation',
+      '--distribution-id',
+      distribution,
+      '--paths',
+      '/*'
+    ])
+  } else if (distribution && !invalidate) {
+    console.log('ℹ Skipping CloudFront invalidation (per --no-invalidate)')
+  }
+
+  if (!distribution && host) {
+    ensureCommand('ssh')
+    ensureCommand('rsync')
+    console.log(`▶ Syncing dist/ to ${host}:/opt/apphub/website/dist`)
+    run('ssh', [`ec2-user@${host}`, 'mkdir -p /opt/apphub/website/dist'])
+    run('rsync', [
+      '-az',
+      '--delete',
+      `${distDir}/`,
+      `ec2-user@${host}:/opt/apphub/website/dist/`
+    ])
+    console.log('▶ Reloading nginx on remote host')
+    run('ssh', [`ec2-user@${host}`, 'sudo systemctl reload nginx'])
+  }
+
+  console.log('✅ Website deployment complete')
+} finally {
+  if (worktreeAttached) {
+    runSilently('git', ['worktree', 'remove', '--force', worktreeDir], { cwd: repoRoot })
+  }
+  rmSync(worktreeDir, { recursive: true, force: true })
+}
+
+function resolveRef(ref) {
+  try {
+    runCapture('git', ['rev-parse', '--verify', ref], { cwd: repoRoot })
+    return ref
+  } catch {
+    const remoteRef = `origin/${ref}`
+    runCapture('git', ['rev-parse', '--verify', remoteRef], { cwd: repoRoot })
+    return remoteRef
+  }
+}
+
+function parseArgs(input) {
+  const result = {}
+  const queue = [...input]
+  while (queue.length) {
+    const arg = queue.shift()
+    switch (arg) {
+      case '--branch':
+      case '--ref': {
+        const value = queue.shift()
+        if (!value) throw new Error(`${arg} requires a value`)
+        result.branch = value
+        break
+      }
+      case '--host': {
+        const value = queue.shift()
+        if (!value) throw new Error('--host requires a value')
+        result.host = value
+        break
+      }
+      case '--no-invalidate':
+        result.invalidate = false
+        break
+      default:
+        throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+  return result
+}
+
+function run(cmd, args, options = {}) {
+  const result = spawnSync(cmd, args, {
+    stdio: 'inherit',
+    ...options
+  })
+  if (result.status !== 0) {
+    throw new Error(`[${cmd}] exited with status ${result.status ?? 'unknown'}`)
+  }
+  return result
+}
+
+function runSilently(cmd, args, options = {}) {
+  const result = spawnSync(cmd, args, {
+    stdio: ['ignore', 'ignore', 'inherit'],
+    ...options
+  })
+  return result
+}
+
+function runCapture(cmd, args, options = {}) {
+  const result = spawnSync(cmd, args, {
+    stdio: ['inherit', 'pipe', 'inherit'],
+    encoding: 'utf8',
+    ...options
+  })
+  if (result.status !== 0) {
+    throw new Error(`[${cmd}] exited with status ${result.status ?? 'unknown'}`)
+  }
+  return result.stdout.trim()
+}
+
+function ensureCommand(binary) {
+  const result = spawnSync(binary, ['--version'], { stdio: 'ignore' })
+  if (result.status !== 0) {
+    throw new Error(`Required command "${binary}" not found in PATH`)
+  }
+}


### PR DESCRIPTION
## Summary
- add deploy helpers for the marketing site and demo stack that accept a git branch
- expose commands via npm scripts and document the workflow in infra/aws-demo/README.md
- sync website bundles to S3/CloudFront or straight to the VM when DNS is not managed

## Testing
- not run (deployment scripts require terraform state + AWS credentials)